### PR TITLE
Add hostname-based redirect rule for @svenvw/fdm-app server entry

### DIFF
--- a/.changeset/loud-turkeys-love.md
+++ b/.changeset/loud-turkeys-love.md
@@ -1,5 +1,0 @@
----
-"@svenvw/fdm-app": patch
----
-
-Redirect all subdomains, except .dev, to original hostname

--- a/.changeset/loud-turkeys-love.md
+++ b/.changeset/loud-turkeys-love.md
@@ -1,0 +1,5 @@
+---
+"@svenvw/fdm-app": patch
+---
+
+Redirect all subdomains, except .dev, to original hostname

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.19.5
+
+### Patch Changes
+
+- a3ede17: Redirect all subdomains, except .dev, to original hostname
+
 ## 0.19.4
 
 ### Patch Changes

--- a/fdm-app/app/entry.server.tsx
+++ b/fdm-app/app/entry.server.tsx
@@ -28,6 +28,27 @@ export default function handleRequest(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     loadContext: AppLoadContext,
 ) {
+    const url = new URL(request.url)
+    const { hostname } = url
+
+    // Don't redirect for the dev subdomain
+    if (hostname.startsWith("dev.")) {
+        // Continue with the request
+    } else {
+        const parts = hostname.split(".")
+        // Redirect if there is a subdomain (more than 2 parts for .com, .nl, etc.)
+        if (parts.length > 2) {
+            const rootDomain = parts.slice(-2).join(".")
+            url.hostname = rootDomain
+            return new Response(null, {
+                status: 301,
+                headers: {
+                    Location: url.toString(),
+                },
+            })
+        }
+    }
+    
     // Add cache control headers based on the request path
     const cacheHeaders = getCacheControlHeaders(request, reactRouterContext)
     cacheHeaders.forEach((value, key) => {

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@svenvw/fdm-app",
-    "version": "0.19.4",
+    "version": "0.19.5",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented automatic redirection of requests from all subdomains (except those starting with "dev.") to the root domain.

- **Chores**
  - Updated the app version to 0.19.5.
  - Added a new changelog entry for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->