### PR TITLE
Update crop residue biomass calculation and adjust related test cases

### DIFF
--- a/.changeset/sour-kings-drive.md
+++ b/.changeset/sour-kings-drive.md
@@ -1,0 +1,5 @@
+---
+"@svenvw/fdm-calculator": patch
+---
+
+Fix calculation of crop residue biomass at nitrogen balance calculation

--- a/fdm-calculator/src/balance/nitrogen/removal/index.test.ts
+++ b/fdm-calculator/src/balance/nitrogen/removal/index.test.ts
@@ -9,6 +9,8 @@ describe("calculateNitrogenRemoval", () => {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
                 m_cropresidue: true,
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
             },
         ]
         const harvests: FieldInput["harvests"] = [
@@ -45,9 +47,9 @@ describe("calculateNitrogenRemoval", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-21.2) // -20 from harvest + -1.2 from residue
+        expect(result.total.toNumber()).toBeCloseTo(-23) // -20 from harvest + -3 from residue
         expect(result.harvests.total.toNumber()).toBeCloseTo(-20)
-        expect(result.residues.total.toNumber()).toBeCloseTo(-1.2)
+        expect(result.residues.total.toNumber()).toBeCloseTo(-3)
     })
 
     it("should handle cases with no harvests or residues", () => {
@@ -56,6 +58,8 @@ describe("calculateNitrogenRemoval", () => {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
                 m_cropresidue: false,
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
             },
         ]
         const harvests: FieldInput["harvests"] = []

--- a/fdm-calculator/src/balance/nitrogen/removal/residue.test.ts
+++ b/fdm-calculator/src/balance/nitrogen/removal/residue.test.ts
@@ -24,7 +24,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: false, // No residue left
             },
         ]
@@ -47,7 +48,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -74,8 +76,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
-        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
+        expect(result.total.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
+        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
     })
 
     it("should calculate nitrogen removal for multiple harvests, averaging yields", () => {
@@ -83,7 +85,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -108,8 +111,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
-        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
+        expect(result.total.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
+        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
     })
 
     it("should handle missing harvest data using cultivation defaults", () => {
@@ -117,7 +120,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -129,8 +133,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
-        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
+        expect(result.total.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
+        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
     })
 
     it("should handle missing cultivation details and throw an error", () => {
@@ -138,7 +142,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -161,7 +166,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: undefined, // Undefined residue handling
             },
         ]
@@ -184,7 +190,8 @@ describe("calculateNitrogenRemovalByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
-                // b_lu_start: new Date(),
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -206,7 +213,7 @@ describe("calculateNitrogenRemovalByResidue", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
-        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-1.2) //Approximation due to floating point
+        expect(result.total.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
+        expect(result.cultivations[0].value.toNumber()).toBeCloseTo(-3) //Approximation due to floating point
     })
 })

--- a/fdm-calculator/src/balance/nitrogen/removal/residue.ts
+++ b/fdm-calculator/src/balance/nitrogen/removal/residue.ts
@@ -103,6 +103,7 @@ export function calculateNitrogenRemovalByResidue(
 
         // Calculate the amount of Nitrogen removed by crop residues of this cultivation
         const removal = b_lu_yield
+            .dividedBy(b_lu_hi)
             .times(b_lu_hi_res)
             .times(b_lu_n_residue)
             .dividedBy(new Decimal(1000)) // Convert from g N / ha to kg N / ha

--- a/fdm-calculator/src/balance/nitrogen/volatization/residues.test.ts
+++ b/fdm-calculator/src/balance/nitrogen/volatization/residues.test.ts
@@ -24,6 +24,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -50,7 +52,7 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
         )
 
         //Check for approximation due to floating point
-        expect(result.total.toNumber()).toBeCloseTo(-2.688, 2)
+        expect(result.total.toNumber()).toBeCloseTo(-6.72, 2)
         expect(result.cultivations).toEqual([
             { id: "cultivation1", value: expect.any(Decimal) },
         ])
@@ -61,6 +63,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -102,7 +106,7 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
         )
 
         //Check for approximation due to floating point
-        expect(result.total.toNumber()).toBeCloseTo(-2.688, 2)
+        expect(result.total.toNumber()).toBeCloseTo(-6.72, 2)
         expect(result.cultivations).toEqual([
             { id: "cultivation1", value: expect.any(Decimal) },
         ])
@@ -113,6 +117,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -135,6 +141,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: false,
             },
         ]
@@ -170,6 +178,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: undefined, // Undefined residue handling
             },
         ]
@@ -206,6 +216,8 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             {
                 b_lu: "cultivation1",
                 b_lu_catalogue: "catalogue1",
+                b_lu_start: new Date("2022-01-01"),
+                b_lu_end: new Date("2022-12-31"),
                 m_cropresidue: true,
             },
         ]
@@ -241,7 +253,7 @@ describe("calculateNitrogenVolatizationViaAmmoniaByResidue", () => {
             cultivationDetailsMap,
         )
 
-        expect(result.total.toNumber()).toBeCloseTo(-2.688, 1)
+        expect(result.total.toNumber()).toBeCloseTo(-6.72, 1)
         expect(result.cultivations).toEqual([
             { id: "cultivation1", value: expect.any(Decimal) },
         ])

--- a/fdm-calculator/src/balance/nitrogen/volatization/residues.ts
+++ b/fdm-calculator/src/balance/nitrogen/volatization/residues.ts
@@ -111,6 +111,7 @@ export function calculateNitrogenVolatizationViaAmmoniaByResidue(
 
         // Calculate the amount of Nitrogen volatilized by crop residues of this cultivation
         const removal = b_lu_yield
+            .dividedBy(b_lu_hi)
             .times(b_lu_hi_res)
             .times(b_lu_n_residue)
             .times(emissionFactor)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of crop residue biomass in nitrogen balance computations, resulting in updated nitrogen removal and volatilization values.

* **Tests**
  * Updated test cases to reflect changes in calculation logic and adjusted expected results accordingly. Input data for tests now includes explicit date ranges for cultivations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #203 