### PR TITLE
Enhance map visualization by coloring available fields based on cultivation class

### DIFF
--- a/.changeset/dark-bats-sip.md
+++ b/.changeset/dark-bats-sip.md
@@ -1,0 +1,5 @@
+---
+"@svenvw/fdm-app": minor
+---
+
+Show available fields in different colors based on cultivation type.

--- a/.changeset/whole-bears-trade.md
+++ b/.changeset/whole-bears-trade.md
@@ -1,0 +1,5 @@
+---
+"@svenvw/fdm-app": minor
+---
+
+Selected fields now have an outline instead of a different fill color in the farm creation wizard atlas.

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -17,6 +17,7 @@ import {
     CardTitle,
 } from "~/components/ui/card"
 import { cn } from "~/lib/utils"
+import { getCultivationColor } from "../../custom/cultivation-colors"
 
 export function FieldsPanelHover({
     zoomLevelFields,
@@ -199,7 +200,7 @@ export function FieldsPanelSelection({
 
                     const cultivations = features.reduce(
                         (
-                            acc: { b_lu_name: string; count: number }[],
+                            acc: { b_lu_name: string; b_lu_croprotation: string; count: number }[],
                             feature,
                         ) => {
                             if (!feature.properties) return acc
@@ -213,6 +214,8 @@ export function FieldsPanelSelection({
                             } else {
                                 acc.push({
                                     b_lu_name: feature.properties.b_lu_name,
+                                    b_lu_croprotation:
+                                        feature.properties.b_lu_croprotation,
                                     count: 1,
                                 })
                             }
@@ -238,7 +241,15 @@ export function FieldsPanelSelection({
                                             key={cultivation.b_lu_name}
                                             className="mb-2 grid grid-cols-[25px_1fr] items-start pb-2 last:mb-0 last:pb-0"
                                         >
-                                            <span className="flex h-2 w-2 translate-y-1 rounded-full bg-green-500" />
+                                            <span
+                                                className="flex h-2 w-2 translate-y-1 rounded-full"
+                                                style={{
+                                                    backgroundColor:
+                                                        getCultivationColor(
+                                                            cultivation.b_lu_croprotation,
+                                                        ),
+                                                }}
+                                            />
                                             <div className="space-y-1">
                                                 <p className="text-sm font-medium leading-none">
                                                     {cultivation.b_lu_name}

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -17,7 +17,7 @@ import {
     CardTitle,
 } from "~/components/ui/card"
 import { cn } from "~/lib/utils"
-import { getCultivationColor } from "../../custom/cultivation-colors"
+import { getCultivationColor } from "~/components/custom/cultivation-colors"
 
 export function FieldsPanelHover({
     zoomLevelFields,
@@ -200,7 +200,7 @@ export function FieldsPanelSelection({
 
                     const cultivations = features.reduce(
                         (
-                            acc: { b_lu_name: string; b_lu_croprotation: string; count: number }[],
+                            acc: { b_lu_name: string; b_lu_croprotation?: string; count: number }[],
                             feature,
                         ) => {
                             if (!feature.properties) return acc

--- a/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
@@ -1,7 +1,7 @@
 import { deserialize } from "flatgeobuf/lib/mjs/geojson.js"
 import type { FeatureCollection, GeoJsonProperties, Geometry } from "geojson"
 import throttle from "lodash.throttle"
-import { type Dispatch, type JSX, type SetStateAction, useEffect, useMemo, useState } from "react"
+import { type Dispatch, type JSX, ReactNode, type SetStateAction, useEffect, useMemo, useState } from "react"
 import { Source, useMap } from "react-map-gl/mapbox"
 import { generateFeatureClass } from "./atlas-functions"
 import { getAvailableFieldsUrl } from "./atlas-url"
@@ -17,7 +17,7 @@ export function FieldsSourceNotClickable({
 }: {
     id: string
     fieldsData: FeatureCollection
-    children: JSX.Element
+    children: ReactNode
 }) {
     return (
         <Source id={id} type="geojson" data={fieldsData}>

--- a/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
@@ -1,12 +1,12 @@
 import { deserialize } from "flatgeobuf/lib/mjs/geojson.js"
 import type { FeatureCollection, GeoJsonProperties, Geometry } from "geojson"
 import throttle from "lodash.throttle"
-import { type Dispatch, type JSX, ReactNode, type SetStateAction, useEffect, useMemo, useState } from "react"
+import { type Dispatch, type JSX, type ReactNode, type SetStateAction, useEffect, useMemo, useState } from "react"
 import { Source, useMap } from "react-map-gl/mapbox"
 import { generateFeatureClass } from "./atlas-functions"
 import { getAvailableFieldsUrl } from "./atlas-url"
 import {
-    CatalogueCultivationItem,
+    type CatalogueCultivationItem,
     getCultivationCatalogue,
 } from "@svenvw/fdm-data"
 

--- a/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
@@ -1,10 +1,14 @@
 import { deserialize } from "flatgeobuf/lib/mjs/geojson.js"
 import type { FeatureCollection, GeoJsonProperties, Geometry } from "geojson"
 import throttle from "lodash.throttle"
-import { type Dispatch, type JSX, type SetStateAction, useEffect, useState } from "react"
+import { type Dispatch, type JSX, type SetStateAction, useEffect, useMemo, useState } from "react"
 import { Source, useMap } from "react-map-gl/mapbox"
 import { generateFeatureClass } from "./atlas-functions"
 import { getAvailableFieldsUrl } from "./atlas-url"
+import {
+    CatalogueCultivationItem,
+    getCultivationCatalogue,
+} from "@svenvw/fdm-data"
 
 export function FieldsSourceNotClickable({
     id,
@@ -119,6 +123,15 @@ export function FieldsSourceAvailable({
     const [data, setData] = useState(generateFeatureClass())
     const availableFieldsUrl = getAvailableFieldsUrl(calendar)
 
+    const cultivationCataloguePromise = useMemo(async () => {
+        const items = await getCultivationCatalogue("brp")
+        const result: Record<string, CatalogueCultivationItem> = {}
+        for (const item of items) {
+            result[item.b_lu_catalogue] = item
+        }
+        return result
+    }, [])
+
     useEffect(() => {
         async function loadData() {
             if (map) {
@@ -135,6 +148,8 @@ export function FieldsSourceAvailable({
                             minY: 0.9995 * minY,
                             maxY: 1.0005 * maxY,
                         }
+                        const cultivationCatalogue =
+                            await cultivationCataloguePromise
                         try {
                             const iter = deserialize(availableFieldsUrl, bbox)
 
@@ -142,9 +157,17 @@ export function FieldsSourceAvailable({
                             const featureClass = generateFeatureClass()
 
                             for await (const feature of iter) {
+                                const catalogueKey =
+                                    feature.properties?.b_lu_catalogue
                                 featureClass.features.push({
                                     ...feature,
                                     id: i,
+                                    properties: {
+                                        ...feature.properties,
+                                        b_lu_croprotation:
+                                            cultivationCatalogue[catalogueKey]
+                                                ?.b_lu_croprotation,
+                                    },
                                 })
                                 i += 1
                             }
@@ -173,7 +196,7 @@ export function FieldsSourceAvailable({
                 map.off("zoomend", throttledLoadData)
             }
         }
-    }, [map, availableFieldsUrl, zoomLevelFields])
+    }, [map, availableFieldsUrl, zoomLevelFields, cultivationCataloguePromise])
 
     return (
         <Source id={id} type="geojson" data={data}>

--- a/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-sources.tsx
@@ -124,12 +124,17 @@ export function FieldsSourceAvailable({
     const availableFieldsUrl = getAvailableFieldsUrl(calendar)
 
     const cultivationCataloguePromise = useMemo(async () => {
-        const items = await getCultivationCatalogue("brp")
-        const result: Record<string, CatalogueCultivationItem> = {}
-        for (const item of items) {
-            result[item.b_lu_catalogue] = item
+        try {
+            const items = await getCultivationCatalogue("brp")
+            const result: Record<string, CatalogueCultivationItem> = {}
+            for (const item of items) {
+                result[item.b_lu_catalogue] = item
+            }
+            return result
+        } catch (err) {
+            console.error("Failed to load cultivation catalogue; defaulting to other color.", err)
+            return {}
         }
-        return result
     }, [])
 
     useEffect(() => {

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -8,21 +8,20 @@ import {
 const baseFieldsFillColorExpr: ExpressionSpecification = [
     "match",
     ["get", "b_lu_croprotation"],
+    ...getCultivationTypesHavingColors().flatMap((k) => [
+        k,
+        getCultivationColor(k),
+    ]),
+    getCultivationColor("other"),
 ]
 
-for (const key of getCultivationTypesHavingColors()) {
-    baseFieldsFillColorExpr.push(key, getCultivationColor(key))
-}
-
-baseFieldsFillColorExpr.push("#60a5fa")
-
-export function getFieldsStyle(layerId: string) {
-    const style = getFieldsStyleInner(layerId) as LayerProps
+export function getFieldsStyle(layerId: string): LayerProps {
+    const style = getFieldsStyleInner(layerId)
     style.id = layerId
     return style
 }
 
-function getFieldsStyleInner(layerId: string): Omit<LayerProps, "id"> {
+function getFieldsStyleInner(layerId: string): LayerProps {
     const baseFillStyles = {
         "fill-outline-color": "#1e3a8a",
     }
@@ -46,8 +45,17 @@ function getFieldsStyleInner(layerId: string): Omit<LayerProps, "id"> {
             type: "fill",
             paint: {
                 ...baseFillStyles,
-                "fill-color": "#10b981",
-                "fill-opacity": 0.8,
+                "fill-color": "transparent",
+            },
+        }
+    }
+
+    if (layerId === "fieldsSavedOutline") {
+        return {
+            type: "line",
+            paint: {
+                ...baseLineStyles,
+                "line-color": "#10b981",
             },
         }
     }

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -4,6 +4,29 @@ import type {
     SymbolLayerSpecification,
 } from "react-map-gl/mapbox"
 
+export const CROP_ROTATION_COLORS = {
+    grass: "#558B2F",
+    maize: "#FBC02D",
+    cereal: "#C2B280",
+    potato: "#8D6E63",
+    sugarbeet: "#9B2D30",
+    rapeseed: "#D4AC0D",
+    clover: "#8BC34A",
+    alfalfa: "#7E57C2",
+    catchcrop: "#4DD0E1",
+    nature: "#00796B",
+    starch: "#F57C00",
+    other: "#9E9E9E",
+}
+
+const baseFieldsFillColorExpr = ["match", ["get", "b_lu_croprotation"]]
+
+for (const [key, value] of Object.entries(CROP_ROTATION_COLORS)) {
+    baseFieldsFillColorExpr.push(key, value)
+}
+
+baseFieldsFillColorExpr.push("#60a5fa")
+
 export function getFieldsStyle(layerId: string): LayerProps &
     (
         | {
@@ -21,7 +44,7 @@ export function getFieldsStyle(layerId: string): LayerProps &
     const baseFieldsStyle: Omit<FillLayerSpecification, "id" | "source"> = {
         type: "fill",
         paint: {
-            "fill-color": "#60a5fa",
+            "fill-color": baseFieldsFillColorExpr,
             "fill-opacity": 0.5,
             "fill-outline-color": "#1e3a8a",
         },

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -45,7 +45,8 @@ function getFieldsStyleInner(layerId: string): LayerProps {
             type: "fill",
             paint: {
                 ...baseFillStyles,
-                "fill-color": "transparent",
+                "fill-color": "#000000",
+                "fill-opacity": 0,
             },
         }
     }
@@ -67,7 +68,6 @@ function getFieldsStyleInner(layerId: string): LayerProps {
             ...baseFillStyles,
             "fill-color": baseFieldsFillColorExpr,
             "fill-opacity": 0.8,
-            "fill-outline-color": "#1e3a8a",
         },
     }
 }

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -41,10 +41,10 @@ function getFieldsStyleInner(layerId: string): LayerProps {
     }
 
     if (layerId === "fieldsSaved") {
+        // This layer should not be visible but still clickable
         return {
             type: "fill",
             paint: {
-                ...baseFillStyles,
                 "fill-color": "#000000",
                 "fill-opacity": 0,
             },

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -1,68 +1,65 @@
-import type {
-    FillLayerSpecification,
-    LayerProps,
-    SymbolLayerSpecification,
-} from "react-map-gl/mapbox"
+import type { ExpressionSpecification } from "mapbox-gl"
+import type { LayerProps } from "react-map-gl/mapbox"
+import {
+    getCultivationColor,
+    getCultivationTypesHavingColors,
+} from "~/components/custom/cultivation-colors"
 
-export const CROP_ROTATION_COLORS = {
-    grass: "#558B2F",
-    maize: "#FBC02D",
-    cereal: "#C2B280",
-    potato: "#8D6E63",
-    sugarbeet: "#9B2D30",
-    rapeseed: "#D4AC0D",
-    clover: "#8BC34A",
-    alfalfa: "#7E57C2",
-    catchcrop: "#4DD0E1",
-    nature: "#00796B",
-    starch: "#F57C00",
-    other: "#9E9E9E",
-}
+const baseFieldsFillColorExpr: ExpressionSpecification = [
+    "match",
+    ["get", "b_lu_croprotation"],
+]
 
-const baseFieldsFillColorExpr = ["match", ["get", "b_lu_croprotation"]]
-
-for (const [key, value] of Object.entries(CROP_ROTATION_COLORS)) {
-    baseFieldsFillColorExpr.push(key, value)
+for (const key of getCultivationTypesHavingColors()) {
+    baseFieldsFillColorExpr.push(key, getCultivationColor(key))
 }
 
 baseFieldsFillColorExpr.push("#60a5fa")
 
-export function getFieldsStyle(layerId: string): LayerProps &
-    (
-        | {
-              id: string
-              type: "fill"
-              paint: FillLayerSpecification["paint"]
-          }
-        | {
-              id: string
-              type: "symbol"
-              layout: SymbolLayerSpecification["layout"]
-              paint: SymbolLayerSpecification["paint"]
-          }
-    ) {
-    const baseFieldsStyle: Omit<FillLayerSpecification, "id" | "source"> = {
-        type: "fill",
-        paint: {
-            "fill-color": baseFieldsFillColorExpr,
-            "fill-opacity": 0.5,
-            "fill-outline-color": "#1e3a8a",
-        },
-    } as FillLayerSpecification // Cast to FillLayerSpecification to allow modification of paint
+export function getFieldsStyle(layerId: string) {
+    const style = getFieldsStyleInner(layerId) as LayerProps
+    style.id = layerId
+    return style
+}
 
-    const fieldsStyle = {
-        ...baseFieldsStyle,
-        id: layerId,
-    } as LayerProps & FillLayerSpecification // Cast to FillLayerSpecification to allow modification of paint
+function getFieldsStyleInner(layerId: string): Omit<LayerProps, "id"> {
+    const baseFillStyles = {
+        "fill-outline-color": "#1e3a8a",
+    }
+
+    const baseLineStyles = {
+        "line-width": 4,
+    }
 
     if (layerId === "fieldsSelected") {
-        fieldsStyle.paint["fill-color"] = "#f43f5e"
-        fieldsStyle.paint["fill-opacity"] = 0.8
-    }
-    if (layerId === "fieldsSaved") {
-        fieldsStyle.paint["fill-color"] = "#10b981"
-        fieldsStyle.paint["fill-opacity"] = 0.8
+        return {
+            type: "line",
+            paint: {
+                ...baseLineStyles,
+                "line-color": "#ffcf0d",
+            },
+        }
     }
 
-    return fieldsStyle
+    if (layerId === "fieldsSaved") {
+        return {
+            type: "fill",
+            paint: {
+                ...baseFillStyles,
+                "fill-color": "#10b981",
+                "fill-opacity": 0.8,
+            },
+        }
+    }
+
+    // default styles
+    return {
+        type: "fill",
+        paint: {
+            ...baseFillStyles,
+            "fill-color": baseFieldsFillColorExpr,
+            "fill-opacity": 0.8,
+            "fill-outline-color": "#1e3a8a",
+        },
+    }
 }

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -22,9 +22,7 @@ export function getFieldsStyle(layerId: string): LayerProps {
 }
 
 function getFieldsStyleInner(layerId: string): LayerProps {
-    const baseFillStyles = {
-        "fill-outline-color": "#1e3a8a",
-    }
+    const baseFillStyles = {}
 
     const baseLineStyles = {
         "line-width": 4,

--- a/fdm-app/app/components/custom/cultivation-colors.ts
+++ b/fdm-app/app/components/custom/cultivation-colors.ts
@@ -1,0 +1,22 @@
+export const CROP_ROTATION_COLORS: Record<string, string> = {
+    grass: "#558B2F",
+    maize: "#FBC02D",
+    cereal: "#C2B280",
+    potato: "#8D6E63",
+    sugarbeet: "#9B2D30",
+    rapeseed: "#D4AC0D",
+    clover: "#8BC34A",
+    alfalfa: "#7E57C2",
+    catchcrop: "#4DD0E1",
+    nature: "#00796B",
+    starch: "#F57C00",
+    other: "#9E9E9E",
+}
+
+export function getCultivationTypesHavingColors() {
+    return Object.keys(CROP_ROTATION_COLORS)
+}
+
+export function getCultivationColor(cultivationType: string) {
+    return CROP_ROTATION_COLORS[cultivationType] ?? CROP_ROTATION_COLORS.other
+}

--- a/fdm-app/app/components/custom/cultivation-colors.ts
+++ b/fdm-app/app/components/custom/cultivation-colors.ts
@@ -17,6 +17,9 @@ export function getCultivationTypesHavingColors() {
     return Object.keys(CROP_ROTATION_COLORS)
 }
 
-export function getCultivationColor(cultivationType: string) {
-    return CROP_ROTATION_COLORS[cultivationType] ?? CROP_ROTATION_COLORS.other
+export function getCultivationColor(cultivationType: string | undefined) {
+    if (cultivationType) {
+        return CROP_ROTATION_COLORS[cultivationType?.toLowerCase()] ?? CROP_ROTATION_COLORS.other
+    }
+    return CROP_ROTATION_COLORS.other
 }

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.tsx
@@ -122,6 +122,9 @@ export default function FarmAtlasFieldsBlock() {
     const initialViewState = getViewState(fields)
     const fieldsSavedStyle = getFieldsStyle(id)
 
+    const idOutline = "fieldsSavedOutline"
+    const fieldsSavedOutlineStyle = getFieldsStyle(idOutline)
+
     const [viewState, setViewState] = useState<ViewState>(
         initialViewState as ViewState,
     )
@@ -154,6 +157,9 @@ export default function FarmAtlasFieldsBlock() {
             />
             <FieldsSourceNotClickable id={id} fieldsData={fields}>
                 <Layer {...fieldsSavedStyle} />
+            </FieldsSourceNotClickable>
+            <FieldsSourceNotClickable id={idOutline} fieldsData={fields}>
+                <Layer {...fieldsSavedOutlineStyle} />
             </FieldsSourceNotClickable>
             <div className="fields-panel grid gap-4 w-[350px]">
                 <FieldsPanelHover

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.tsx
@@ -122,8 +122,7 @@ export default function FarmAtlasFieldsBlock() {
     const initialViewState = getViewState(fields)
     const fieldsSavedStyle = getFieldsStyle(id)
 
-    const idOutline = "fieldsSavedOutline"
-    const fieldsSavedOutlineStyle = getFieldsStyle(idOutline)
+    const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     const [viewState, setViewState] = useState<ViewState>(
         initialViewState as ViewState,
@@ -157,8 +156,6 @@ export default function FarmAtlasFieldsBlock() {
             />
             <FieldsSourceNotClickable id={id} fieldsData={fields}>
                 <Layer {...fieldsSavedStyle} />
-            </FieldsSourceNotClickable>
-            <FieldsSourceNotClickable id={idOutline} fieldsData={fields}>
                 <Layer {...fieldsSavedOutlineStyle} />
             </FieldsSourceNotClickable>
             <div className="fields-panel grid gap-4 w-[350px]">

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.atlas.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.atlas.tsx
@@ -107,6 +107,7 @@ export default function FarmFieldAtlasBlock() {
     const fields = loaderData.field
     const viewState = getViewState(fields)
     const fieldsSavedStyle = getFieldsStyle(id)
+    const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     return (
         <div className="space-y-6">
@@ -139,6 +140,7 @@ export default function FarmFieldAtlasBlock() {
                                 fieldsData={fields}
                             >
                                 <Layer {...fieldsSavedStyle} />
+                                <Layer {...fieldsSavedOutlineStyle} />
                             </FieldsSourceNotClickable>
                         </MapGL>
                     )}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new.tsx
@@ -194,8 +194,7 @@ export default function Index() {
     const fieldsSaved = loaderData.featureCollection
     const fieldsSavedStyle = getFieldsStyle(fieldsSavedId)
 
-    const idOutline = "fieldsSavedOutline"
-    const fieldsSavedOutlineStyle = getFieldsStyle(idOutline)
+    const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     const mapProps =
         fieldsSaved.features.length > 0
@@ -318,11 +317,6 @@ export default function Index() {
                                     fieldsData={fieldsSaved}
                                 >
                                     <Layer {...fieldsSavedStyle} />
-                                </FieldsSourceNotClickable>
-                                <FieldsSourceNotClickable
-                                    id={idOutline}
-                                    fieldsData={fieldsSaved}
-                                >
                                     <Layer {...fieldsSavedOutlineStyle} />
                                 </FieldsSourceNotClickable>
 

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new.tsx
@@ -193,6 +193,10 @@ export default function Index() {
     const fieldsSavedId = "fieldsSaved"
     const fieldsSaved = loaderData.featureCollection
     const fieldsSavedStyle = getFieldsStyle(fieldsSavedId)
+
+    const idOutline = "fieldsSavedOutline"
+    const fieldsSavedOutlineStyle = getFieldsStyle(idOutline)
+
     const mapProps =
         fieldsSaved.features.length > 0
             ? getViewState(fieldsSaved)
@@ -286,7 +290,12 @@ export default function Index() {
                                             f.source === fieldsAvailableId &&
                                             f.geometry?.type === "Polygon",
                                     )
-                                    if (polygonFeature) {
+                                    const savedPolygonFeature = evt.features.find(
+                                        (f) =>
+                                            f.source === fieldsSavedId &&
+                                            f.geometry?.type === "Polygon",
+                                    )
+                                    if (polygonFeature && !savedPolygonFeature) {
                                         handleSelectField(
                                             polygonFeature as Feature<Polygon>,
                                         )
@@ -309,6 +318,12 @@ export default function Index() {
                                     fieldsData={fieldsSaved}
                                 >
                                     <Layer {...fieldsSavedStyle} />
+                                </FieldsSourceNotClickable>
+                                <FieldsSourceNotClickable
+                                    id={idOutline}
+                                    fieldsData={fieldsSaved}
+                                >
+                                    <Layer {...fieldsSavedOutlineStyle} />
                                 </FieldsSourceNotClickable>
 
                                 <div className="fields-panel grid gap-4 w-[350px]">

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
@@ -288,7 +288,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
                     }
                     const b_name = `Perceel ${index + 1}`
                     const b_id_source = field.properties.b_id_source
-                    const b_lu_catalogue = `nl_${field.properties.b_lu_catalogue}` //TEMPORARY
+                    const b_lu_catalogue = field.properties.b_lu_catalogue
                     const b_geometry = field.geometry
                     const currentYear = new Date().getFullYear()
                     const defaultDate = timeframe.start

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.fields.$b_id._index.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.fields.$b_id._index.tsx
@@ -227,6 +227,7 @@ export default function Index() {
     const id = "fieldsSaved"
     const fields = loaderData.featureCollection
     const fieldsSavedStyle = getFieldsStyle(id)
+    const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     const form = useRemixForm({
         mode: "onTouched",
@@ -384,6 +385,7 @@ export default function Index() {
                                     fieldsData={fields}
                                 >
                                     <Layer {...fieldsSavedStyle} />
+                                    <Layer {...fieldsSavedOutlineStyle} />
                                 </FieldsSourceNotClickable>
                             </MapGL>
                         ) : (


### PR DESCRIPTION
**New Features**
- Available fields appear in different, hard-coded colors based on the cultivation class which is currently based on the crop rotation type.
- Selected fields are outlined instead of appearing in different fill colors.

Closes #227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fields are now displayed in different colors based on their cultivation type.
  * Cultivation types and their corresponding colors are visually represented in the atlas panels.

* **Style**
  * Selected fields in the farm creation wizard atlas are now highlighted with an outline instead of a fill color.
  * Field fill opacity has been increased for improved visibility.
  * Added a distinct outline layer for saved fields to improve map clarity.

* **Bug Fixes**
  * Improved accuracy and consistency of cultivation type color coding across relevant components.
  * Refined field selection logic to prevent overlap between available and saved fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->