### PR TITLE
Use definitive for 2024 and draft for 2025 in atlas-url.ts; add changeset

### DIFF
--- a/.changeset/fruity-yaks-accept.md
+++ b/.changeset/fruity-yaks-accept.md
@@ -2,4 +2,4 @@
 "@svenvw/fdm-app": patch
 ---
 
-For the available fields layer at 2024 switch from the draft version to definitive
+Switch the 2024 available fields layer from "draft" to "definitive".

--- a/.changeset/fruity-yaks-accept.md
+++ b/.changeset/fruity-yaks-accept.md
@@ -1,0 +1,5 @@
+---
+"@svenvw/fdm-app": patch
+---
+
+For the available fields layer at 2024 switch from the draft version to definitive

--- a/fdm-app/app/components/blocks/atlas/atlas-url.ts
+++ b/fdm-app/app/components/blocks/atlas/atlas-url.ts
@@ -13,7 +13,7 @@ export function getAvailableFieldsUrl(calendar: string): string {
 
     // Set version according to availability at FDM public datasets
     let version = "definitive"
-    if (year >= 2024) {
+    if (year >= 2025) {
         version = "draft"
     }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated year-based version selection: 2024 now uses the definitive layer, while the draft layer is reserved for 2025. No changes to URL structure or other logic.

* **Chores**
  * Prepared a patch release to reflect the version selection update in release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #240 