### PR TITLE
Fix users not being able to view the atlas before creating any farms

### DIFF
--- a/.changeset/rare-bottles-wonder.md
+++ b/.changeset/rare-bottles-wonder.md
@@ -1,5 +1,0 @@
----
-"@svenvw/fdm-app": patch
----
-
-The atlas no longer redirects the users to an invalid route when they don't have any farms.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.23.2
+
+### Patch Changes
+
+- 2ba569e: The atlas no longer redirects the users to an invalid route when they don't have any farms.
+
 ## 0.23.1
 
 ### Patch Changes

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@svenvw/fdm-app",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
Bug Fixes
- The atlas no longer redirects the users to an invalid route when they don't have any farms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the atlas would redirect users to an invalid route when they had no farms. The application now properly handles this scenario, validating farm data before performing redirects and ensuring the atlas loads correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->