### PR TITLE
Store SECTORID as b_id_source in RVO uploads

### DIFF
--- a/.changeset/major-kids-laugh.md
+++ b/.changeset/major-kids-laugh.md
@@ -1,5 +1,0 @@
----
-"@svenvw/fdm-app": patch
----
-
-At RVO MijnPercelen shapefile upload store SECTORID as b_id_source for the field

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.25.3
+
+### Patch Changes
+
+- 598a3b6: At RVO MijnPercelen shapefile upload store SECTORID as b_id_source for the field
+
 ## 0.25.2
 
 ### Patch Changes

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@svenvw/fdm-app",
-    "version": "0.25.2",
+    "version": "0.25.3",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected field source identifier handling in farm shapefile uploads. SECTORID values are now properly stored as field source references when uploading RVO MijnPercelen data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #371 