### PR TITLE
Fix width and height for the soil atlas feature query

### DIFF
--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.soil.tsx
@@ -179,8 +179,8 @@ export default function FarmAtlasSoilBlock() {
 
             // Construct GetFeatureInfo request
             const bounds = map.getBounds()
-            const width = map.getCanvas().width
-            const height = map.getCanvas().height
+            const width = map.getCanvas().offsetWidth
+            const height = map.getCanvas().offsetHeight
 
             // Use proj4 to get bounds in EPSG:3857
             const sw = proj4("EPSG:3857").forward([


### PR DESCRIPTION
**Bug Fixes**
- Uses offsetWidth and offsetHeight instead of just width and height. The reason is that the style width and height differ from the canvas pixel width and height.