### PR TITLE
Add Vite plugin to replace calculator version in build

### DIFF
--- a/.changeset/ten-spiders-hang.md
+++ b/.changeset/ten-spiders-hang.md
@@ -1,5 +1,0 @@
----
-"@svenvw/fdm-app": patch
----
-
-Fix calculator version placeholder in `fdm-app` build. This ensures the calculation cache key correctly reflects the calculator version in production, where `fdm-app` consumes source files directly.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.27.3
+
+### Patch Changes
+
+- [#445](https://github.com/SvenVw/fdm/pull/445) [`f30565a`](https://github.com/SvenVw/fdm/commit/f30565ada2349775c159fa23ba58545159e9c15a) Thanks [@SvenVw](https://github.com/SvenVw)! - Fix calculator version placeholder in `fdm-app` build. This ensures the calculation cache key correctly reflects the calculator version in production, where `fdm-app` consumes source files directly.
+
 ## 0.27.2
 
 ### Patch Changes

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@svenvw/fdm-app",
-    "version": "0.27.2",
+    "version": "0.27.3",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calculator version tracking in production builds to ensure the calculation cache key properly reflects the currently active calculator version.

* **Chores**
  * Version bumped to 0.27.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #443