### PR TITLE
fix: include instrument.server.mjs in docker image

### DIFF
--- a/.changeset/bumpy-canyons-joke.md
+++ b/.changeset/bumpy-canyons-joke.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-Fix to include instrument.server.mjs in docker image

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.28.6
+
+### Patch Changes
+
+- [#525](https://github.com/nmi-agro/fdm/pull/525) [`6876a82`](https://github.com/nmi-agro/fdm/commit/6876a82611b6ad1cbc67174e9e1f2c40b74e0eeb) Thanks [@SvenVw](https://github.com/SvenVw)! - Fix to include instrument.server.mjs in docker image
+
 ## 0.28.5
 
 ### Patch Changes

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmi-agro/fdm-app",
-    "version": "0.28.5",
+    "version": "0.28.6",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker image build to ensure all required runtime files are properly included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->