### PR TITLE
Add missing a_nmin_cc field to FormSchema

### DIFF
--- a/.changeset/yellow-papayas-visit.md
+++ b/.changeset/yellow-papayas-visit.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+Fix that `a_nmin_cc` is stored when filled in for soil analysis

--- a/fdm-app/app/components/blocks/soil/formschema.tsx
+++ b/fdm-app/app/components/blocks/soil/formschema.tsx
@@ -203,6 +203,14 @@ export const FormSchema = z
                 .lte(30000, "Waarde moet kleiner of gelijk aan 30000 zijn")
                 .optional(),
         ),
+        a_nmin_cc: z.preprocess(
+            (val) => (val === "" ? undefined : val),
+            z.coerce
+                .number()
+                .gte(0, "Waarde moet groter of gelijk aan 0 zijn")
+                .lte(500, "Waarde moet kleiner of gelijk aan 500 zijn")
+                .optional(),
+        ),
         a_nh4_cc: z.preprocess(
             (val) => (val === "" ? undefined : val),
             z.coerce


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed soil analysis field storage to ensure nitrogen mineralization values are properly retained when entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #540