### PR TITLE
Add RVO feature flag to control field import functionality

### DIFF
--- a/.changeset/four-buttons-do.md
+++ b/.changeset/four-buttons-do.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+Add feature flag to manage access to RVO import of fields

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
@@ -42,7 +42,8 @@ import {
     DialogTrigger,
     DialogClose,
 } from "~/components/ui/dialog"
-import { AlertTriangle, Loader2 } from "lucide-react"
+import { AlertTriangle, CloudDownload, Loader2 } from "lucide-react"
+import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useEffect, useState } from "react"
 import { FarmContent } from "~/components/blocks/farm/farm-content"
 import { FarmTitle } from "~/components/blocks/farm/farm-title"
@@ -228,6 +229,8 @@ export default function RvoImportReviewPage() {
     const navigation = useNavigation()
     const location = useLocation()
 
+    const isRvoEnabled = useFeatureFlagEnabled("rvo")
+
     const isImporting =
         navigation.state === "submitting" &&
         navigation.formData?.get("intent") === "start_import"
@@ -298,6 +301,39 @@ export default function RvoImportReviewPage() {
         { add: 0, remove: 0, update: 0, close: 0 },
     )
     const hasChanges = Object.values(changes).some((count) => count > 0)
+
+    if (isRvoEnabled === false) {
+        return (
+            <SidebarInset>
+                <Header
+                    action={{
+                        to: `/farm/${b_id_farm}`,
+                        label: "Terug naar bedrijf",
+                        disabled: false,
+                    }}
+                >
+                    <HeaderFarm b_id_farm={b_id_farm} farmOptions={farms} />
+                </Header>
+                <FarmContent>
+                    <div className="max-w-2xl mx-auto mt-20 text-center space-y-6">
+                        <div className="bg-primary/10 border border-primary/20 p-8 rounded-xl">
+                            <CloudDownload className="w-12 h-12 text-primary mx-auto mb-4" />
+                            <h2 className="text-2xl font-bold text-foreground mb-2">
+                                Percelen ophalen bij RVO is nog niet beschikbaar
+                                voor je.
+                            </h2>
+                            <p className="text-muted-foreground mb-6">
+                                Deze functionaliteit is momenteel in ontwikkeling
+                                en is nog niet voor iedereen beschikbaar. Neem
+                                contact op met Ondersteuning als je hier vragen
+                                over hebt.
+                            </p>
+                        </div>
+                    </div>
+                </FarmContent>
+            </SidebarInset>
+        )
+    }
 
     if (error) {
         return (

--- a/fdm-app/app/routes/farm.$b_id_farm._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm._index.tsx
@@ -25,6 +25,7 @@ import {
     UserRoundCheck,
     CloudDownload,
 } from "lucide-react"
+import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useState } from "react"
 import {
     data,
@@ -155,6 +156,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function FarmDashboardIndex() {
     const loaderData = useLoaderData<typeof loader>()
+    const isRvoEnabled = useFeatureFlagEnabled("rvo")
 
     const calendar = useCalendarStore((state) => state.calendar)
     const setCalendar = useCalendarStore((state) => state.setCalendar)
@@ -449,7 +451,8 @@ export default function FarmDashboardIndex() {
                                             </CardHeader>
                                         </Card>
                                     </NavLink>
-                                    {loaderData.isRvoConfigured && (
+                                    {loaderData.isRvoConfigured &&
+                                        isRvoEnabled !== false && (
                                         <NavLink
                                             to={`${calendar}/rvo`}
                                             className={cn(

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar._index.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar._index.tsx
@@ -1,5 +1,6 @@
 import { getFarm } from "@nmi-agro/fdm-core"
 import { DownloadCloud, Map as MapIcon, UploadCloud } from "lucide-react"
+import { useFeatureFlagEnabled } from "posthog-js/react"
 import type { LoaderFunctionArgs, MetaFunction } from "react-router"
 import { data, NavLink, useLoaderData } from "react-router"
 import { Header } from "~/components/blocks/header/base"
@@ -63,6 +64,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
 export default function ChooseFieldImportMethod() {
     const { farm, isRvoConfigured } = useLoaderData<typeof loader>()
+    const isRvoEnabled = useFeatureFlagEnabled("rvo")
+    const showRvoOption = isRvoConfigured && isRvoEnabled !== false
 
     return (
         <SidebarInset>
@@ -80,12 +83,12 @@ export default function ChooseFieldImportMethod() {
                     <div
                         className={cn(
                             "grid gap-8",
-                            isRvoConfigured
+                            showRvoOption
                                 ? "md:grid-cols-3"
                                 : "md:grid-cols-2",
                         )}
                     >
-                        {isRvoConfigured && (
+                        {showRvoOption && (
                             <Card className="flex flex-col">
                                 <CardHeader className="items-center text-center">
                                     <DownloadCloud className="w-12 h-12 mb-4" />

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
@@ -30,7 +30,8 @@ import { RvoImportReviewTable } from "~/components/blocks/rvo/import-review-tabl
 import { type Cultivation, type Field, getFarm } from "@nmi-agro/fdm-core"
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert"
 import { Button } from "~/components/ui/button"
-import { AlertTriangle, Loader2 } from "lucide-react"
+import { AlertTriangle, CloudDownload, Loader2 } from "lucide-react"
+import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useEffect, useState } from "react"
 import { FarmContent } from "~/components/blocks/farm/farm-content"
 import { FarmTitle } from "~/components/blocks/farm/farm-title"
@@ -202,6 +203,8 @@ export default function RvoImportCreatePage() {
     const navigation = useNavigation()
     const location = useLocation()
 
+    const isRvoEnabled = useFeatureFlagEnabled("rvo")
+
     const isImporting =
         navigation.state === "submitting" &&
         navigation.formData?.get("intent") === "start_import"
@@ -249,6 +252,33 @@ export default function RvoImportCreatePage() {
 
     const handleChoiceChange = (id: string, action: ImportReviewAction) => {
         setUserChoices((prev: UserChoiceMap) => ({ ...prev, [id]: action }))
+    }
+
+    if (isRvoEnabled === false) {
+        return (
+            <SidebarInset>
+                <Header action={undefined}>
+                    <HeaderFarmCreate b_name_farm={b_name_farm} />
+                </Header>
+                <FarmContent>
+                    <div className="max-w-2xl mx-auto mt-20 text-center space-y-6">
+                        <div className="bg-primary/10 border border-primary/20 p-8 rounded-xl">
+                            <CloudDownload className="w-12 h-12 text-primary mx-auto mb-4" />
+                            <h2 className="text-2xl font-bold text-foreground mb-2">
+                                Percelen ophalen bij RVO is nog niet beschikbaar
+                                voor je.
+                            </h2>
+                            <p className="text-muted-foreground mb-6">
+                                Deze functionaliteit is momenteel in ontwikkeling
+                                en is nog niet voor iedereen beschikbaar. Neem
+                                contact op met Ondersteuning als je hier vragen
+                                over hebt.
+                            </p>
+                        </div>
+                    </div>
+                </FarmContent>
+            </SidebarInset>
+        )
     }
 
     if (error) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added feature flag management for RVO field import capabilities. The RVO import functionality across farm dashboards, field creation workflows, and import review pages can now be dynamically toggled between enabled and disabled states. When the feature flag is disabled, users see unavailable status messaging instead of standard import options and workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->