### PR TITLE
Hotfix: Rotation table harvest dates

### DIFF
--- a/.changeset/tasty-lies-accept.md
+++ b/.changeset/tasty-lies-accept.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-Fixed the rotation table harvest date display sorting issues.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.29.2
+
+### Patch Changes
+
+- [#555](https://github.com/nmi-agro/fdm/pull/555) [`c718131`](https://github.com/nmi-agro/fdm/commit/c71813150b69bfca07ebc6c59d9201bdfa382ea1) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - Fixed the rotation table harvest date display sorting issues.
+
 ## 0.29.1
 
 ### Patch Changes

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmi-agro/fdm-app",
-    "version": "0.29.1",
+    "version": "0.29.2",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
**Bug fixes**

- Rotation table harvest date sorting is fixed. 1e snede, 2e snede etc. are now properly assigned according to ascending harvest date.

Closes #554 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed harvest date sorting in the rotation table to correctly order and display harvest dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->