### PR TITLE
Sort cultivation field cultivations by descending year

### DIFF
--- a/.changeset/tame-falcons-speak.md
+++ b/.changeset/tame-falcons-speak.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-When viewing the cultivation history for a field on the atlas, history items are now correctly sorted by descending year.

--- a/.changeset/tame-falcons-speak.md
+++ b/.changeset/tame-falcons-speak.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+When viewing the cultivation history for a field on the atlas, history items are now correctly sorted by descending year.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.29.3
+
+### Patch Changes
+
+- [#561](https://github.com/nmi-agro/fdm/pull/561) [`f5fd4b5`](https://github.com/nmi-agro/fdm/commit/f5fd4b5f4d3aa40716c1b556c484647f72ce9ad8) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - When viewing the cultivation history for a field on the atlas, history items are now correctly sorted by descending year.
+
 ## 0.29.2
 
 ### Patch Changes

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.$centroid.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.$centroid.tsx
@@ -149,8 +149,9 @@ async function loadAsyncData(
                         catalogueItem?.b_lu_croprotation ?? "other",
                     b_lu_rest_oravib: catalogueItem?.b_lu_rest_oravib ?? false,
                 }
-            },
-        )
+            })
+            // Sort by descending year
+            .sort((c1, c2) => c2.year - c1.year)
 
         return {
             cultivationHistory,

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmi-agro/fdm-app",
-    "version": "0.29.2",
+    "version": "0.29.3",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
**Bug Fixes**

- NMI API no longer returns the cultivation history of a centroid by descending year. The atlas field detail page code has been adapted to this.

Closes #hotfix/FDM560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cultivation history items on the field Atlas now display in the correct descending order by year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->