### PR TITLE
Improve atlas field panel styling

### DIFF
--- a/.changeset/moody-berries-wave.md
+++ b/.changeset/moody-berries-wave.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+The cultivation and field count list seen on field selection atlas pages now becomes scrollable when there are too many different cultivations to display, ensuring that the "Sla geselecteerde percelen op" button is always reachable.

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -2,7 +2,7 @@ import type { FeatureCollection } from "geojson"
 import throttle from "lodash.throttle"
 import { Check, Info } from "lucide-react"
 import type { MapGeoJSONFeature, MapLibreZoomEvent } from "maplibre-gl"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import type { MapLayerMouseEvent as MapMouseEvent } from "react-map-gl/maplibre"
 import { useMap } from "react-map-gl/maplibre"
 import { data, NavLink, useFetcher } from "react-router"
@@ -247,6 +247,8 @@ export function FieldsPanelSelection({
     const fetcher = useFetcher()
     const { current: map } = useMap()
     const [panel, setPanel] = useState<React.ReactNode | null>(null)
+    const scrollContainerRef = useRef<HTMLDivElement>(null)
+    const scrollRef = useRef<HTMLDivElement>(null)
 
     const isSubmitting = fetcher.state !== "idle"
 
@@ -275,6 +277,26 @@ export function FieldsPanelSelection({
         [fetcher],
     )
 
+    function handleScroll(
+        scrollElement: HTMLDivElement,
+        scrollContainerElement: HTMLDivElement,
+    ) {
+        if (scrollElement.scrollTop > 5) {
+            scrollContainerElement.dataset.scrollStart = ""
+        } else {
+            delete scrollContainerElement.dataset.scrollStart
+        }
+
+        if (
+            scrollElement.scrollHeight - scrollElement.scrollTop >
+            5 + scrollElement.offsetHeight
+        ) {
+            scrollContainerElement.dataset.scrollEnd = ""
+        } else {
+            delete scrollContainerElement.dataset.scrollEnd
+        }
+    }
+
     useEffect(() => {
         function updatePanel() {
             if (map) {
@@ -298,19 +320,18 @@ export function FieldsPanelSelection({
                             }[],
                             feature,
                         ) => {
-                            if (!feature.properties) return acc
+                            const cropField = feature.properties
+                            if (!cropField) return acc
                             const existingCultivation = acc.find(
-                                (c) =>
-                                    c.b_lu_name ===
-                                    feature.properties.b_lu_name,
+                                (c) => c.b_lu_name === cropField.b_lu_name,
                             )
                             if (existingCultivation) {
                                 existingCultivation.count++
                             } else {
                                 acc.push({
-                                    b_lu_name: feature.properties.b_lu_name,
+                                    b_lu_name: cropField.b_lu_name,
                                     b_lu_croprotation:
-                                        feature.properties.b_lu_croprotation,
+                                        cropField.b_lu_croprotation,
                                     count: 1,
                                 })
                             }
@@ -319,6 +340,8 @@ export function FieldsPanelSelection({
                         [],
                     )
 
+                    const pseudoElemClasses =
+                        "before:absolute before:h-16 before:left-0 before:right-0 before:from-card before:to-transparent before:opacity-0 before:transition-opacity before:duration-250 before:pointer-events-none"
                     setPanel(
                         <Card className="w-full flex-initial min-h-0 flex flex-col gap-4">
                             <CardHeader>
@@ -327,34 +350,46 @@ export function FieldsPanelSelection({
                                     {fieldCountText}
                                 </CardDescription>
                             </CardHeader>
-                            <CardContent className="flex-initial min-h-0 overflow-y-scroll">
-                                <div className="space-y-4">
-                                    {cultivations.map((cultivation, _index) => (
-                                        // let cultivationCountText = `${cultivation.count + 1} percelen`
+                            <CardContent
+                                ref={scrollContainerRef}
+                                className={`p-0 relative flex-initial min-h-0 overflow-hidden flex items-stretch before:top-0 after:bottom-0 before:bg-linear-to-b after:bg-linear-to-t data-scroll-start:before:opacity-100 data-scroll-end:after:opacity-100 ${pseudoElemClasses} ${pseudoElemClasses.replaceAll("before:", "after:")}`}
+                            >
+                                <div
+                                    ref={scrollRef}
+                                    className="overflow-y-scroll"
+                                >
+                                    <div className="px-6 py-4 space-y-4">
+                                        {cultivations.map(
+                                            (cultivation, _index) => (
+                                                // let cultivationCountText = `${cultivation.count + 1} percelen`
 
-                                        <div
-                                            key={cultivation.b_lu_name}
-                                            className="grid grid-cols-[25px_1fr] items-start"
-                                        >
-                                            <span
-                                                className="flex h-2 w-2 translate-y-1 rounded-full"
-                                                style={{
-                                                    backgroundColor:
-                                                        getCultivationColor(
-                                                            cultivation.b_lu_croprotation,
-                                                        ),
-                                                }}
-                                            />
-                                            <div className="space-y-1">
-                                                <p className="text-sm font-medium leading-none">
-                                                    {cultivation.b_lu_name}
-                                                </p>
-                                                <p className="text-sm text-muted-foreground">
-                                                    {`${cultivation.count} percelen`}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    ))}
+                                                <div
+                                                    key={cultivation.b_lu_name}
+                                                    className="grid grid-cols-[25px_1fr] items-start"
+                                                >
+                                                    <span
+                                                        className="flex h-2 w-2 translate-y-1 rounded-full"
+                                                        style={{
+                                                            backgroundColor:
+                                                                getCultivationColor(
+                                                                    cultivation.b_lu_croprotation,
+                                                                ),
+                                                        }}
+                                                    />
+                                                    <div className="space-y-1">
+                                                        <p className="text-sm font-medium leading-none">
+                                                            {
+                                                                cultivation.b_lu_name
+                                                            }
+                                                        </p>
+                                                        <p className="text-sm text-muted-foreground">
+                                                            {`${cultivation.count} percelen`}
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            ),
+                                        )}
+                                    </div>
                                 </div>
                             </CardContent>
                             <CardFooter>
@@ -425,6 +460,21 @@ export function FieldsPanelSelection({
         continueTo,
         numFieldsSaved,
     ])
+
+    useEffect(() => {
+        const scrollElement = scrollRef.current
+        const scrollContainerElement = scrollContainerRef.current
+        if (!scrollElement || !scrollContainerElement) return
+        const handler = () => {
+            handleScroll(scrollElement, scrollContainerElement)
+        }
+        const timeout = setTimeout(handler, 100)
+        scrollElement.addEventListener("scroll", handler, { passive: true })
+        return () => {
+            scrollElement.removeEventListener("scroll", handler)
+            clearTimeout(timeout)
+        }
+    })
 
     return panel
 }

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -1,6 +1,6 @@
 import type { FeatureCollection } from "geojson"
 import throttle from "lodash.throttle"
-import { Check, Info } from "lucide-react"
+import { Check, ChevronDown, ChevronUp, Info } from "lucide-react"
 import type { MapGeoJSONFeature, MapLibreZoomEvent } from "maplibre-gl"
 import { useCallback, useEffect, useRef, useState } from "react"
 import type { MapLayerMouseEvent as MapMouseEvent } from "react-map-gl/maplibre"
@@ -18,6 +18,7 @@ import {
     CardTitle,
 } from "~/components/ui/card"
 import { Spinner } from "~/components/ui/spinner"
+import { Separator } from "~/components/ui/separator"
 import { cn } from "~/lib/utils"
 
 export function FieldsPanelHover({
@@ -316,11 +317,9 @@ export function FieldsPanelSelection({
                         [],
                     )
 
-                    const pseudoElemClasses =
-                        "before:absolute before:h-16 before:left-0 before:right-0 before:from-card before:to-transparent before:opacity-0 before:transition-opacity before:duration-250 before:pointer-events-none"
                     setPanel(
                         <Card className="w-full flex-initial min-h-0 flex flex-col gap-4">
-                            <CardHeader>
+                            <CardHeader className="pb-0">
                                 <CardTitle>Percelen</CardTitle>
                                 <CardDescription>
                                     {fieldCountText}
@@ -328,8 +327,14 @@ export function FieldsPanelSelection({
                             </CardHeader>
                             <CardContent
                                 ref={scrollContainerRef}
-                                className={`p-0 relative flex-initial min-h-0 overflow-hidden flex items-stretch before:top-0 after:bottom-0 before:bg-linear-to-b after:bg-linear-to-t data-scroll-start:before:opacity-100 data-scroll-end:after:opacity-100 ${pseudoElemClasses} ${pseudoElemClasses.replaceAll("before:", "after:")}`}
+                                className="p-0 relative flex-initial min-h-0 overflow-hidden flex items-stretch group"
                             >
+                                {/* Top scroll indicator */}
+                                <div className="absolute top-0 left-0 right-0 z-10 flex flex-col items-center pointer-events-none opacity-0 transition-opacity duration-200 group-data-[scroll-start]:opacity-100">
+                                    <Separator />
+                                    <ChevronUp className="h-4 w-4 text-muted-foreground my-1" />
+                                </div>
+
                                 <div
                                     ref={scrollRef}
                                     className="overflow-y-auto"
@@ -366,6 +371,12 @@ export function FieldsPanelSelection({
                                             ),
                                         )}
                                     </div>
+                                </div>
+
+                                {/* Bottom scroll indicator */}
+                                <div className="absolute bottom-0 left-0 right-0 z-10 flex flex-col items-center pointer-events-none opacity-0 transition-opacity duration-200 group-data-[scroll-end]:opacity-100">
+                                    <ChevronDown className="h-4 w-4 text-muted-foreground my-1" />
+                                    <Separator />
                                 </div>
                             </CardContent>
                             <CardFooter>

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -132,6 +132,8 @@ export function FieldsPanelHover({
                             </Card>
                         )
                     }
+                } else {
+                    setPanel(null)
                 }
             }
         }
@@ -165,12 +167,11 @@ export function FieldsPanelHover({
             map.on("mousemove", throttledUpdatePanel)
             map.on("mousedown", delayedUpdatePanel)
             map.on("zoom", throttledUpdatePanel)
-            map.on("load", updatePanel)
+            map.once("load", updatePanel)
             return () => {
                 map.off("mousemove", throttledUpdatePanel)
                 map.off("mousedown", delayedUpdatePanel)
                 map.off("zoom", throttledUpdatePanel)
-                map.off("load", updatePanel)
 
                 // Cancel pending updates
                 clearTimeout(delayedUpdateTimeout)
@@ -217,7 +218,7 @@ export function FieldsPanelZoom({
             }
         }
 
-        const throttledUpdatePanel = throttle(updatePanel, 250, {
+        const throttledUpdatePanel = throttle(updatePanel, 200, {
             trailing: true,
         })
 

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -172,6 +172,7 @@ export function FieldsPanelHover({
                 map.off("mousemove", throttledUpdatePanel)
                 map.off("mousedown", delayedUpdatePanel)
                 map.off("zoom", throttledUpdatePanel)
+                map.off("load", updatePanel)
 
                 // Cancel pending updates
                 clearTimeout(delayedUpdateTimeout)
@@ -395,6 +396,7 @@ export function FieldsPanelSelection({
                             </CardContent>
                             <CardFooter>
                                 <Button
+                                    className="w-full"
                                     onClick={() => submitSelectedFields(fields)}
                                     disabled={isSubmitting}
                                 >

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -33,6 +33,16 @@ export function FieldsPanelHover({
 }) {
     const { current: map } = useMap()
     const [panel, setPanel] = useState<React.ReactNode | null>(null)
+    const layerIds = Array.isArray(layer) ? layer : [layer]
+    const excludedLayerIds = layerExclude
+        ? Array.isArray(layerExclude)
+            ? layerExclude
+            : [layerExclude]
+        : []
+    const layerIdsKey = layerIds.join("|")
+    const excludedLayerIdsKey = excludedLayerIds.join("|")
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: effective changes in layer and layerExclude are detected through layerIdsKey and excludedLayerIdsKey
     useEffect(() => {
         function updatePanel(evt: MapMouseEvent | MapLibreZoomEvent) {
             if (map) {
@@ -40,8 +50,11 @@ export function FieldsPanelHover({
                 const zoom = map.getZoom()
                 if (zoom && zoom > zoomLevelFields) {
                     if (!map.getStyle()) return
-                    const layers = Array.isArray(layer) ? layer : [layer]
-                    const validLayers = layers.filter((l) => map.getLayer(l))
+                    if (!("point" in evt)) {
+                        setPanel(makePanel({}))
+                        return
+                    }
+                    const validLayers = layerIds.filter((l) => map.getLayer(l))
                     if (validLayers.length === 0) return
                     const features = map.queryRenderedFeatures(evt.point, {
                         layers: validLayers,
@@ -54,10 +67,7 @@ export function FieldsPanelHover({
                     )
 
                     if (layerExclude) {
-                        const layers = Array.isArray(layerExclude)
-                            ? layerExclude
-                            : [layerExclude]
-                        const validLayers = layers.filter((l) =>
+                        const validLayers = excludedLayerIds.filter((l) =>
                             map.getLayer(l),
                         )
 
@@ -161,9 +171,19 @@ export function FieldsPanelHover({
                 map.off("mousedown", delayedUpdatePanel)
                 map.off("zoom", throttledUpdatePanel)
                 map.off("load", updatePanel)
+
+                // Cancel pending updates
+                clearTimeout(delayedUpdateTimeout)
+                throttledUpdatePanelInner.cancel()
             }
         }
-    }, [map, zoomLevelFields, layer, layerExclude, clickRedirectsToDetailsPage])
+    }, [
+        map,
+        zoomLevelFields,
+        layerIdsKey,
+        excludedLayerIdsKey,
+        clickRedirectsToDetailsPage,
+    ])
 
     return panel
 }

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -154,13 +154,11 @@ export function FieldsPanelHover({
         if (map) {
             map.on("mousemove", throttledUpdatePanel)
             map.on("mousedown", delayedUpdatePanel)
-            map.on("click", updatePanel)
             map.on("zoom", throttledUpdatePanel)
             map.on("load", updatePanel)
             return () => {
                 map.off("mousemove", throttledUpdatePanel)
                 map.off("mousedown", delayedUpdatePanel)
-                map.off("click", updatePanel)
                 map.off("zoom", throttledUpdatePanel)
                 map.off("load", updatePanel)
             }

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -85,16 +85,10 @@ export function FieldsPanelHover({
                         }
                     }
 
-                    if (
-                        features &&
-                        features.length > 0 &&
-                        features[0].properties
-                    ) {
+                    const top = features[0]
+                    if (top?.properties) {
                         setPanel(
-                            makePanel({
-                                layer: features[0].layer.id,
-                                feature: features[0],
-                            }),
+                            makePanel({ layer: top.layer.id, feature: top }),
                         )
                     } else {
                         setPanel(makePanel({}))
@@ -110,8 +104,8 @@ export function FieldsPanelHover({
                         const active = layer && feature
                         const name = feature
                             ? layer === "fieldsSaved"
-                                ? features[0].properties.b_name
-                                : features[0].properties.b_lu_name
+                                ? feature.properties.b_name
+                                : feature.properties.b_lu_name
                             : "Naam"
                         return (
                             <Card
@@ -279,26 +273,6 @@ export function FieldsPanelSelection({
         [fetcher],
     )
 
-    function handleScroll(
-        scrollElement: HTMLDivElement,
-        scrollContainerElement: HTMLDivElement,
-    ) {
-        if (scrollElement.scrollTop > 5) {
-            scrollContainerElement.dataset.scrollStart = ""
-        } else {
-            delete scrollContainerElement.dataset.scrollStart
-        }
-
-        if (
-            scrollElement.scrollHeight - scrollElement.scrollTop >
-            5 + scrollElement.offsetHeight
-        ) {
-            scrollContainerElement.dataset.scrollEnd = ""
-        } else {
-            delete scrollContainerElement.dataset.scrollEnd
-        }
-    }
-
     useEffect(() => {
         function updatePanel() {
             if (map) {
@@ -358,7 +332,7 @@ export function FieldsPanelSelection({
                             >
                                 <div
                                     ref={scrollRef}
-                                    className="overflow-y-scroll"
+                                    className="overflow-y-auto"
                                 >
                                     <div className="px-6 py-4 space-y-4">
                                         {cultivations.map(
@@ -464,20 +438,43 @@ export function FieldsPanelSelection({
         numFieldsSaved,
     ])
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies: refs will change when the panel changes
     useEffect(() => {
         const scrollElement = scrollRef.current
         const scrollContainerElement = scrollContainerRef.current
         if (!scrollElement || !scrollContainerElement) return
+
+        function handleScroll(
+            scrollElement: HTMLDivElement,
+            scrollContainerElement: HTMLDivElement,
+        ) {
+            if (scrollElement.scrollTop > 5) {
+                scrollContainerElement.dataset.scrollStart = ""
+            } else {
+                delete scrollContainerElement.dataset.scrollStart
+            }
+
+            if (
+                scrollElement.scrollHeight - scrollElement.scrollTop >
+                5 + scrollElement.offsetHeight
+            ) {
+                scrollContainerElement.dataset.scrollEnd = ""
+            } else {
+                delete scrollContainerElement.dataset.scrollEnd
+            }
+        }
+
         const handler = () => {
             handleScroll(scrollElement, scrollContainerElement)
         }
+
         const timeout = setTimeout(handler, 100)
         scrollElement.addEventListener("scroll", handler, { passive: true })
         return () => {
             scrollElement.removeEventListener("scroll", handler)
             clearTimeout(timeout)
         }
-    })
+    }, [panel])
 
     return panel
 }

--- a/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-panels.tsx
@@ -1,7 +1,7 @@
 import type { FeatureCollection } from "geojson"
 import throttle from "lodash.throttle"
 import { Check, Info } from "lucide-react"
-import type { MapLibreZoomEvent } from "maplibre-gl"
+import type { MapGeoJSONFeature, MapLibreZoomEvent } from "maplibre-gl"
 import { useCallback, useEffect, useState } from "react"
 import type { MapLayerMouseEvent as MapMouseEvent } from "react-map-gl/maplibre"
 import { useMap } from "react-map-gl/maplibre"
@@ -27,7 +27,7 @@ export function FieldsPanelHover({
     clickRedirectsToDetailsPage = false,
 }: {
     zoomLevelFields: number
-    layer: string
+    layer: string[] | string
     layerExclude?: string[] | string
     clickRedirectsToDetailsPage?: boolean
 }) {
@@ -39,11 +39,19 @@ export function FieldsPanelHover({
                 // Set message about zoom level
                 const zoom = map.getZoom()
                 if (zoom && zoom > zoomLevelFields) {
-                    if (!map.getStyle() || !map.getLayer(layer)) return
-
+                    if (!map.getStyle()) return
+                    const layers = Array.isArray(layer) ? layer : [layer]
+                    const validLayers = layers.filter((l) => map.getLayer(l))
+                    if (validLayers.length === 0) return
                     const features = map.queryRenderedFeatures(evt.point, {
-                        layers: [layer],
+                        layers: validLayers,
                     })
+                    // Layer, whose id is specified last in the layer prop, has the highest priority
+                    features.sort(
+                        (f1, f2) =>
+                            validLayers.indexOf(f2.layer.id) -
+                            validLayers.indexOf(f1.layer.id),
+                    )
 
                     if (layerExclude) {
                         const layers = Array.isArray(layerExclude)
@@ -61,7 +69,7 @@ export function FieldsPanelHover({
                                 },
                             )
                             if (featuresExclude && featuresExclude.length > 0) {
-                                setPanel(null)
+                                setPanel(makePanel({}))
                                 return
                             }
                         }
@@ -73,13 +81,34 @@ export function FieldsPanelHover({
                         features[0].properties
                     ) {
                         setPanel(
-                            <Card className={cn("w-full")}>
+                            makePanel({
+                                layer: features[0].layer.id,
+                                feature: features[0],
+                            }),
+                        )
+                    } else {
+                        setPanel(makePanel({}))
+                    }
+
+                    function makePanel({
+                        layer,
+                        feature,
+                    }: {
+                        layer?: string
+                        feature?: MapGeoJSONFeature
+                    }) {
+                        const active = layer && feature
+                        const name = feature
+                            ? layer === "fieldsSaved"
+                                ? features[0].properties.b_name
+                                : features[0].properties.b_lu_name
+                            : "Naam"
+                        return (
+                            <Card
+                                className={cn("w-full", !active && "invisible")}
+                            >
                                 <CardHeader>
-                                    <CardTitle>
-                                        {layer === "fieldsSaved"
-                                            ? features[0].properties.b_name
-                                            : features[0].properties.b_lu_name}
-                                    </CardTitle>
+                                    <CardTitle>{name}</CardTitle>
                                     <CardDescription>
                                         {layer === "fieldsSaved"
                                             ? `${features[0].properties.b_area} ha`
@@ -90,26 +119,47 @@ export function FieldsPanelHover({
                                                 : "Klik om te verwijderen"}
                                     </CardDescription>
                                 </CardHeader>
-                            </Card>,
+                            </Card>
                         )
-                    } else {
-                        setPanel(null)
                     }
                 }
             }
         }
 
-        const throttledUpdatePanel = throttle(updatePanel, 250, {
-            trailing: true,
-        })
+        // Throttle panel updates to not overwhelm React, the rendering thread etc.
+        const throttleInterval = 200
+        const throttledUpdatePanelInner = throttle(
+            updatePanel,
+            throttleInterval,
+            {
+                trailing: true,
+            },
+        )
+
+        // Delay handling of clicks so that if the field selection under the mouse changes we catch it
+        let delayedUpdateTimeout: ReturnType<typeof setTimeout>
+        const delayedUpdatePanel: typeof updatePanel = (e) => {
+            delayedUpdateTimeout = setTimeout(
+                () => throttledUpdatePanelInner(e),
+                throttleInterval,
+            )
+        }
+
+        // Cancels any timed out invocations and tries to invoke again
+        const throttledUpdatePanel: typeof updatePanel = (e) => {
+            clearTimeout(delayedUpdateTimeout)
+            throttledUpdatePanelInner(e)
+        }
 
         if (map) {
             map.on("mousemove", throttledUpdatePanel)
+            map.on("mousedown", delayedUpdatePanel)
             map.on("click", updatePanel)
             map.on("zoom", throttledUpdatePanel)
             map.on("load", updatePanel)
             return () => {
                 map.off("mousemove", throttledUpdatePanel)
+                map.off("mousedown", delayedUpdatePanel)
                 map.off("click", updatePanel)
                 map.off("zoom", throttledUpdatePanel)
                 map.off("load", updatePanel)
@@ -252,21 +302,21 @@ export function FieldsPanelSelection({
                     )
 
                     setPanel(
-                        <Card className={cn("w-full")}>
+                        <Card className="w-full flex-initial min-h-0 flex flex-col gap-4">
                             <CardHeader>
                                 <CardTitle>Percelen</CardTitle>
                                 <CardDescription>
                                     {fieldCountText}
                                 </CardDescription>
                             </CardHeader>
-                            <CardContent className="grid gap-4">
-                                <div>
+                            <CardContent className="flex-initial min-h-0 overflow-y-scroll">
+                                <div className="space-y-4">
                                     {cultivations.map((cultivation, _index) => (
                                         // let cultivationCountText = `${cultivation.count + 1} percelen`
 
                                         <div
                                             key={cultivation.b_lu_name}
-                                            className="mb-2 grid grid-cols-[25px_1fr] items-start pb-2 last:mb-0 last:pb-0"
+                                            className="grid grid-cols-[25px_1fr] items-start"
                                         >
                                             <span
                                                 className="flex h-2 w-2 translate-y-1 rounded-full"

--- a/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
+++ b/fdm-app/app/components/blocks/atlas/atlas-styles.tsx
@@ -29,6 +29,17 @@ function getFieldsStyleInner(layerId: string): LayerProps {
     }
 
     if (layerId === "fieldsSelected") {
+        // This layer should not be visible but still clickable
+        return {
+            type: "fill",
+            paint: {
+                "fill-color": "#000000",
+                "fill-opacity": 0,
+            },
+        }
+    }
+
+    if (layerId === "fieldsSelectedOutline") {
         return {
             type: "line",
             paint: {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields._index.tsx
@@ -235,16 +235,11 @@ export default function FarmAtlasFieldsBlock() {
                 </FieldsSourceNotClickable>
             )}
 
-            <div className="fields-panel grid gap-4 w-[350px]">
+            <div className="fields-panel">
                 <FieldsPanelHover
                     zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                    layer={fieldsAvailableId}
-                    layerExclude={id}
+                    layer={[fieldsAvailableId, id]}
                     clickRedirectsToDetailsPage={true}
-                />
-                <FieldsPanelHover
-                    zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                    layer={id}
                 />
             </div>
         </MapGL>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
@@ -236,6 +236,7 @@ export default function Index() {
     const calendar = loaderData.calendar
     const fieldsSavedStyle = getFieldsStyle(fieldsSavedId)
 
+    const fieldsSelectedOutlineStyle = getFieldsStyle("fieldsSelectedOutline")
     const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     // Set selected fields
@@ -306,7 +307,7 @@ export default function Index() {
                                 {...viewState} // Use viewState directly
                                 ref={mapRef}
                                 style={{
-                                    height: "calc(100vh - 64px - 123px)",
+                                    height: "calc(100vh - 64px - 123px - 24px)",
                                     width: "100%",
                                 }}
                                 interactive={true}
@@ -398,6 +399,12 @@ export default function Index() {
                                             layout: layerLayout,
                                         } as any)}
                                     />
+                                    <Layer
+                                        {...({
+                                            ...fieldsSelectedOutlineStyle,
+                                            layout: layerLayout,
+                                        } as any)}
+                                    />
                                 </FieldsSourceSelected>
 
                                 <FieldsSourceNotClickable
@@ -414,7 +421,7 @@ export default function Index() {
                                     />
                                 </FieldsSourceNotClickable>
 
-                                <div className="fields-panel grid gap-4 w-[350px]">
+                                <div className="fields-panel">
                                     <FieldsPanelSelection
                                         fields={selectedFieldsData}
                                         numFieldsSaved={
@@ -428,15 +435,11 @@ export default function Index() {
                                     />
                                     <FieldsPanelHover
                                         zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                                        layer={fieldsAvailableId}
-                                        layerExclude={[
+                                        layer={[
+                                            fieldsAvailableId,
                                             fieldsSelectedId,
-                                            fieldsSavedId,
                                         ]}
-                                    />
-                                    <FieldsPanelHover
-                                        zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                                        layer={fieldsSelectedId}
+                                        layerExclude={[fieldsSavedId]}
                                     />
                                 </div>
                             </MapGL>

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
@@ -221,6 +221,7 @@ export default function Index() {
     const fieldsSaved = loaderData.fieldsSaved
     const fieldsSavedStyle = getFieldsStyle(fieldsSavedId)
 
+    const fieldsSelectedOutlineStyle = getFieldsStyle("fieldsSelectedOutline")
     const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
 
     // Set selected fields
@@ -367,6 +368,12 @@ export default function Index() {
                                             layout: layerLayout,
                                         } as any)}
                                     />
+                                    <Layer
+                                        {...({
+                                            ...fieldsSelectedOutlineStyle,
+                                            layout: layerLayout,
+                                        } as any)}
+                                    />
                                 </FieldsSourceSelected>
 
                                 <FieldsSourceNotClickable
@@ -383,7 +390,7 @@ export default function Index() {
                                     />
                                 </FieldsSourceNotClickable>
 
-                                <div className="fields-panel grid gap-4 w-[350px]">
+                                <div className="fields-panel">
                                     <FieldsPanelSelection
                                         fields={selectedFieldsData}
                                         numFieldsSaved={
@@ -397,15 +404,11 @@ export default function Index() {
                                     />
                                     <FieldsPanelHover
                                         zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                                        layer={fieldsAvailableId}
-                                        layerExclude={[
+                                        layer={[
+                                            fieldsAvailableId,
                                             fieldsSelectedId,
-                                            fieldsSavedId,
                                         ]}
-                                    />
-                                    <FieldsPanelHover
-                                        zoomLevelFields={ZOOM_LEVEL_FIELDS}
-                                        layer={fieldsSelectedId}
+                                        layerExclude={[fieldsSavedId]}
                                     />
                                 </div>
                             </MapGL>

--- a/fdm-app/app/tailwind.css
+++ b/fdm-app/app/tailwind.css
@@ -165,13 +165,19 @@
 
 .fields-panel {
     position: absolute;
+    box-sizing: border-box;
     top: 0;
     left: 0;
-    /* max-width: 320px; */
+    max-height: 100%;
+    width: 320px;
     /* background: #fff; */
     /* box-shadow: 0 2px 4px rgba(0,0,0,0.3); */
-    padding: 12px 24px;
-    margin: 20px;
+    display: flex;
+    flex-direction: column;
+    margin-left: 44px;
+    padding-block: 32px;
+    gap: 16px;
+    /* margin: 20px; */
     /* font-size: 13px; */
     /* line-height: 2; */
     /* color: #6b6b76; */


### PR DESCRIPTION
**Bug fixes**

- The cultivation and field count list seen on field selection atlas pages now becomes scrollable when there are
 too many different cultivations to display, ensuring that the "Sla geselecteerde percelen op" button is always reachable.

**Enhancements**
- Now the clickable area around the atlas panels should be larger since some margin and padding is removed around it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Field selection atlas pages: cultivation and field count list is now scrollable so the "Sla geselecteerde percelen op" button stays reachable.
  * More reliable field hover and selection interactions, and clearer selected-field outline/visibility.

* **Style**
  * Updated field panel layout, sizing and spacing for improved readability and consistent placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->