### PR TITLE
Use server time zone for querying

### DIFF
--- a/.changeset/hot-frogs-listen.md
+++ b/.changeset/hot-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+fdm-app now converts the URL calendar parameter to a timeframe in the server's local time zone, ensuring that the same time zone is used both for saving and querying.

--- a/fdm-app/app/lib/calendar.ts
+++ b/fdm-app/app/lib/calendar.ts
@@ -20,8 +20,8 @@ export function getTimeframe(params: Params): Timeframe {
     // Current assumption is that the user and the server will both be in the same time zone (for the Netherlands: Amsterdam)
     // When retrieving 1 January and 31 December for the given year, the runtime will most of the time fill in the winter time zone (for Amsterdam: CET)
     const timeframe = {
-        start: new Date(`${yearStart}-01-01T00:00:00.000`),
-        end: new Date(`${yearEnd}-12-31T23:59:59.999`),
+        start: new Date(yearStart, 0, 1, 0, 0, 0, 0),
+        end: new Date(yearEnd, 11, 31, 23, 59, 59, 999),
     }
 
     // Check if calendar is year and create a timeframe
@@ -34,8 +34,8 @@ export function getTimeframe(params: Params): Timeframe {
                 throw new Error(`Unsupported year: ${calendar}`)
             }
             // Set start and end date
-            timeframe.start = new Date(`${year}-01-01T00:00:00.000`)
-            timeframe.end = new Date(`${year}-12-31T23:59:59.999`)
+            timeframe.start = new Date(year, 0, 1, 0, 0, 0, 0)
+            timeframe.end = new Date(year, 11, 31, 23, 59, 59, 999)
         }
     }
 

--- a/fdm-app/app/lib/calendar.ts
+++ b/fdm-app/app/lib/calendar.ts
@@ -16,9 +16,12 @@ export function getCalendar(params: Params): string {
 export function getTimeframe(params: Params): Timeframe {
     const calendar = getCalendar(params)
 
+    // Use the server time zone
+    // Current assumption is that the user and the server will both be in the same time zone (for the Netherlands: Amsterdam)
+    // When retrieving 1 January and 31 December for the given year, the runtime will most of the time fill in the winter time zone (for Amsterdam: CET)
     const timeframe = {
-        start: new Date(`${yearStart}-01-01T00:00:00.000Z`),
-        end: new Date(`${yearEnd}-12-31T23:59:59.999Z`),
+        start: new Date(`${yearStart}-01-01T00:00:00.000`),
+        end: new Date(`${yearEnd}-12-31T23:59:59.999`),
     }
 
     // Check if calendar is year and create a timeframe
@@ -31,8 +34,8 @@ export function getTimeframe(params: Params): Timeframe {
                 throw new Error(`Unsupported year: ${calendar}`)
             }
             // Set start and end date
-            timeframe.start = new Date(`${year}-01-01T00:00:00.000Z`)
-            timeframe.end = new Date(`${year}-12-31T23:59:59.999Z`)
+            timeframe.start = new Date(`${year}-01-01T00:00:00.000`)
+            timeframe.end = new Date(`${year}-12-31T23:59:59.999`)
         }
     }
 


### PR DESCRIPTION
** Enhancements **
- fdm-app now converts the URL calendar parameter to a timeframe in the server's local time zone, ensuring that the same time zone is used both for saving and querying.

Closes #549 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar URL parameter now consistently uses the server's local time zone when deriving timeframes, ensuring the same timezone is applied for both saved values and subsequent queries. This also stabilizes default and year-specific timeframe behavior so displayed and stored dates match expected local-day boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->