### PR TITLE
Make cache writes fire-and-forget in withCalculationCache

### DIFF
--- a/.changeset/giant-lands-return.md
+++ b/.changeset/giant-lands-return.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-core": patch
----
-
-Fixed a performance issue where parallel calculator cache INSERT queries caused PostgreSQL lock contention, leading to nitrogen balance page timeouts (~90s requests). Cache writes (`setCachedCalculation`) and error logging (`setCalculationError`) in `withCalculationCache` are now fire-and-forget, eliminating the INSERT bottleneck while still persisting results asynchronously.

--- a/.changeset/giant-lands-return.md
+++ b/.changeset/giant-lands-return.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-core": patch
+---
+
+Fixed a performance issue where parallel calculator cache INSERT queries caused PostgreSQL lock contention, leading to nitrogen balance page timeouts (~90s requests). Cache writes (`setCachedCalculation`) and error logging (`setCalculationError`) in `withCalculationCache` are now fire-and-forget, eliminating the INSERT bottleneck while still persisting results asynchronously.

--- a/fdm-core/CHANGELOG.md
+++ b/fdm-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-core
 
+## 0.31.2
+
+### Patch Changes
+
+- [#583](https://github.com/nmi-agro/fdm/pull/583) [`8aa9fb4`](https://github.com/nmi-agro/fdm/commit/8aa9fb405136da1d7c7b2928be8c14112c7c3a07) Thanks [@SvenVw](https://github.com/SvenVw)! - Fixed a performance issue where parallel calculator cache INSERT queries caused PostgreSQL lock contention, leading to nitrogen balance page timeouts (~90s requests). Cache writes (`setCachedCalculation`) and error logging (`setCalculationError`) in `withCalculationCache` are now fire-and-forget, eliminating the INSERT bottleneck while still persisting results asynchronously.
+
 ## 0.31.1
 
 ### Patch Changes

--- a/fdm-core/package.json
+++ b/fdm-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-core",
     "private": false,
-    "version": "0.31.1",
+    "version": "0.31.2",
     "description": "Interface for the Farm Data Model",
     "license": "MIT",
     "homepage": "https://svenvw.github.io/fdm/",

--- a/fdm-core/src/calculator.ts
+++ b/fdm-core/src/calculator.ts
@@ -255,52 +255,40 @@ export function withCalculationCache<T_Input extends object, T_Output>(
             const result = await calculationFunction(input)
 
             // If the initial cache read was successful (meaning the cache is healthy),
-            // then attempt to store the new calculation result in the cache.
+            // then store the new calculation result in the cache.
+            // Fire-and-forget: don't await the cache write to avoid blocking the response
+            // when many parallel calculations complete simultaneously (lock contention).
             if (cacheResultOfCalculation) {
-                try {
-                    await setCachedCalculation(
-                        fdm,
-                        calculationHash,
-                        calculationFunctionName,
-                        calculatorVersion,
-                        inputForCache,
-                        result,
-                    )
-                } catch (e: unknown) {
+                setCachedCalculation(
+                    fdm,
+                    calculationHash,
+                    calculationFunctionName,
+                    calculatorVersion,
+                    inputForCache,
+                    result,
+                ).catch((e: unknown) => {
                     const errorMessage =
                         e instanceof Error ? e.message : String(e)
                     console.error(
                         `Failed to write to calculation cache for ${calculationFunctionName} (hash: ${calculationHash}): ${errorMessage}`,
                     )
-                    // Continue execution - the calculation succeeded, only caching failed
-                }
-                // console.log(
-                //     `Calculation for ${calculationFunctionName} (hash: ${calculationHash}) completed and cached.`,
-                // )
-            } else {
-                // If cache read failed, log that the result is not being cached.
-                // console.log(
-                //     `Calculation for ${calculationFunctionName} (hash: ${calculationHash}) completed and not cached due to prior cache read failure.`,
-                // )
+                })
             }
 
             return result
         } catch (e: unknown) {
-            // If the calculation itself fails, record the error in the database
-            // and re-throw it to propagate the failure to the caller.
+            // Record the error in the database (fire-and-forget to avoid blocking error propagation).
             const errorMessage = e instanceof Error ? e.message : String(e)
             const stackTrace = e instanceof Error ? e.stack : undefined
 
-            try {
-                await setCalculationError(
-                    fdm,
-                    calculationFunctionName,
-                    calculatorVersion,
-                    inputForCache,
-                    errorMessage,
-                    stackTrace,
-                )
-            } catch (loggingError: unknown) {
+            setCalculationError(
+                fdm,
+                calculationFunctionName,
+                calculatorVersion,
+                inputForCache,
+                errorMessage,
+                stackTrace,
+            ).catch((loggingError: unknown) => {
                 const loggingErrorMessage =
                     loggingError instanceof Error
                         ? loggingError.message
@@ -308,8 +296,7 @@ export function withCalculationCache<T_Input extends object, T_Output>(
                 console.error(
                     `Failed to log calculation error for ${calculationFunctionName}: ${loggingErrorMessage}`,
                 )
-                // Continue to re-throw the original calculation error
-            }
+            })
 
             throw e
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance on nitrogen balance page by optimizing cache write and error logging operations, resolving timeout issues on long-running requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #582 