### PR TITLE
Make productive filter work on rotation tables

### DIFF
--- a/.changeset/ninety-pets-jog.md
+++ b/.changeset/ninety-pets-jog.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+The show-productive-only button on rotation tables works again. The search terms and the show-productive-only selection are now shared between field and rotation tables, and this is shown to the user properly.

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -32,16 +32,11 @@ export type CropRow = {
     b_lu_catalogue: string
     b_lu: string[]
     b_lu_name: string
-    m_cropresidue: "all" | "some" | "none"
     b_lu_eom_residue: number | null
-    b_lu_variety: Record<string, number>
     b_lu_variety_options: { label: string; value: string }[] | null
     b_lu_croprotation: string
     b_lu_harvestable: "once" | "multiple" | "none"
     calendar: string
-    b_lu_start: Date[]
-    b_lu_end: Date[]
-    b_bufferstrip: boolean
     fields: FieldRow[]
 }
 
@@ -57,7 +52,7 @@ export type FieldRow = {
     m_cropresidue: "all" | "some" | "none"
     b_lu_eom_residue: number | null
     m_cropresidue_ending: [Date, boolean][]
-    b_lu_variety: Record<string, number>
+    b_lu_variety: [string, number][]
     b_lu_catalogue: string
     b_lu_croprotation: string
     harvests: {
@@ -164,19 +159,26 @@ export const columns: ColumnDef<RotationExtended>[] = [
             return <DataTableColumnHeader column={column} title="Zaaidatum" />
         },
         enableHiding: true, // Enable hiding for mobile
-        cell: ({ cell, row }) =>
-            !row.original.canModify ? (
-                <DateRangeDisplay
-                    range={row.original.b_lu_start}
-                    emptyContent="Geen"
-                />
+        cell: ({ cell, row }) => {
+            const dates =
+                row.original.type === "field"
+                    ? row.original.b_lu_start
+                    : (row.subRows ?? [])
+                          .flatMap(
+                              (fieldRow) =>
+                                  (fieldRow.original as FieldRow).b_lu_start,
+                          )
+                          .sort((d1, d2) => d1.getTime() - d2.getTime())
+            return !row.original.canModify ? (
+                <DateRangeDisplay range={dates} emptyContent="Geen" />
             ) : (
                 <TableDateSelector
                     name="b_lu_start"
                     row={row}
                     cellId={cell.id}
                 />
-            ),
+            )
+        },
     },
     {
         accessorKey: "b_lu_end",
@@ -187,13 +189,17 @@ export const columns: ColumnDef<RotationExtended>[] = [
         },
         enableHiding: true, // Enable hiding for mobile
         cell: ({ cell, row }) => {
+            const dates =
+                row.original.type === "field"
+                    ? row.original.b_lu_end
+                    : (row.subRows ?? [])
+                          .flatMap(
+                              (fieldRow) =>
+                                  (fieldRow.original as FieldRow).b_lu_end,
+                          )
+                          .sort((d1, d2) => d1.getTime() - d2.getTime())
             if (!row.original.canModify) {
-                return (
-                    <DateRangeDisplay
-                        range={row.original.b_lu_end}
-                        emptyContent="Geen"
-                    />
-                )
+                return <DateRangeDisplay range={dates} emptyContent="Geen" />
             }
             const cultivation = (row.getParentRow() ?? row).original as CropRow
             const tooltipMessageNumHarvests =
@@ -211,7 +217,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
                     <Tooltip>
                         <TooltipTrigger>
                             <DateRangeDisplay
-                                range={row.original.b_lu_end}
+                                range={dates}
                                 emptyContent="Geen"
                             />
                         </TooltipTrigger>
@@ -237,8 +243,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
         },
         enableHiding: true, // Enable hiding for mobile
         cell: ({ row }) => {
-            const cultivation = row.original
-            return <HarvestDatesDisplay row={cultivation} />
+            return <HarvestDatesDisplay row={row} />
         },
     },
     {
@@ -279,8 +284,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
             )
         },
         cell: ({ row }) => {
-            const cultivation = row.original
-            return <FertilizerDisplay cultivation={cultivation} />
+            return <FertilizerDisplay row={row} />
         },
     },
     {
@@ -370,21 +374,21 @@ export const columns: ColumnDef<RotationExtended>[] = [
         },
         enableHiding: true, // Enable hiding for mobile
         cell: ({ row }) => {
-            const cultivation = row.original
-
-            const provided_b_area =
-                cultivation.type === "field" ? cultivation.b_area : null
             const formattedArea = React.useMemo(() => {
+                // There will always be some field rows below the crop row
+                // Otherwise, the crop row wouldn't be displayed altogether
                 const b_area =
-                    cultivation.type === "field"
-                        ? (provided_b_area ?? 0)
-                        : cultivation.fields.reduce(
-                              (acc, field) => acc + field.b_area,
+                    row.original.type === "field"
+                        ? (row.original.b_area ?? 0)
+                        : (row.subRows ?? []).reduce(
+                              (total, fieldRow) =>
+                                  total +
+                                  (fieldRow.original as FieldRow).b_area,
                               0,
                           )
 
                 return b_area < 0.1 ? "< 0.1 ha" : `${b_area.toFixed(1)} ha`
-            }, [cultivation.type, provided_b_area, cultivation.fields])
+            }, [row.original, row.subRows])
 
             return <p className="text-muted-foreground">{formattedArea}</p>
         },

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -299,7 +299,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
             const cultivation = row.original
 
             const fieldsDisplay = React.useMemo(() => {
-                if (row.original.type === "field") return null
+                if (cultivation.type === "field") return null
                 const fieldsSorted = (row.subRows ?? [])
                     .map((row) => row.original as FieldRow)
                     .sort((a, b) => a.b_name.localeCompare(b.b_name))
@@ -340,12 +340,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
                         </DropdownMenu>
                     )
                 )
-            }, [
-                cultivation.type,
-                cultivation.calendar,
-                row.original.type,
-                row.subRows,
-            ])
+            }, [cultivation.type, cultivation.calendar, row.subRows])
 
             return fieldsDisplay
         },

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -299,9 +299,10 @@ export const columns: ColumnDef<RotationExtended>[] = [
             const cultivation = row.original
 
             const fieldsDisplay = React.useMemo(() => {
-                const fieldsSorted = [...(cultivation.fields ?? [])].sort(
-                    (a, b) => a.b_name.localeCompare(b.b_name),
-                )
+                if (row.original.type === "field") return null
+                const fieldsSorted = (row.subRows ?? [])
+                    .map((row) => row.original as FieldRow)
+                    .sort((a, b) => a.b_name.localeCompare(b.b_name))
                 return (
                     cultivation.type === "crop" && (
                         <DropdownMenu>
@@ -339,7 +340,12 @@ export const columns: ColumnDef<RotationExtended>[] = [
                         </DropdownMenu>
                     )
                 )
-            }, [cultivation.type, cultivation.calendar, cultivation.fields])
+            }, [
+                cultivation.type,
+                cultivation.calendar,
+                row.original.type,
+                row.subRows,
+            ])
 
             return fieldsDisplay
         },

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -176,6 +176,7 @@ export const columns: ColumnDef<RotationExtended>[] = [
                     name="b_lu_start"
                     row={row}
                     cellId={cell.id}
+                    required={true}
                 />
             )
         },
@@ -231,7 +232,12 @@ export const columns: ColumnDef<RotationExtended>[] = [
                     </Tooltip>
                 </span>
             ) : (
-                <TableDateSelector name="b_lu_end" row={row} cellId={cell.id} />
+                <TableDateSelector
+                    name="b_lu_end"
+                    row={row}
+                    cellId={cell.id}
+                    required={false}
+                />
             )
         },
     },

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -58,6 +58,7 @@ export type FieldRow = {
     b_lu_eom_residue: number | null
     m_cropresidue_ending: [Date, boolean][]
     b_lu_variety: Record<string, number>
+    b_lu_catalogue: string
     b_lu_croprotation: string
     harvests: {
         b_lu: string

--- a/fdm-app/app/components/blocks/rotation/columns.tsx
+++ b/fdm-app/app/components/blocks/rotation/columns.tsx
@@ -207,10 +207,12 @@ export const columns: ColumnDef<RotationExtended>[] = [
                 cultivation.b_lu_harvestable === "multiple"
                     ? 0
                     : (row.original.type === "crop"
-                          ? row.original.fields
-                          : [row.original]
+                          ? (row.subRows ?? [])
+                          : [row]
                       ).reduce(
-                          (sum, fieldRow) => sum + fieldRow.harvests.length,
+                          (sum, fieldRow) =>
+                              sum +
+                              (fieldRow.original as FieldRow).harvests.length,
                           0,
                       )
             return cultivation.b_lu_harvestable !== "multiple" ? (

--- a/fdm-app/app/components/blocks/rotation/crop-residue-checkbox.tsx
+++ b/fdm-app/app/components/blocks/rotation/crop-residue-checkbox.tsx
@@ -2,7 +2,7 @@ import type { CellContext } from "@tanstack/react-table"
 import { useFetcher } from "react-router"
 import { Checkbox } from "~/components/ui/checkbox"
 import { Spinner } from "~/components/ui/spinner"
-import type { CropRow, RotationExtended } from "./columns"
+import type { CropRow, FieldRow, RotationExtended } from "./columns"
 
 export function CropResidueCheckbox({
     cell,
@@ -10,10 +10,15 @@ export function CropResidueCheckbox({
 }: CellContext<RotationExtended, unknown>) {
     const fetcher = useFetcher()
 
+    const fields =
+        row.original.type === "crop"
+            ? (row.subRows ?? []).map(
+                  (fieldRow) => fieldRow.original as FieldRow,
+              )
+            : [row.original]
+
     const submit = (value: boolean) => {
-        const fieldIds = (
-            row.original.type === "crop" ? row.original.fields : [row.original]
-        )
+        const fieldIds = fields
             .map((field) => encodeURIComponent(field.b_id))
             .join(",")
         const cultivationIds = encodeURIComponent(
@@ -33,13 +38,19 @@ export function CropResidueCheckbox({
 
     const inputId = `${cell.id}_checkbox`
 
+    const m_cropresidue = fields.every((field) => field.m_cropresidue === "all")
+        ? "all"
+        : fields.every((field) => field.m_cropresidue === "none")
+          ? "none"
+          : "some"
+
     const checkedState = (
         {
             all: true,
             some: "indeterminate",
             none: false,
         } as const
-    )[row.original.m_cropresidue]
+    )[m_cropresidue]
 
     return fetcher.state !== "idle" ? (
         <Spinner />
@@ -63,7 +74,7 @@ export function CropResidueCheckbox({
                             some: "Gedeeltelijk",
                             none: "Nee",
                         } as const
-                    )[row.original.m_cropresidue]
+                    )[m_cropresidue]
                 }
             </label>
         </div>

--- a/fdm-app/app/components/blocks/rotation/date-selector.tsx
+++ b/fdm-app/app/components/blocks/rotation/date-selector.tsx
@@ -20,12 +20,14 @@ function TableDateSelectorForm({
     name,
     value,
     row,
+    required,
     onHide,
 }: {
     fetcher: ReturnType<typeof useFetcher>
     name: keyof AllowedFormSchemaType
     value: Date[]
     row: Row<RotationExtended>
+    required?: boolean
     onHide?: () => unknown
 }) {
     const form = useForm({
@@ -42,11 +44,15 @@ function TableDateSelectorForm({
                     render={({ field, fieldState }) => (
                         <DatePicker
                             label={undefined}
+                            required={required}
                             field={{
                                 ...field,
                                 onChange: (value) => {
                                     const formValues = form.getValues()
-                                    if (formValues[name as string] !== value) {
+                                    const shouldSubmit =
+                                        row.original.type === "crop" ||
+                                        formValues[name] !== value
+                                    if (shouldSubmit) {
                                         const fieldIds = encodeURIComponent(
                                             row.original.type === "field"
                                                 ? row.original.b_id
@@ -99,10 +105,12 @@ export function TableDateSelector({
     name,
     row,
     cellId,
+    required,
 }: {
     name: keyof AllowedFormSchemaType
     row: Row<RotationExtended>
     cellId: string
+    required: boolean
 }) {
     const fetcher = useFetcher()
     const activeTableFormStore = useActiveTableFormStore()
@@ -135,6 +143,7 @@ export function TableDateSelector({
                     name={name}
                     value={value}
                     row={row}
+                    required={required}
                     onHide={() => {
                         const currentState = useActiveTableFormStore.getState()
                         if (currentState.activeForm === cellId)

--- a/fdm-app/app/components/blocks/rotation/date-selector.tsx
+++ b/fdm-app/app/components/blocks/rotation/date-selector.tsx
@@ -7,7 +7,7 @@ import { useActiveTableFormStore } from "@/app/store/active-table-form"
 import { Button } from "~/components/ui/button"
 import { Spinner } from "~/components/ui/spinner"
 import { DatePicker } from "../../custom/date-picker-v2"
-import type { CropRow, RotationExtended } from "./columns"
+import type { CropRow, FieldRow, RotationExtended } from "./columns"
 import { DateRangeDisplay } from "./date-range-display"
 import type { RotationTableFormSchemaType } from "./schema"
 
@@ -18,15 +18,16 @@ type AllowedFormSchemaType = Pick<
 function TableDateSelectorForm({
     fetcher,
     name,
+    value,
     row,
     onHide,
 }: {
     fetcher: ReturnType<typeof useFetcher>
     name: keyof AllowedFormSchemaType
+    value: Date[]
     row: Row<RotationExtended>
     onHide?: () => unknown
 }) {
-    const value = row.original[name]
     const form = useForm({
         defaultValues: {
             [name]: value?.length ? value[0].toISOString() : undefined,
@@ -46,15 +47,18 @@ function TableDateSelectorForm({
                                 onChange: (value) => {
                                     const formValues = form.getValues()
                                     if (formValues[name as string] !== value) {
-                                        const fieldIds = (
-                                            row.original.type === "crop"
-                                                ? row.original.fields
-                                                : [row.original]
+                                        const fieldIds = encodeURIComponent(
+                                            row.original.type === "field"
+                                                ? row.original.b_id
+                                                : (row.subRows ?? [])
+                                                      .map(
+                                                          (fieldRow) =>
+                                                              (
+                                                                  fieldRow.original as FieldRow
+                                                              ).b_id,
+                                                      )
+                                                      .join(","),
                                         )
-                                            .map((field) =>
-                                                encodeURIComponent(field.b_id),
-                                            )
-                                            .join(",")
                                         const cultivationIds =
                                             encodeURIComponent(
                                                 (
@@ -102,7 +106,12 @@ export function TableDateSelector({
 }) {
     const fetcher = useFetcher()
     const activeTableFormStore = useActiveTableFormStore()
-    const value = row.original[name]
+    const value =
+        row.original.type === "field"
+            ? row.original[name]
+            : (row.subRows ?? [])
+                  .flatMap((fieldRow) => (fieldRow.original as FieldRow)[name])
+                  .sort((d1, d2) => d1.getTime() - d2.getTime())
 
     const showForm =
         fetcher.state !== "idle" || activeTableFormStore.activeForm === cellId
@@ -124,6 +133,7 @@ export function TableDateSelector({
                 <TableDateSelectorForm
                     fetcher={fetcher}
                     name={name}
+                    value={value}
                     row={row}
                     onHide={() => {
                         const currentState = useActiveTableFormStore.getState()

--- a/fdm-app/app/components/blocks/rotation/fertilizer-display.tsx
+++ b/fdm-app/app/components/blocks/rotation/fertilizer-display.tsx
@@ -62,7 +62,9 @@ export const FertilizerDisplay: React.FC<FertilizerDisplayProps> = ({
         const fieldIds =
             row.original.type === "field"
                 ? [row.original.b_id]
-                : row.original.fields.map((field) => field.b_id)
+                : row.subRows.map(
+                      (fieldRow) => (fieldRow.original as FieldRow).b_id,
+                  )
         return (
             <div className="flex items-start flex-col space-y-2">
                 {uniqueFertilizers.map((fertilizer) => {

--- a/fdm-app/app/components/blocks/rotation/fertilizer-display.tsx
+++ b/fdm-app/app/components/blocks/rotation/fertilizer-display.tsx
@@ -1,3 +1,4 @@
+import type { Row } from "@tanstack/react-table"
 import { Circle, Diamond, Square, Triangle } from "lucide-react"
 import React from "react"
 import { NavLink } from "react-router"
@@ -10,7 +11,7 @@ import {
 import type { FieldRow, RotationExtended } from "./columns"
 
 type FertilizerDisplayProps = {
-    cultivation: RotationExtended
+    row: Row<RotationExtended>
 }
 
 const fertilizerIconClassMap = {
@@ -45,31 +46,30 @@ const fertilizerIconClassMap = {
 } as const
 
 export const FertilizerDisplay: React.FC<FertilizerDisplayProps> = ({
-    cultivation,
+    row,
 }) => {
-    const resolvedFertilizers =
-        cultivation.type === "field" ? cultivation.fertilizers : null
-    const uniqueFertilizers = React.useMemo(() => {
-        const fields = cultivation.fields
-        const fertilizers =
-            resolvedFertilizers ??
-            (fields as FieldRow[]).flatMap((field) => field.fertilizers)
-        return Array.from(new Map(fertilizers.map((f) => [f.p_id, f])).values())
-    }, [resolvedFertilizers, cultivation.fields])
-
     const fertilizerDisplay = React.useMemo(() => {
-        const fields = cultivation.fields
+        const fields =
+            row.original.type === "field"
+                ? [row.original]
+                : (row.subRows ?? []).map(
+                      (fieldRow) => fieldRow.original as FieldRow,
+                  )
+        const fertilizers = fields.flatMap((field) => field.fertilizers)
+        const uniqueFertilizers = Array.from(
+            new Map(fertilizers.map((f) => [f.p_id, f])).values(),
+        )
         const fieldIds =
-            cultivation.type === "field"
-                ? [cultivation.b_id]
-                : cultivation.fields.map((field) => field.b_id)
+            row.original.type === "field"
+                ? [row.original.b_id]
+                : row.original.fields.map((field) => field.b_id)
         return (
             <div className="flex items-start flex-col space-y-2">
                 {uniqueFertilizers.map((fertilizer) => {
                     const isFertilizerUsedOnAllFieldsForThisCultivation =
-                        cultivation.type === "field" ||
-                        (fields as FieldRow[]).every((field) =>
-                            field.fertilizers.some(
+                        row.original.type === "field" ||
+                        (row.subRows as Row<FieldRow>[]).every((fieldRow) =>
+                            fieldRow.original.fertilizers.some(
                                 (f) => f.p_id === fertilizer.p_id,
                             ),
                         )
@@ -111,7 +111,7 @@ export const FertilizerDisplay: React.FC<FertilizerDisplayProps> = ({
                         </NavLink>
                     )
 
-                    return cultivation.type === "field" ? (
+                    return row.original.type === "field" ? (
                         component
                     ) : (
                         <Tooltip key={fertilizer.p_id}>
@@ -126,12 +126,7 @@ export const FertilizerDisplay: React.FC<FertilizerDisplayProps> = ({
                 })}
             </div>
         )
-    }, [
-        uniqueFertilizers,
-        (cultivation as FieldRow).b_id,
-        cultivation.type,
-        cultivation.fields,
-    ])
+    }, [row.original, row.subRows])
 
     return fertilizerDisplay
 }

--- a/fdm-app/app/components/blocks/rotation/harvest-dates-display.tsx
+++ b/fdm-app/app/components/blocks/rotation/harvest-dates-display.tsx
@@ -1,3 +1,4 @@
+import type { Row } from "@tanstack/react-table"
 import { format } from "date-fns"
 import { nl } from "date-fns/locale/nl"
 import React from "react"
@@ -7,7 +8,7 @@ import { Button } from "~/components/ui/button"
 import type { FieldRow, RotationExtended } from "./columns"
 
 type HarvestDatesDisplayProps = {
-    row: RotationExtended
+    row: Row<RotationExtended>
 }
 
 type HarvestRecordItem = {
@@ -23,9 +24,7 @@ function compareDates(a: Date | null, b: Date | null) {
     return a && b ? a.getTime() - b.getTime() : !a && !b ? 0 : !a ? 1 : -1
 }
 
-function groupAndOrderHarvests(row: RotationExtended) {
-    const fields = row.type === "field" ? [row] : row.fields
-
+function groupAndOrderHarvests(fields: FieldRow[]) {
     const grouped: FieldRow["harvests"][] = []
 
     for (const field of fields) {
@@ -117,7 +116,11 @@ export const HarvestDatesDisplay: React.FC<HarvestDatesDisplayProps> = ({
     row,
 }) => {
     const formattedHarvestDates = React.useMemo(() => {
-        const harvestsByOrder = groupAndOrderHarvests(row)
+        const harvestsByOrder = groupAndOrderHarvests(
+            row.original.type === "field"
+                ? [row.original]
+                : row.subRows.map((fieldRow) => fieldRow.original as FieldRow),
+        )
 
         if (harvestsByOrder.length === 1) {
             return (
@@ -128,7 +131,7 @@ export const HarvestDatesDisplay: React.FC<HarvestDatesDisplayProps> = ({
         }
 
         if (harvestsByOrder.length > 1) {
-            if (row.b_lu_harvestable === "once") {
+            if (row.original.b_lu_harvestable === "once") {
                 const combined = combineRecords(harvestsByOrder)
                 return (
                     <HarvestDatesDisplayButton record={combined}>
@@ -145,7 +148,7 @@ export const HarvestDatesDisplay: React.FC<HarvestDatesDisplayProps> = ({
                                 key={record.id}
                                 record={record}
                             >
-                                {`${idx + 1}e ${row.b_lu_croprotation === "grass" ? "snede" : "oogst"}:`}
+                                {`${idx + 1}e ${row.original.b_lu_croprotation === "grass" ? "snede" : "oogst"}:`}
                                 <br />
                                 {formatDateRange(record.dates)}
                             </HarvestDatesDisplayButton>
@@ -155,7 +158,7 @@ export const HarvestDatesDisplay: React.FC<HarvestDatesDisplayProps> = ({
             )
         }
         return null // Should not happen
-    }, [row, row.type, row.fields, row.b_lu_harvestable, row.b_lu_croprotation])
+    }, [row.original, row.subRows])
 
     return formattedHarvestDates
 }

--- a/fdm-app/app/components/blocks/rotation/table.tsx
+++ b/fdm-app/app/components/blocks/rotation/table.tsx
@@ -23,7 +23,7 @@ import { NavLink, useLocation, useParams } from "react-router-dom"
 import { toast as notify } from "sonner"
 import { modifySearchParams } from "@/app/lib/url-utils"
 import { useActiveTableFormStore } from "@/app/store/active-table-form"
-import { useRotationFilterStore } from "@/app/store/field-filter"
+import { useFieldFilterStore } from "@/app/store/field-filter"
 import { useRotationSelectionStore } from "@/app/store/rotation-selection"
 import { Button } from "~/components/ui/button"
 import {
@@ -65,7 +65,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
 }: DataTableProps<TData, TValue>) {
     const [sorting, setSorting] = useState<SortingState>([])
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-    const fieldFilter = useRotationFilterStore()
+    const fieldFilter = useFieldFilterStore()
     const isMobile = useIsMobile()
     const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
         isMobile
@@ -255,9 +255,12 @@ export function DataTable<TData extends RotationExtended, TValue>({
                 crop.fields.every(
                     (field) =>
                         !fuzzySearchAndProductivityFilter(
-                            { original: field } as unknown as Row<TData>,
-                            null,
+                            {
+                                original: field,
+                            } as unknown as Row<MemoizedTData>,
+                            "",
                             fieldFilter,
+                            () => {},
                         ) || selection[crop.b_lu_catalogue]?.[field.b_id],
                 ),
             ]),

--- a/fdm-app/app/components/blocks/rotation/table.tsx
+++ b/fdm-app/app/components/blocks/rotation/table.tsx
@@ -374,6 +374,23 @@ export function DataTable<TData extends RotationExtended, TValue>({
                 searchParams.set("create", "")
         })
     }
+
+    function isFirstFieldRowForACrop(
+        flatRows: Row<MemoizedTData>[],
+        i: number,
+    ) {
+        if (flatRows[i].original.type !== "field") return false
+        return i === 0 || flatRows[i - 1].original.type === "crop"
+    }
+
+    function isLastFieldRowForACrop(flatRows: Row<MemoizedTData>[], i: number) {
+        if (flatRows[i].original.type !== "field") return false
+        return (
+            i + 1 === flatRows.length ||
+            flatRows[i + 1].original.type === "crop"
+        )
+    }
+
     return (
         <div className="w-full flex flex-col h-full min-w-0">
             <div className="sticky top-0 z-5 bg-background py-4 flex flex-col sm:flex-row gap-2 items-center">
@@ -541,7 +558,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
                     </TableHeader>
                     <TableBody>
                         {table.getRowModel().rows?.length ? (
-                            table.getRowModel().rows.map((row) => (
+                            table.getRowModel().rows.map((row, i, flatRows) => (
                                 <TableRow
                                     key={row.id}
                                     onClick={(event) =>
@@ -560,11 +577,15 @@ export function DataTable<TData extends RotationExtended, TValue>({
                                             (row.getParentRow()?.subRows
                                                 .length === 1
                                                 ? "shadow-[inset_0_1em_2em_-2em_#00000088,inset_0_-1em_2em_-2em_#00000088]"
-                                                : row.index === 0
+                                                : isFirstFieldRowForACrop(
+                                                        flatRows,
+                                                        i,
+                                                    )
                                                   ? "shadow-[inset_0_1em_2em_-2em_#00000088]"
-                                                  : row.index + 1 ===
-                                                        row.getParentRow()
-                                                            ?.subRows.length &&
+                                                  : isLastFieldRowForACrop(
+                                                        flatRows,
+                                                        i,
+                                                    ) &&
                                                     "shadow-[inset_0_-1em_2em_-2em_#00000088]"),
                                     )}
                                 >

--- a/fdm-app/app/components/blocks/rotation/table.tsx
+++ b/fdm-app/app/components/blocks/rotation/table.tsx
@@ -1,7 +1,6 @@
 import {
     type ColumnDef,
     type ColumnFiltersState,
-    type FilterFn,
     flexRender,
     getCoreRowModel,
     getExpandedRowModel,
@@ -110,7 +109,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
             table
                 .getFilteredRowModel()
                 .rows.map((row) => [
-                    (row.original as CropRow).b_lu_catalogue,
+                    row.original.b_lu_catalogue,
                     Object.fromEntries(
                         row.subRows.map((fieldRow) => [
                             (fieldRow.original as FieldRow).b_id,
@@ -123,7 +122,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
     }
 
     const handleRowClick = (
-        row: Row<TData>,
+        row: Row<MemoizedTData>,
         event: React.MouseEvent<HTMLTableRowElement>,
     ) => {
         // Ignore clicks on interactive elements inside the row
@@ -183,8 +182,8 @@ export function DataTable<TData extends RotationExtended, TValue>({
     }
 
     const memoizedData = useMemo(() => {
-        return data.map((item) => {
-            const commonTerms = (item as CropRow).b_lu_name
+        return (data as CropRow[]).map((item) => {
+            const commonTerms = item.b_lu_name
             const crop_b_lu_start = new Set<string>()
             const crop_b_lu_end = new Set<string>()
             const crop_b_lu_harvest_date = new Set<string>()
@@ -194,7 +193,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
             const dateTermsArr = (dates: Date[]) =>
                 [...new Set(dates.map(formatDate))].join(" ")
 
-            const fields = (item as CropRow).fields.map((field) => {
+            const fields = item.fields.map((field) => {
                 field.b_lu_start.forEach((v) => {
                     crop_b_lu_start.add(formatDate(v))
                 })
@@ -210,7 +209,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
 
                 return {
                     ...field,
-                    b_lu_catalogue: (item as CropRow).b_lu_catalogue,
+                    b_lu_catalogue: item.b_lu_catalogue,
                     searchTarget: `${field.b_name} ${commonTerms} ${dateTermsArr(field.b_lu_start)} ${dateTermsArr(field.b_lu_end)} ${dateTermsArr(field.harvests.flatMap((harvest) => harvest.b_lu_harvest_date ?? []))}`,
                 }
             })
@@ -222,27 +221,27 @@ export function DataTable<TData extends RotationExtended, TValue>({
             }
         })
     }, [data])
-    type MemoizedTData = (typeof memoizedData)[number]
+    type MemoizedTData =
+        | (typeof memoizedData)[number] // Memoized CropRow
+        | (typeof memoizedData)[number]["fields"][number] // Memoized FieldRow
 
-    const fuzzySearchAndProductivityFilter: FilterFn<MemoizedTData> = (
-        row,
-        _columnId,
-        { searchTerms, showProductiveOnly },
+    const fuzzySearchAndProductivityFilter = (
+        data: MemoizedTData,
+        searchTerms: string,
+        showProductiveOnly: boolean,
     ) => {
         if (
             showProductiveOnly &&
-            !(row.original.type === "crop"
-                ? row.original.fields.some((field) => !field.b_bufferstrip)
-                : !row.original.b_bufferstrip)
+            !(data.type === "crop"
+                ? data.fields.some((field) => !field.b_bufferstrip)
+                : !data.b_bufferstrip)
         ) {
             return false
         }
 
         return (
             searchTerms === "" ||
-            fuzzysort.go(searchTerms, [
-                (row.original as MemoizedTData).searchTarget,
-            ]).length > 0
+            fuzzysort.go(searchTerms, [data.searchTarget]).length > 0
         )
     }
 
@@ -255,12 +254,9 @@ export function DataTable<TData extends RotationExtended, TValue>({
                 crop.fields.every(
                     (field) =>
                         !fuzzySearchAndProductivityFilter(
-                            {
-                                original: field,
-                            } as unknown as Row<MemoizedTData>,
-                            "",
-                            fieldFilter,
-                            () => {},
+                            field,
+                            fieldFilter.searchTerms,
+                            fieldFilter.showProductiveOnly,
                         ) || selection[crop.b_lu_catalogue]?.[field.b_id],
                 ),
             ]),
@@ -274,9 +270,9 @@ export function DataTable<TData extends RotationExtended, TValue>({
         ])
     }, [selection, memoizedData, fieldFilter])
 
-    const table = useReactTable({
+    const table = useReactTable<MemoizedTData>({
         data: memoizedData,
-        columns,
+        columns: columns as ColumnDef<MemoizedTData>[],
         getRowId: (row) =>
             row.type === "crop"
                 ? `crop_${row.b_lu_catalogue}`
@@ -288,8 +284,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
         getFilteredRowModel: getFilteredRowModel(),
         getFacetedRowModel: getFacetedRowModel(),
         getExpandedRowModel: getExpandedRowModel(),
-        getSubRows: (row) =>
-            row.type === "crop" ? (row.fields as TData[]) : undefined,
+        getSubRows: (row) => (row.type === "crop" ? row.fields : undefined),
         onColumnVisibilityChange: setColumnVisibility,
         onGlobalFilterChange: (fn) => {
             const result = typeof fn === "function" ? fn(fieldFilter) : fn
@@ -302,7 +297,12 @@ export function DataTable<TData extends RotationExtended, TValue>({
             const selection = typeof fn === "function" ? fn(rowSelection) : fn
             handleSelection(selection)
         },
-        globalFilterFn: fuzzySearchAndProductivityFilter,
+        globalFilterFn: (row) =>
+            fuzzySearchAndProductivityFilter(
+                row.original,
+                fieldFilter.searchTerms,
+                fieldFilter.showProductiveOnly,
+            ),
         // There are nulls in the columns which can cause false assumptions if this is not provided
         // The global filter checks the searchTarget field anyways
         // Filter only one of the columns to gain performance
@@ -319,15 +319,14 @@ export function DataTable<TData extends RotationExtended, TValue>({
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: rowSelection is needed for Oogst button activation
     const selectedCultivations = useMemo(() => {
-        return (
-            table
-                .getFilteredRowModel()
-                .rows.filter(
-                    (row) =>
-                        row.original.type === "crop" &&
-                        (row.getIsSelected() || row.getIsSomeSelected()),
-                ) as Row<CropRow>[]
-        ).map((row) => row.original)
+        return table
+            .getFilteredRowModel()
+            .rows.filter(
+                (row) =>
+                    row.original.type === "crop" &&
+                    (row.getIsSelected() || row.getIsSomeSelected()),
+            )
+            .map((row) => row.original)
     }, [table, rowSelection])
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: rowSelection is needed for Bemesting button activation
@@ -558,14 +557,15 @@ export function DataTable<TData extends RotationExtended, TValue>({
                                               : row.original.type === "field" &&
                                                 "bg-muted/50 hover:bg-muted",
                                         row.original.type === "field" &&
-                                            ((row.getParentRow() as Row<TData>)
-                                                ?.subRows.length === 1
+                                            ((
+                                                row.getParentRow() as Row<MemoizedTData>
+                                            )?.subRows.length === 1
                                                 ? "shadow-[inset_0_1em_2em_-2em_#00000088,inset_0_-1em_2em_-2em_#00000088]"
                                                 : row.index === 0
                                                   ? "shadow-[inset_0_1em_2em_-2em_#00000088]"
                                                   : row.index ===
                                                         (
-                                                            row.getParentRow() as Row<TData>
+                                                            row.getParentRow() as Row<MemoizedTData>
                                                         )?.subRows.length -
                                                             1 &&
                                                     "shadow-[inset_0_-1em_2em_-2em_#00000088]"),

--- a/fdm-app/app/components/blocks/rotation/table.tsx
+++ b/fdm-app/app/components/blocks/rotation/table.tsx
@@ -379,7 +379,7 @@ export function DataTable<TData extends RotationExtended, TValue>({
             <div className="sticky top-0 z-5 bg-background py-4 flex flex-col sm:flex-row gap-2 items-center">
                 <Input
                     placeholder="Zoek op gewas, meststof of datum"
-                    value={fieldFilter?.searchTerms ?? ""}
+                    value={fieldFilter.searchTerms ?? ""}
                     onChange={(event) =>
                         fieldFilter.setSearchTerms(event.target.value)
                     }
@@ -557,17 +557,14 @@ export function DataTable<TData extends RotationExtended, TValue>({
                                               : row.original.type === "field" &&
                                                 "bg-muted/50 hover:bg-muted",
                                         row.original.type === "field" &&
-                                            ((
-                                                row.getParentRow() as Row<MemoizedTData>
-                                            )?.subRows.length === 1
+                                            (row.getParentRow()?.subRows
+                                                .length === 1
                                                 ? "shadow-[inset_0_1em_2em_-2em_#00000088,inset_0_-1em_2em_-2em_#00000088]"
                                                 : row.index === 0
                                                   ? "shadow-[inset_0_1em_2em_-2em_#00000088]"
-                                                  : row.index ===
-                                                        (
-                                                            row.getParentRow() as Row<MemoizedTData>
-                                                        )?.subRows.length -
-                                                            1 &&
+                                                  : row.index + 1 ===
+                                                        row.getParentRow()
+                                                            ?.subRows.length &&
                                                     "shadow-[inset_0_-1em_2em_-2em_#00000088]"),
                                     )}
                                 >

--- a/fdm-app/app/components/blocks/rotation/variety-selector.tsx
+++ b/fdm-app/app/components/blocks/rotation/variety-selector.tsx
@@ -13,32 +13,28 @@ import {
     SelectValue,
 } from "~/components/ui/select"
 import { Spinner } from "~/components/ui/spinner"
-import type { CropRow, RotationExtended } from "./columns"
+import type { CropRow, FieldRow, RotationExtended } from "./columns"
 import type { RotationTableFormSchemaType } from "./schema"
 
 type AllowedFormSchemaType = Pick<RotationTableFormSchemaType, "b_lu_variety">
 function TableVarietySelectorForm({
     name,
+    value,
     row,
     b_lu_variety_options,
     onHide,
     fetcher,
 }: {
     name: keyof AllowedFormSchemaType
+    value: string[]
     row: Row<RotationExtended>
     b_lu_variety_options: { label: string; value: string }[]
     onHide?: () => unknown
     fetcher: ReturnType<typeof useFetcher>
 }) {
-    const currentSortedValues = (
-        Object.entries(row.original[name]) as [string, number][]
-    )
-        .sort((a, b) => b[1] - a[1])
-        .map(([key]) => key)
-    const value = currentSortedValues?.length ? currentSortedValues[0] : null
     const form = useForm({
         defaultValues: {
-            [name]: value,
+            [name]: value[0],
         },
     })
 
@@ -133,7 +129,26 @@ export function TableVarietySelector({
 }) {
     const activeTableFormStore = useActiveTableFormStore()
     const fetcher = useFetcher()
-    const value = row.original[name] ? Object.keys(row.original[name]) : null
+    const varietyCounts =
+        row.original.type === "field"
+            ? // Return the variety counts directly
+              row.original[name]
+            : // Merge variety counts from each displayed field
+              Object.entries(
+                  (row.subRows ?? []).reduce(
+                      (acc, fieldRow) => {
+                          ;(fieldRow.original as FieldRow).b_lu_variety.forEach(
+                              ([variety, count]) => {
+                                  acc[variety] = (acc[variety] ?? 0) + count
+                              },
+                          )
+                          return acc
+                      },
+                      {} as Record<string, number>,
+                  ),
+              ).sort((a, b) => b[1] - a[1])
+    const value = varietyCounts.map((v) => v[0])
+
     const b_lu_variety_options = (
         (row.getParentRow() ?? row).original as CropRow
     ).b_lu_variety_options
@@ -178,6 +193,7 @@ export function TableVarietySelector({
             {showForm && (
                 <TableVarietySelectorForm
                     name={name}
+                    value={value}
                     row={row}
                     b_lu_variety_options={b_lu_variety_options}
                     onHide={() => {

--- a/fdm-app/app/components/blocks/rotation/variety-selector.tsx
+++ b/fdm-app/app/components/blocks/rotation/variety-selector.tsx
@@ -55,11 +55,14 @@ function TableVarietySelectorForm({
                                 if (formValues[name] !== value) {
                                     const fieldIds = (
                                         row.original.type === "crop"
-                                            ? row.original.fields
-                                            : [row.original]
+                                            ? (row.subRows ?? [])
+                                            : [row]
                                     )
-                                        .map((field) =>
-                                            encodeURIComponent(field.b_id),
+                                        .map((fieldRow) =>
+                                            encodeURIComponent(
+                                                (fieldRow.original as FieldRow)
+                                                    .b_id,
+                                            ),
                                         )
                                         .join(",")
                                     const cultivationIds = encodeURIComponent(

--- a/fdm-app/app/components/custom/date-picker-v2.tsx
+++ b/fdm-app/app/components/custom/date-picker-v2.tsx
@@ -167,6 +167,7 @@ export function DatePicker({
                             startMonth={new Date(1970, 0)}
                             endMonth={endMonth}
                             locale={calenderLocale}
+                            required={required}
                         />
                     </PopoverContent>
                 </Popover>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.rotation.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.rotation.tsx
@@ -435,6 +435,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                                     ),
                             ).sort((a, b) => b[1] - a[1]),
                         ),
+                        b_lu_catalogue: b_lu_catalogue,
                         b_lu_croprotation:
                             cultivationsForCatalogue[0]?.b_lu_croprotation ??
                             "",

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.rotation.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.rotation.tsx
@@ -278,35 +278,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                         ),
                 )
 
-                // Get all unique b_lu_start of cultivation
-                const b_lu_start = collectUniqueDates(
-                    cultivationsForCatalogue
-                        .filter((cultivation) => cultivation.b_lu_start != null)
-                        .map((cultivation) => cultivation.b_lu_start),
-                )
-                const b_lu_end = collectUniqueDates(
-                    cultivationsForCatalogue
-                        .filter((cultivation) => cultivation.b_lu_end)
-                        .map((cultivation) => cultivation.b_lu_end),
-                )
-
                 const b_lu = cultivationsForCatalogue.map(
                     (cultivation: { b_lu: string }) => cultivation.b_lu,
                 )
 
-                const cropResidue = fieldsWithThisCultivation.flatMap((field) =>
-                    field.cultivations
-                        .filter(
-                            (cultivation) =>
-                                cultivation.b_lu_catalogue === b_lu_catalogue,
-                        )
-                        .map((cultivation) => cultivation.m_cropresidue),
-                )
-                const aggr_m_crop_residue = cropResidue.every((a) => a)
-                    ? "all"
-                    : cropResidue.some((a) => a)
-                      ? "some"
-                      : "none"
                 const b_lu_eom_residue =
                     cultivationsForCatalogue[0]?.b_lu_eom_residue
                 const b_lu_harvestable =
@@ -317,35 +292,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                     b_lu_catalogue: b_lu_catalogue,
                     b_lu: b_lu,
                     b_lu_name: cultivationsForCatalogue[0]?.b_lu_name ?? "",
-                    b_lu_variety: Object.fromEntries(
-                        Object.entries(
-                            fieldsWithThisCultivation
-                                .flatMap((field) =>
-                                    field.cultivations
-                                        .filter(
-                                            (cultivation) =>
-                                                cultivation.b_lu_catalogue ===
-                                                b_lu_catalogue,
-                                        )
-                                        .flatMap(
-                                            (cultivation: {
-                                                b_lu_variety: string | null
-                                            }) =>
-                                                cultivation.b_lu_variety
-                                                    ? [cultivation.b_lu_variety]
-                                                    : [],
-                                        ),
-                                )
-                                .reduce(
-                                    (counts, variety) => {
-                                        counts[variety] =
-                                            (counts[variety] ?? 0) + 1
-                                        return counts
-                                    },
-                                    {} as Record<string, number>,
-                                ),
-                        ).sort((a, b) => b[1] - a[1]),
-                    ),
                     b_lu_variety_options:
                         cultivationCatalogue
                             .find(
@@ -360,13 +306,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                         cultivationsForCatalogue[0]?.b_lu_croprotation ?? "",
                     b_lu_eom_residue: b_lu_eom_residue,
                     b_lu_harvestable: b_lu_harvestable,
-                    b_lu_start: b_lu_start,
-                    b_lu_end: b_lu_end,
                     calendar: calendar,
-                    m_cropresidue: aggr_m_crop_residue,
-                    b_bufferstrip: fieldsWithThisCultivation.some(
-                        (field) => field.b_bufferstrip,
-                    ),
                     fields: fieldsWithThisCultivation.map((field, _i) => ({
                         // TODO: Define a proper type for field
                         type: "field",
@@ -409,32 +349,30 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                                 }
                             }),
                         b_lu_harvestable: b_lu_harvestable,
-                        b_lu_variety: Object.fromEntries(
-                            Object.entries(
-                                field.cultivations
-                                    .filter(
-                                        (cultivation) =>
-                                            cultivation.b_lu_catalogue ===
-                                            b_lu_catalogue,
-                                    )
-                                    .flatMap(
-                                        (cultivation: {
-                                            b_lu_variety: string | null
-                                        }) =>
-                                            cultivation.b_lu_variety
-                                                ? [cultivation.b_lu_variety]
-                                                : [],
-                                    )
-                                    .reduce(
-                                        (counts, variety) => {
-                                            counts[variety] =
-                                                (counts[variety] ?? 0) + 1
-                                            return counts
-                                        },
-                                        {} as Record<string, number>,
-                                    ),
-                            ).sort((a, b) => b[1] - a[1]),
-                        ),
+                        b_lu_variety: Object.entries(
+                            field.cultivations
+                                .filter(
+                                    (cultivation) =>
+                                        cultivation.b_lu_catalogue ===
+                                        b_lu_catalogue,
+                                )
+                                .flatMap(
+                                    (cultivation: {
+                                        b_lu_variety: string | null
+                                    }) =>
+                                        cultivation.b_lu_variety
+                                            ? [cultivation.b_lu_variety]
+                                            : [],
+                                )
+                                .reduce(
+                                    (counts, variety) => {
+                                        counts[variety] =
+                                            (counts[variety] ?? 0) + 1
+                                        return counts
+                                    },
+                                    {} as Record<string, number>,
+                                ),
+                        ).sort((a, b) => b[1] - a[1]),
                         b_lu_catalogue: b_lu_catalogue,
                         b_lu_croprotation:
                             cultivationsForCatalogue[0]?.b_lu_croprotation ??

--- a/fdm-app/app/store/field-filter.ts
+++ b/fdm-app/app/store/field-filter.ts
@@ -41,7 +41,3 @@ const createFilterStore = (name: string) =>
     )
 
 export const useFieldFilterStore = createFilterStore("field-filter-storage")
-
-export const useRotationFilterStore = createFilterStore(
-    "rotation-filter-storage",
-)


### PR DESCRIPTION
**Bug fixes**

- The show productive only button can only update the fieldFilterStore, so now the rotation table also uses that filter store, not a separate one. Back then I was thinking they should use separate filter states but now I changed my mind. Although I still think the show productive button should be controllable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the "show-productive-only" control and ensured search terms & productive-only selection stay synchronized between field and rotation tables.
  * Table UI, selection and visible rows now update consistently when filters or search change.
  * Date inputs behavior improved: start dates are required where appropriate and submissions reflect correct field/group selections.
  * Crop-residue checkbox and variety selector now show aggregated, accurate values across grouped rows.
  * Parcel names, total area, fertilizer and harvest displays now reflect correct underlying field data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->