### PR TITLE
Add field-level indicators detail page with map and radar chart

### DIFF
--- a/.changeset/social-glasses-write.md
+++ b/.changeset/social-glasses-write.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Add field page for indicators to get an overview of the scores for the indicators and a map to quickly switch fields

--- a/fdm-app/app/components/blocks/farm/farm-title.tsx
+++ b/fdm-app/app/components/blocks/farm/farm-title.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { NavLink } from "react-router"
 import { Button } from "~/components/ui/button"
 import { Separator } from "~/components/ui/separator"
@@ -6,13 +7,15 @@ import { Skeleton } from "~/components/ui/skeleton"
 interface FarmTitleProps {
     title: string
     description: string
+    /** Optional override rendered instead of the plain description text. */
+    descriptionNode?: ReactNode
     action?: {
         to: string
         label: string
     }
 }
 
-export function FarmTitle({ title, description, action }: FarmTitleProps) {
+export function FarmTitle({ title, description, descriptionNode, action }: FarmTitleProps) {
     return (
         <div className="space-y-6 p-4 md:px-8 md:py-8 pb-0">
             <div className="flex flex-col xl:flex-row xl:items-center gap-4">
@@ -20,9 +23,11 @@ export function FarmTitle({ title, description, action }: FarmTitleProps) {
                     <h2 className="text-2xl font-bold tracking-tight truncate xl:whitespace-normal">
                         {title}
                     </h2>
-                    <p className="text-muted-foreground wrap-break-word">
-                        {description}
-                    </p>
+                    {descriptionNode ?? (
+                        <p className="text-muted-foreground wrap-break-word">
+                            {description}
+                        </p>
+                    )}
                 </div>
                 {action && (
                     <div className="ml-auto">

--- a/fdm-app/app/components/blocks/header/indicators.tsx
+++ b/fdm-app/app/components/blocks/header/indicators.tsx
@@ -1,9 +1,10 @@
 import { ChevronDown } from "lucide-react"
-import { NavLink, useLocation, useParams } from "react-router"
+import { NavLink, useLocation, useMatches, useParams } from "react-router"
 import { useCalendarStore } from "@/app/store/calendar"
 import {
     BreadcrumbItem,
     BreadcrumbLink,
+    BreadcrumbPage,
     BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb"
 import {
@@ -15,47 +16,103 @@ import {
 
 export function HeaderIndicators({ b_id_farm }: { b_id_farm: string }) {
     const calendarFromStore = useCalendarStore((state) => state.calendar)
-    const { calendar: calendarFromRoute } = useParams()
+    const { calendar: calendarFromRoute, b_id } = useParams()
     const calendar = calendarFromRoute ?? calendarFromStore
     const location = useLocation()
+    const matches = useMatches()
+
     const isKaart = location.pathname.includes("/atlas")
-    const currentName = isKaart ? "Kaart" : "Tabel"
+    const isFieldDetail = !!b_id && !isKaart
+
+    // Read field name + field list from the field detail loader
+    const fieldMatch = matches.find((m) =>
+        m.id.includes("indicators.$b_id"),
+    )
+    const fieldData = fieldMatch?.data as
+        | {
+              field?: { b_name?: string | null }
+              fieldList?: Array<{ b_id: string; b_name: string | null }>
+          }
+        | undefined
+    const fieldName: string | null = fieldData?.field?.b_name ?? null
+    const fieldList = fieldData?.fieldList ?? []
+
+    const basePath = `/farm/${b_id_farm}/${calendar}/indicators`
+    const overviewLabel = isKaart ? "Kaart" : "Tabel"
 
     return (
         <>
             <BreadcrumbSeparator className="hidden xl:block" />
             <BreadcrumbItem className="hidden xl:block">
-                <BreadcrumbLink
-                    href={`/farm/${b_id_farm}/${calendar}/indicators`}
-                >
+                <BreadcrumbLink href={basePath}>
                     Indicatoren
                 </BreadcrumbLink>
             </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-                <DropdownMenu>
-                    <DropdownMenuTrigger className="flex items-center gap-1 max-w-30 sm:max-w-50 md:max-w-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
-                        <span className="truncate">{currentName}</span>
-                        <ChevronDown className="h-4 w-4 shrink-0" />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start">
-                        <DropdownMenuItem asChild>
-                            <NavLink
-                                to={`/farm/${b_id_farm}/${calendar}/indicators`}
-                            >
-                                Tabel
-                            </NavLink>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem asChild>
-                            <NavLink
-                                to={`/farm/${b_id_farm}/${calendar}/indicators/atlas`}
-                            >
-                                Kaart
-                            </NavLink>
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            </BreadcrumbItem>
+
+            {isFieldDetail ? (
+                <>
+                    <BreadcrumbSeparator />
+                    <BreadcrumbItem>
+                        {fieldList.length > 1 ? (
+                            <DropdownMenu>
+                                <DropdownMenuTrigger className="flex items-center gap-1 max-w-30 sm:max-w-50 md:max-w-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                                    <span className="truncate">
+                                        {fieldName ?? b_id}
+                                    </span>
+                                    <ChevronDown className="h-4 w-4 shrink-0" />
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start" className="max-h-72 overflow-y-auto">
+                                    {fieldList.map((f) => (
+                                        <DropdownMenuItem
+                                            key={f.b_id}
+                                            asChild
+                                            className={
+                                                f.b_id === b_id
+                                                    ? "font-semibold"
+                                                    : ""
+                                            }
+                                        >
+                                            <NavLink
+                                                to={`${basePath}/${f.b_id}`}
+                                            >
+                                                {f.b_name ?? f.b_id}
+                                            </NavLink>
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        ) : (
+                            <BreadcrumbPage className="max-w-30 sm:max-w-50 md:max-w-none truncate">
+                                {fieldName ?? b_id}
+                            </BreadcrumbPage>
+                        )}
+                    </BreadcrumbItem>
+                </>
+            ) : (
+                <>
+                    <BreadcrumbSeparator />
+                    <BreadcrumbItem>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger className="flex items-center gap-1 max-w-30 sm:max-w-50 md:max-w-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
+                                <span className="truncate">{overviewLabel}</span>
+                                <ChevronDown className="h-4 w-4 shrink-0" />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="start">
+                                <DropdownMenuItem asChild>
+                                    <NavLink to={basePath}>
+                                        Tabel
+                                    </NavLink>
+                                </DropdownMenuItem>
+                                <DropdownMenuItem asChild>
+                                    <NavLink to={`${basePath}/atlas`}>
+                                        Kaart
+                                    </NavLink>
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </BreadcrumbItem>
+                </>
+            )}
         </>
     )
 }

--- a/fdm-app/app/components/blocks/indicators/field-input-dialog.tsx
+++ b/fdm-app/app/components/blocks/indicators/field-input-dialog.tsx
@@ -1,0 +1,217 @@
+import { Database } from "lucide-react"
+import { getCultivationColor } from "~/components/custom/cultivation-colors"
+import { Badge } from "~/components/ui/badge"
+import { Button } from "~/components/ui/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog"
+import type { Measure } from "@nmi-agro/fdm-core"
+
+type CultivationSummary = {
+    name: string
+    year: number | null
+    croprotation: string | null
+}
+
+type SoilMeasurement = {
+    key: string
+    label: string
+    unit: string | null
+    value: number
+}
+
+type SoilData = {
+    soilType: string | null
+    gwlClass: string | null
+    measurements: SoilMeasurement[]
+}
+
+type FieldInputDialogProps = {
+    cultivations: CultivationSummary[]
+    fieldMeasures: Measure[]
+    soilData: SoilData | null
+}
+
+export function FieldInputDialog({
+    cultivations,
+    fieldMeasures,
+    soilData,
+}: FieldInputDialogProps) {
+    const bln3Measures = fieldMeasures.filter((m) => m.m_id.startsWith("bln_"))
+
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5 text-muted-foreground"
+                >
+                    <Database className="h-3.5 w-3.5" />
+                    Invoergegevens
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto">
+                <DialogHeader>
+                    <DialogTitle>Invoergegevens BLN3</DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4 text-sm">
+                    {/* Soil analysis */}
+                    <Section label="Bodemanalyse">
+                        {!soilData ||
+                        (!soilData.soilType &&
+                            !soilData.gwlClass &&
+                            soilData.measurements.length === 0) ? (
+                            <p className="text-muted-foreground italic">
+                                Geen bodemanalyse beschikbaar
+                            </p>
+                        ) : (
+                            <div className="space-y-0.5">
+                                {soilData.soilType && (
+                                    <Row
+                                        label="Bodemtype"
+                                        value={soilData.soilType}
+                                    />
+                                )}
+                                {soilData.gwlClass && (
+                                    <Row
+                                        label="Grondwaterklasse"
+                                        value={soilData.gwlClass}
+                                    />
+                                )}
+                                {soilData.measurements.length > 0 && (
+                                    <div className="mt-1.5 border-t pt-1.5 space-y-0.5">
+                                        {soilData.measurements.map(
+                                            ({ key, label, unit, value }) => (
+                                                <Row
+                                                    key={key}
+                                                    label={label}
+                                                    value={String(value)}
+                                                    unit={unit ?? undefined}
+                                                    mono
+                                                />
+                                            ),
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </Section>
+
+                    {/* Cultivations using Badge + getCultivationColor */}
+                    <Section label={`Teelten (${cultivations.length})`}>
+                        {cultivations.length === 0 ? (
+                            <p className="text-muted-foreground italic">
+                                Geen teelten geregistreerd
+                            </p>
+                        ) : (
+                            <ul className="flex flex-wrap gap-1.5">
+                                {cultivations.map((c, i) => (
+                                    <li key={i}>
+                                        <Badge
+                                            style={{
+                                                backgroundColor:
+                                                    getCultivationColor(
+                                                        c.croprotation ??
+                                                            undefined,
+                                                    ),
+                                            }}
+                                            className="text-white"
+                                            variant="default"
+                                        >
+                                            {c.name}
+                                            {c.year !== null && (
+                                                <span className="ml-1 opacity-80">
+                                                    {c.year}
+                                                </span>
+                                            )}
+                                        </Badge>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Section>
+
+                    {/* BLN measures */}
+                    <Section label={`BLN maatregelen (${bln3Measures.length})`}>
+                        {bln3Measures.length === 0 ? (
+                            <p className="text-muted-foreground italic">
+                                Geen maatregelen actief
+                            </p>
+                        ) : (
+                            <ul className="space-y-1">
+                                {bln3Measures.map((m) => (
+                                    <li
+                                        key={m.b_id_measure}
+                                        className="flex items-start gap-2"
+                                    >
+                                        <span className="shrink-0 font-mono text-xs text-muted-foreground pt-px">
+                                            {m.m_id.replace("bln_", "")}
+                                        </span>
+                                        <span className="text-foreground">
+                                            {m.m_name}
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Section>
+
+                    <p className="text-xs text-muted-foreground pt-2 border-t">
+                        Dit zijn de gegevens die worden gebruikt als invoer
+                        voor de NMI BLN3-berekening.
+                    </p>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+function Section({
+    label,
+    children,
+}: {
+    label: string
+    children: React.ReactNode
+}) {
+    return (
+        <div>
+            <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1.5">
+                {label}
+            </p>
+            {children}
+        </div>
+    )
+}
+
+function Row({
+    label,
+    value,
+    unit,
+    mono = false,
+}: {
+    label: string
+    value: string
+    unit?: string
+    mono?: boolean
+}) {
+    return (
+        <div className="flex items-baseline justify-between gap-2">
+            <span className="text-muted-foreground text-xs shrink-0">
+                {label}
+            </span>
+            <span
+                className={`text-foreground text-xs text-right ${mono ? "tabular-nums font-mono" : ""}`}
+            >
+                {value}
+                {unit && (
+                    <span className="text-muted-foreground ml-1">{unit}</span>
+                )}
+            </span>
+        </div>
+    )
+}

--- a/fdm-app/app/components/blocks/indicators/field-input-dialog.tsx
+++ b/fdm-app/app/components/blocks/indicators/field-input-dialog.tsx
@@ -110,8 +110,8 @@ export function FieldInputDialog({
                             </p>
                         ) : (
                             <ul className="flex flex-wrap gap-1.5">
-                                {cultivations.map((c, i) => (
-                                    <li key={i}>
+                                {cultivations.map((c) => (
+                                    <li key={`${c.name}-${c.year}`}>
                                         <Badge
                                             style={{
                                                 backgroundColor:

--- a/fdm-app/app/components/blocks/indicators/field-map.tsx
+++ b/fdm-app/app/components/blocks/indicators/field-map.tsx
@@ -1,0 +1,194 @@
+/**
+ * Lazy-loaded mini map for the field-level indicator detail page.
+ *
+ * Shows all farm fields coloured by their average BLN3 score. The current
+ * field is highlighted with a yellow outline. Clicking another field navigates
+ * to that field's indicator detail page.
+ *
+ * Import with React.lazy to avoid SSR issues with maplibre-gl.
+ */
+import maplibregl from "maplibre-gl"
+import { useCallback, useMemo, useState } from "react"
+import {
+    Layer,
+    Map as MapGL,
+    type MapMouseEvent,
+    type ViewState,
+    type ViewStateChangeEvent,
+} from "react-map-gl/maplibre"
+import { useNavigate } from "react-router"
+import type { FeatureCollection } from "geojson"
+import type { StyleSpecification } from "maplibre-gl"
+import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
+import { FieldsSourceNotClickable } from "~/components/blocks/atlas/atlas-sources"
+import {
+    getFieldsScoreStyle,
+    getFieldsScoreOutlineStyle,
+} from "~/components/blocks/atlas/atlas-styles"
+import { getViewState } from "~/components/blocks/atlas/atlas-viewstate"
+import { getScoreVerdict, getScoreColor } from "~/lib/indicators"
+
+type FieldMapProps = {
+    /** GeoJSON with all farm fields. Each feature needs b_id, b_name and score properties. */
+    fieldsGeoJSON: FeatureCollection
+    /** GeoJSON with only the currently-selected field, for the yellow highlight. */
+    selectedFieldGeoJSON: FeatureCollection
+    mapStyle: string | StyleSpecification
+    /** Base path to navigate to — the b_id will be appended: `${basePath}/${b_id}` */
+    basePath: string
+    /**
+     * GeoJSON property key to use for colouring fields.
+     * One of "avg" | "obi" | "bbwp" | indicator ID (e.g. "B_DI").
+     * Defaults to "avg".
+     */
+    scoreKey?: string
+    /** Human-readable label for the selected score key, used in the hover tooltip. */
+    scoreLabel?: string
+    height?: string
+}
+
+const FIELDS_LAYER = "fieldMapFields"
+const FIELDS_OUTLINE_LAYER = "fieldMapFieldsOutline"
+const SELECTED_LAYER = "fieldMapSelected"
+const SELECTED_OUTLINE_LAYER = "fieldMapSelectedOutline"
+const FIELDS_SOURCE = "fieldMapSource"
+const SELECTED_SOURCE = "fieldMapSelectedSource"
+
+export default function FieldMap({
+    fieldsGeoJSON,
+    selectedFieldGeoJSON,
+    mapStyle,
+    basePath,
+    scoreKey = "avg",
+    scoreLabel,
+    height = "320px",
+}: FieldMapProps) {
+    const navigate = useNavigate()
+    const initialViewState = getViewState(fieldsGeoJSON)
+    const [viewState, setViewState] = useState<ViewState>(
+        initialViewState as ViewState,
+    )
+    const [hoveredFieldId, setHoveredFieldId] = useState<string | null>(null)
+
+    const onViewportChange = useCallback(
+        (event: ViewStateChangeEvent) => setViewState(event.viewState),
+        [],
+    )
+
+    const onMouseMove = useCallback((e: MapMouseEvent) => {
+        const feature = e.features?.[0]
+        setHoveredFieldId(
+            feature ? (feature.properties?.b_id as string) ?? null : null,
+        )
+    }, [])
+
+    const onMouseLeave = useCallback(() => setHoveredFieldId(null), [])
+
+    const onClick = useCallback(
+        (e: MapMouseEvent) => {
+            const b_id = e.features?.[0]?.properties?.b_id as string | undefined
+            if (b_id) navigate(`${basePath}/${b_id}`)
+        },
+        [navigate, basePath],
+    )
+
+    const scoreStyle = useMemo(
+        () => getFieldsScoreStyle(FIELDS_LAYER, scoreKey),
+        [scoreKey],
+    )
+    const scoreOutlineStyle = useMemo(
+        () => getFieldsScoreOutlineStyle(FIELDS_OUTLINE_LAYER, scoreKey),
+        [scoreKey],
+    )
+
+    // Hover data for tooltip
+    const hoveredFeature = useMemo(() => {
+        if (!hoveredFieldId) return null
+        return (
+            fieldsGeoJSON.features.find(
+                (f) => f.properties?.b_id === hoveredFieldId,
+            ) ?? null
+        )
+    }, [fieldsGeoJSON, hoveredFieldId])
+
+    const hoveredScore =
+        typeof hoveredFeature?.properties?.[scoreKey] === "number" &&
+        hoveredFeature.properties[scoreKey] >= 0
+            ? (hoveredFeature.properties[scoreKey] as number)
+            : null
+
+    return (
+        <div className="relative" style={{ height }}>
+            <MapGL
+                {...viewState}
+                style={{ height: "100%", width: "100%", borderRadius: "0.5rem" }}
+                mapStyle={mapStyle as any}
+                mapLib={maplibregl}
+                interactiveLayerIds={[FIELDS_LAYER]}
+                onMove={onViewportChange}
+                onMouseMove={onMouseMove}
+                onMouseLeave={onMouseLeave}
+                onClick={onClick}
+                cursor={hoveredFieldId ? "pointer" : "default"}
+            >
+                <MapTilerAttribution />
+
+                {/* All farm fields coloured by score */}
+                <FieldsSourceNotClickable
+                    id={FIELDS_SOURCE}
+                    fieldsData={fieldsGeoJSON}
+                >
+                    <Layer
+                        {...(scoreStyle as any)}
+                        id={FIELDS_LAYER}
+                        source={FIELDS_SOURCE}
+                    />
+                    <Layer
+                        {...(scoreOutlineStyle as any)}
+                        id={FIELDS_OUTLINE_LAYER}
+                        source={FIELDS_SOURCE}
+                    />
+                </FieldsSourceNotClickable>
+
+                {/* Selected field: yellow outline highlight */}
+                <FieldsSourceNotClickable
+                    id={SELECTED_SOURCE}
+                    fieldsData={selectedFieldGeoJSON}
+                >
+                    <Layer
+                        id={SELECTED_LAYER}
+                        source={SELECTED_SOURCE}
+                        type="fill"
+                        paint={{ "fill-color": "#ffcf0d", "fill-opacity": 0.25 }}
+                    />
+                    <Layer
+                        id={SELECTED_OUTLINE_LAYER}
+                        source={SELECTED_SOURCE}
+                        type="line"
+                        paint={{ "line-color": "#ffcf0d", "line-width": 3 }}
+                    />
+                </FieldsSourceNotClickable>
+            </MapGL>
+
+            {/* Hover tooltip */}
+            {hoveredFeature && (
+                <div className="absolute bottom-3 left-3 z-10 bg-background/95 backdrop-blur-sm border rounded-lg px-2.5 py-1.5 shadow-md text-xs pointer-events-none">
+                    <p className="font-semibold">
+                        {hoveredFeature.properties?.b_name ?? "Onbekend perceel"}
+                    </p>
+                    {scoreLabel && (
+                        <p className="text-muted-foreground text-[10px]">{scoreLabel}</p>
+                    )}
+                    {hoveredScore !== null && (
+                        <span
+                            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold text-white mt-0.5"
+                            style={{ backgroundColor: getScoreColor(hoveredScore) }}
+                        >
+                            {hoveredScore} – {getScoreVerdict(hoveredScore)}
+                        </span>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/fdm-app/app/components/blocks/indicators/indicator-card.tsx
+++ b/fdm-app/app/components/blocks/indicators/indicator-card.tsx
@@ -1,0 +1,254 @@
+/**
+ * Expandable indicator card for the field-level indicator detail page.
+ *
+ * Collapsed (default): shows indicator name, category badge, status/target
+ * values, a stacked progress bar (field state + measures contribution), and
+ * the verdict badge.
+ *
+ * Expanded (on click): reveals the full indicator description, a list of
+ * active measures on this field, and a link to the Maatregelen page.
+ */
+import { ChevronDown, ChevronUp, ExternalLink } from "lucide-react"
+import { useState } from "react"
+import { Link } from "react-router"
+import { cn } from "~/lib/utils"
+import {
+    getScoreColor,
+    getScoreTier,
+    scoreToDisplay,
+    type IndicatorInfo,
+} from "~/lib/indicators"
+import { ScoreBadge } from "./score-badge"
+import type { Bln3IndicatorResult } from "@nmi-agro/fdm-calculator"
+import type { Measure } from "@nmi-agro/fdm-core"
+
+type IndicatorCardProps = {
+    info: IndicatorInfo
+    result: Bln3IndicatorResult
+    /** All measures active on this field */
+    fieldMeasures: Measure[]
+    /** Link to the Maatregelen page for this field */
+    measuresHref: string
+    /** When true, display index instead of score */
+    showIndex: boolean
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+    Biologisch: "bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400",
+    Chemisch: "bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400",
+    Fysisch: "bg-stone-100 text-stone-700 dark:bg-stone-950/30 dark:text-stone-400",
+    Grondwater: "bg-cyan-100 text-cyan-700 dark:bg-cyan-950/30 dark:text-cyan-400",
+    "Nutriënten": "bg-green-100 text-green-700 dark:bg-green-950/30 dark:text-green-400",
+    Oppervlaktewater: "bg-sky-100 text-sky-700 dark:bg-sky-950/30 dark:text-sky-400",
+}
+
+function StackedScoreBar({
+    indexValue,
+    impactValue,
+    indexColor,
+}: {
+    indexValue: number
+    impactValue: number
+    indexColor: string
+}) {
+    const indexWidth = Math.min(indexValue, 100)
+    const impactWidth = Math.min(impactValue, 100 - indexWidth)
+    return (
+        <div className="relative h-2 w-full overflow-hidden rounded-full bg-primary/10">
+            <div
+                className="absolute left-0 top-0 h-full rounded-l-full transition-all duration-500"
+                style={{ width: `${indexWidth}%`, backgroundColor: indexColor }}
+            />
+            {impactWidth > 0 && (
+                <div
+                    className="absolute top-0 h-full bg-green-500/60 transition-all duration-500"
+                    style={{
+                        left: `${indexWidth}%`,
+                        width: `${impactWidth}%`,
+                    }}
+                />
+            )}
+        </div>
+    )
+}
+
+export function IndicatorCard({
+    info,
+    result,
+    fieldMeasures,
+    measuresHref,
+    showIndex,
+}: IndicatorCardProps) {
+    const [expanded, setExpanded] = useState(false)
+
+    const indexDisplay = scoreToDisplay(result.index)
+    const scoreDisplay = scoreToDisplay(result.score)
+    const activeDisplay = showIndex ? indexDisplay : scoreDisplay
+    const color = getScoreColor(activeDisplay)
+    const tier = getScoreTier(activeDisplay)
+    const indexColor = getScoreColor(indexDisplay)
+
+    const impactDisplay = scoreToDisplay(result.impact)
+    const hasImpact = impactDisplay > 0
+
+    return (
+        <div
+            className={cn(
+                "border rounded-lg overflow-hidden transition-shadow",
+                tier === "red" && "border-red-200 dark:border-red-900/40",
+                tier === "yellow" && "border-yellow-200 dark:border-yellow-900/40",
+                tier === "green" && "border-green-200 dark:border-green-900/40",
+            )}
+        >
+            {/* Card header — always visible, clickable to expand */}
+            <button
+                type="button"
+                className="w-full text-left px-4 py-3 hover:bg-muted/40 transition-colors"
+                onClick={() => setExpanded((prev) => !prev)}
+                aria-expanded={expanded}
+            >
+                <div className="flex items-start gap-3">
+                    {/* Score circle */}
+                    <div
+                        className="shrink-0 w-11 h-11 rounded-full flex flex-col items-center justify-center text-white font-bold text-sm leading-tight"
+                        style={{ backgroundColor: color }}
+                    >
+                        <span>{activeDisplay}</span>
+                    </div>
+
+                    {/* Main content */}
+                    <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-semibold text-sm">{info.name}</span>
+                            <span className="text-xs text-muted-foreground font-mono">{info.id}</span>
+                            <span
+                                className={cn(
+                                    "text-[10px] font-medium rounded-full px-2 py-0.5",
+                                    CATEGORY_COLORS[info.category] ??
+                                        "bg-muted text-muted-foreground",
+                                )}
+                            >
+                                {info.category}
+                            </span>
+                        </div>
+
+                        {/* Status & target */}
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                            Status{" "}
+                            <span className="font-medium text-foreground">
+                                {result.status.toFixed(2)}
+                            </span>
+                            {"  "}· Doel{" "}
+                            <span className="font-medium text-foreground">
+                                {result.target.toFixed(2)}
+                            </span>
+                        </p>
+
+                        {/* Stacked score bar */}
+                        <div className="mt-2 space-y-1">
+                            <div className="flex items-center gap-2">
+                                <div className="flex-1">
+                                    <StackedScoreBar
+                                        indexValue={indexDisplay}
+                                        impactValue={showIndex ? 0 : impactDisplay}
+                                        indexColor={indexColor}
+                                    />
+                                </div>
+                                <span className="text-[10px] tabular-nums w-6 text-right font-medium">
+                                    {activeDisplay}
+                                </span>
+                            </div>
+                            {/* Legend: only shown when measures are visible and there is impact */}
+                            {!showIndex && hasImpact && (
+                                <div className="flex gap-3 text-[9px] text-muted-foreground">
+                                    <span className="flex items-center gap-1">
+                                        <span
+                                            className="inline-block w-2 h-1.5 rounded-sm"
+                                            style={{ backgroundColor: indexColor }}
+                                        />
+                                        Perceel: {indexDisplay}
+                                    </span>
+                                    <span className="flex items-center gap-1 text-green-600 dark:text-green-400">
+                                        <span className="inline-block w-2 h-1.5 rounded-sm bg-green-500 opacity-60" />
+                                        Maatregelen: +{impactDisplay}
+                                    </span>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Right side: verdict + chevron */}
+                    <div className="shrink-0 flex flex-col items-end gap-1.5">
+                        <ScoreBadge score={activeDisplay} />
+                        {expanded ? (
+                            <ChevronUp className="h-4 w-4 text-muted-foreground mt-1" />
+                        ) : (
+                            <ChevronDown className="h-4 w-4 text-muted-foreground mt-1" />
+                        )}
+                    </div>
+                </div>
+            </button>
+
+            {/* Expanded detail panel */}
+            {expanded && (
+                <div className="border-t bg-muted/20 px-4 py-3 space-y-4 text-sm">
+                    {/* Description */}
+                    {info.description && (
+                        <div>
+                            <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1">
+                                Beschrijving
+                            </p>
+                            <p className="text-sm text-foreground">{info.description}</p>
+                        </div>
+                    )}
+
+                    {/* Active measures impact */}
+                    {fieldMeasures.length > 0 && (
+                        <div>
+                            <p className="font-medium text-xs uppercase tracking-wide text-muted-foreground mb-1.5">
+                                Actieve maatregelen op dit perceel
+                            </p>
+                            <ul className="space-y-1">
+                                {fieldMeasures.map((measure) => (
+                                    <li
+                                        key={measure.b_id_measure}
+                                        className="flex items-start gap-2 text-xs"
+                                    >
+                                        <span className="shrink-0 font-mono text-muted-foreground">
+                                            {measure.m_id.replace("bln_", "")}
+                                        </span>
+                                        <span className="text-foreground">
+                                            {measure.m_name}
+                                        </span>
+                                        {measure.m_end === null && (
+                                            <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                                                doorlopend
+                                            </span>
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
+                            {!hasImpact && (
+                                <p className="text-xs text-muted-foreground mt-1.5 italic">
+                                    Deze maatregelen hebben geen directe invloed op deze indicator.
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Link to Maatregelen */}
+                    <div className="pt-1">
+                        <Link
+                            to={measuresHref}
+                            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+                        >
+                            Ga naar Maatregelen
+                            <ExternalLink className="h-3 w-3" />
+                        </Link>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+

--- a/fdm-app/app/components/blocks/indicators/indicator-card.tsx
+++ b/fdm-app/app/components/blocks/indicators/indicator-card.tsx
@@ -51,8 +51,8 @@ function StackedScoreBar({
     impactValue: number
     indexColor: string
 }) {
-    const indexWidth = Math.min(indexValue, 100)
-    const impactWidth = Math.min(impactValue, 100 - indexWidth)
+    const indexWidth = Math.max(0, Math.min(indexValue, 100))
+    const impactWidth = Math.max(0, Math.min(impactValue, 100 - indexWidth))
     return (
         <div className="relative h-2 w-full overflow-hidden rounded-full bg-primary/10">
             <div

--- a/fdm-app/app/components/blocks/indicators/radar-chart.tsx
+++ b/fdm-app/app/components/blocks/indicators/radar-chart.tsx
@@ -1,0 +1,176 @@
+/**
+ * Radar (spider) chart showing BLN3 indicator scores for a single field.
+ *
+ * Shows all 28 indicators at once. Tick labels are coloured by category so
+ * the user can spot clusters at a glance. Two overlaid radars:
+ * - Index (field state without measures) — dashed, semi-transparent
+ * - Score (field state + measures)       — solid fill
+ */
+import { useMemo } from "react"
+import {
+    PolarAngleAxis,
+    PolarGrid,
+    Radar,
+    RadarChart,
+    ResponsiveContainer,
+    Tooltip,
+} from "recharts"
+import type { Bln3IndicatorResult } from "@nmi-agro/fdm-calculator"
+import {
+    INDICATORS,
+    type IndicatorCategory,
+    type IndicatorInfo,
+    scoreToDisplay,
+} from "~/lib/indicators"
+
+// Hex colours matching category-filter chip colours
+const CATEGORY_COLORS: Record<IndicatorCategory, string> = {
+    Biologisch: "#f59e0b",       // amber-400
+    Chemisch: "#3b82f6",         // blue-500
+    Fysisch: "#78716c",          // stone-500
+    Grondwater: "#06b6d4",       // cyan-500
+    "Nutriënten": "#22c55e",     // green-500
+    Oppervlaktewater: "#0ea5e9", // sky-500
+}
+
+// Pre-compute indicator id → category colour for fast lookup
+const ID_TO_COLOR = new Map<string, string>(
+    INDICATORS.map((i) => [i.id, CATEGORY_COLORS[i.category]]),
+)
+
+type IndicatorRadarChartProps = {
+    /** All 28 indicator results from the BLN3 API */
+    indicators: Bln3IndicatorResult[]
+    /** Indicator metadata — pass all INDICATORS (not filtered) */
+    indicatorInfos: IndicatorInfo[]
+}
+
+type RadarDataPoint = {
+    id: string
+    name: string
+    /** Short label for the axis — indicator ID */
+    label: string
+    index: number
+    score: number
+}
+
+function CustomTooltip({
+    active,
+    payload,
+}: {
+    active?: boolean
+    payload?: Array<{ payload: RadarDataPoint }>
+}) {
+    if (!active || !payload?.length) return null
+    const d = payload[0].payload
+    return (
+        <div className="bg-background/95 backdrop-blur-sm border rounded-lg px-3 py-2 shadow-md text-xs">
+            <p className="font-semibold mb-1">{d.name}</p>
+            <p className="text-muted-foreground">
+                Perceel{" "}
+                <span className="font-medium text-foreground">{d.index}</span>
+            </p>
+            <p className="text-muted-foreground">
+                Met maatregelen{" "}
+                <span className="font-medium text-foreground">{d.score}</span>
+            </p>
+        </div>
+    )
+}
+
+// Custom tick renderer that colours each label by its indicator's category
+function CategoryTick(props: {
+    x?: string | number
+    y?: string | number
+    cx?: string | number
+    cy?: string | number
+    payload?: { value: string }
+    [key: string]: unknown
+}) {
+    const x = Number(props.x ?? 0)
+    const y = Number(props.y ?? 0)
+    const cx = Number(props.cx ?? 0)
+    const id = props.payload?.value ?? ""
+    const fill = ID_TO_COLOR.get(id) ?? "hsl(var(--muted-foreground))"
+    const dx = x - cx
+    const textAnchor =
+        Math.abs(dx) < 6 ? "middle" : dx > 0 ? "start" : "end"
+
+    return (
+        <text
+            x={x}
+            y={y}
+            textAnchor={textAnchor}
+            dominantBaseline="central"
+            fontSize={9}
+            fill={fill}
+            fontWeight="600"
+        >
+            {id}
+        </text>
+    )
+}
+
+export function IndicatorRadarChart({
+    indicators,
+    indicatorInfos,
+}: IndicatorRadarChartProps) {
+    const data = useMemo<RadarDataPoint[]>(() => {
+        return indicatorInfos.flatMap((info) => {
+            const result = indicators.find((r) => r.indicator_id === info.id)
+            if (!result) return []
+            return [
+                {
+                    id: info.id,
+                    name: info.name,
+                    label: info.id,
+                    index: scoreToDisplay(result.index),
+                    score: scoreToDisplay(result.score),
+                },
+            ]
+        })
+    }, [indicators, indicatorInfos])
+
+    if (data.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-52 text-sm text-muted-foreground">
+                Geen indicatoren beschikbaar.
+            </div>
+        )
+    }
+
+    return (
+        <ResponsiveContainer width="100%" height={320}>
+            <RadarChart
+                data={data}
+                margin={{ top: 20, right: 50, bottom: 20, left: 50 }}
+            >
+                <PolarGrid stroke="hsl(var(--border))" />
+                <PolarAngleAxis
+                    dataKey="label"
+                    tick={(tickProps) => <CategoryTick {...tickProps} />}
+                />
+                <Tooltip content={<CustomTooltip />} />
+                {/* Index — without measures */}
+                <Radar
+                    name="Perceel"
+                    dataKey="index"
+                    stroke="#94a3b8"
+                    fill="#94a3b8"
+                    fillOpacity={0.1}
+                    strokeDasharray="4 3"
+                    strokeWidth={1.5}
+                />
+                {/* Score — with measures */}
+                <Radar
+                    name="Met maatregelen"
+                    dataKey="score"
+                    stroke="#22c55e"
+                    fill="#22c55e"
+                    fillOpacity={0.25}
+                    strokeWidth={2}
+                />
+            </RadarChart>
+        </ResponsiveContainer>
+    )
+}

--- a/fdm-app/app/components/blocks/indicators/table.tsx
+++ b/fdm-app/app/components/blocks/indicators/table.tsx
@@ -1,4 +1,3 @@
-import { TriangleAlert } from "lucide-react"
 import {
     flexRender,
     getCoreRowModel,
@@ -28,23 +27,25 @@ type FieldRow = {
     b_id: string
     b_name: string | null | undefined
     scores: Record<string, { score01: number; index01: number } | undefined>
+    /** Number of indicators with display score <40 for this field */
+    knelpuntCount: number
 }
 
 const CATEGORY_TEXT: Record<IndicatorCategory, string> = {
-    Biologisch:       "text-amber-600 dark:text-amber-400",
-    Chemisch:         "text-blue-600 dark:text-blue-400",
-    Fysisch:          "text-stone-600 dark:text-stone-400",
-    Grondwater:       "text-cyan-600 dark:text-cyan-400",
-    "Nutriënten":     "text-green-600 dark:text-green-400",
+    Biologisch: "text-amber-600 dark:text-amber-400",
+    Chemisch: "text-blue-600 dark:text-blue-400",
+    Fysisch: "text-stone-600 dark:text-stone-400",
+    Grondwater: "text-cyan-600 dark:text-cyan-400",
+    Nutriënten: "text-green-600 dark:text-green-400",
     Oppervlaktewater: "text-sky-600 dark:text-sky-400",
 }
 
 const CATEGORY_BORDER: Record<IndicatorCategory, string> = {
-    Biologisch:       "border-b-amber-400",
-    Chemisch:         "border-b-blue-400",
-    Fysisch:          "border-b-stone-400",
-    Grondwater:       "border-b-cyan-400",
-    "Nutriënten":     "border-b-green-400",
+    Biologisch: "border-b-amber-400",
+    Chemisch: "border-b-blue-400",
+    Fysisch: "border-b-stone-400",
+    Grondwater: "border-b-cyan-400",
+    Nutriënten: "border-b-green-400",
     Oppervlaktewater: "border-b-sky-400",
 }
 
@@ -78,6 +79,12 @@ export function HeatmapTable({
 }: HeatmapTableProps) {
     // Build per-field score rows
     const data = useMemo<FieldRow[]>(() => {
+        const activeInds =
+            activeCategories.length > 0
+                ? INDICATORS.filter((i) =>
+                      activeCategories.includes(i.category),
+                  )
+                : INDICATORS
         return fields.map((field) => {
             const fs = fieldScores.find((s) => s.b_id === field.b_id)
             const scores: FieldRow["scores"] = {}
@@ -89,11 +96,23 @@ export function HeatmapTable({
                     }
                 }
             }
-            return { b_id: field.b_id, b_name: field.b_name, scores }
+            let knelpuntCount = 0
+            for (const ind of activeInds) {
+                const vals = scores[ind.id]
+                if (!vals) continue
+                const active01 = showIndex ? vals.index01 : vals.score01
+                if (scoreToDisplay(active01) < 40) knelpuntCount++
+            }
+            return {
+                b_id: field.b_id,
+                b_name: field.b_name,
+                scores,
+                knelpuntCount,
+            }
         })
-    }, [fields, fieldScores])
+    }, [fields, fieldScores, activeCategories, showIndex])
 
-    // Column definitions: field column + one group per category
+    // Column definitions: field column + knelpunten summary column + one group per category
     const columns = useMemo<ColumnDef<FieldRow>[]>(() => {
         const fieldCol: ColumnDef<FieldRow> = {
             id: "field",
@@ -109,7 +128,50 @@ export function HeatmapTable({
             ),
         }
 
-        const categories = activeCategories.length > 0 ? activeCategories : INDICATOR_CATEGORIES
+        const knelpuntCol: ColumnDef<FieldRow> = {
+            id: "knelpunten",
+            header: () => (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span className="vertical-header text-[11px] font-medium cursor-default self-stretch text-red-700 dark:text-red-400">
+                            Knelpunten
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent
+                        side="right"
+                        className="max-w-[220px] text-xs"
+                    >
+                        Aantal knelpunten voor dit perceel
+                    </TooltipContent>
+                </Tooltip>
+                // <Tooltip>
+                //     <TooltipTrigger asChild>
+                //         <span className="vertical-header text-[11px] font-medium text-foreground cursor-default items-center text-red-600 dark:text-red-400">
+
+                //         </span>
+                //     </TooltipTrigger>
+                //     <TooltipContent
+                //         side="right"
+                //         className="max-w-[180px] text-xs"
+                //     >
+                //         Aantal knelpunten voor dit perceel
+                //     </TooltipContent>
+                // </Tooltip>
+            ),
+            cell: ({ row }) => {
+                const count = row.original.knelpuntCount
+                return count > 0 ? (
+                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 text-xs font-bold">
+                        {count}
+                    </span>
+                ) : null
+            },
+        }
+
+        const categories =
+            activeCategories.length > 0
+                ? activeCategories
+                : INDICATOR_CATEGORIES
         const groups: ColumnDef<FieldRow>[] = categories.map((cat) => ({
             id: cat,
             header: cat,
@@ -120,13 +182,14 @@ export function HeatmapTable({
                     header: () => (
                         <Tooltip>
                             <TooltipTrigger asChild>
-                                <span
-                                    className="vertical-header text-[11px] font-medium text-foreground cursor-default self-stretch break-words"
-                                >
+                                <span className="vertical-header text-[11px] font-medium text-foreground cursor-default self-stretch">
                                     {ind.name}
                                 </span>
                             </TooltipTrigger>
-                            <TooltipContent side="right" className="max-w-[220px] text-xs">
+                            <TooltipContent
+                                side="right"
+                                className="max-w-[220px] text-xs"
+                            >
                                 {ind.name}
                             </TooltipContent>
                         </Tooltip>
@@ -146,7 +209,7 @@ export function HeatmapTable({
             ),
         }))
 
-        return [fieldCol, ...groups]
+        return [fieldCol, knelpuntCol, ...groups]
     }, [activeCategories, showIndex, basePath])
 
     const table = useReactTable({
@@ -158,17 +221,20 @@ export function HeatmapTable({
     // Always 2 header groups: [category group row, indicator name row]
     const [categoryGroupRow, indicatorNameRow] = table.getHeaderGroups()
 
-    // Indicator leaf columns (excluding the field column) for the painpoint row
+    // Indicator leaf columns (excluding field and knelpunten columns) for the painpoint row
     const indicatorLeafHeaders = indicatorNameRow.headers.filter(
-        (h) => h.column.id !== "field",
+        (h) => h.column.id !== "field" && h.column.id !== "knelpunten",
     )
 
     // Painpoint counts: number of fields with display score <40 per indicator
     const painpointCounts = useMemo(() => {
         const counts = new Map<string, number>()
-        const indicators = activeCategories.length > 0
-            ? INDICATORS.filter((i) => activeCategories.includes(i.category))
-            : INDICATORS
+        const indicators =
+            activeCategories.length > 0
+                ? INDICATORS.filter((i) =>
+                      activeCategories.includes(i.category),
+                  )
+                : INDICATORS
         for (const ind of indicators) {
             let count = 0
             for (const row of data) {
@@ -182,13 +248,21 @@ export function HeatmapTable({
         return counts
     }, [data, activeCategories, showIndex])
 
-    const hasPainpoints = [...painpointCounts.values()].some((c) => c > 0)
+    // Total knelpunten across all fields (for the crossing cell)
+    const totalKnelpunten = useMemo(
+        () => data.reduce((sum, r) => sum + r.knelpuntCount, 0),
+        [data],
+    )
 
     // Shared cell class strings
-    const thBase = "bg-background px-1 text-xs font-medium text-muted-foreground border-b border-border"
+    const thBase =
+        "bg-background px-1 text-xs font-medium text-muted-foreground border-b border-border"
     const tdBase = "text-center px-1 py-2 border-b border-border"
     const stickyCol = "sticky left-0 z-10 bg-background"
     const stickyCorner = "sticky left-0 z-30 bg-background"
+    // Second sticky column — knelpunten summary (left offset = field column width 160px)
+    const stickyKnelpunt = "sticky left-[160px] z-10 bg-background"
+    const stickyKnelpuntCorner = "sticky left-[160px] z-30 bg-background"
 
     return (
         <TooltipProvider>
@@ -203,17 +277,31 @@ export function HeatmapTable({
                         <tr>
                             {categoryGroupRow.headers.map((header) => {
                                 if (header.isPlaceholder) {
+                                    // field placeholder
+                                    if (header.column.id === "field") {
+                                        return (
+                                            <th
+                                                key={header.id}
+                                                className={cn(
+                                                    stickyCorner,
+                                                    "w-[160px] min-w-[160px] px-3 py-1.5 border-b border-r border-border",
+                                                )}
+                                            />
+                                        )
+                                    }
+                                    // knelpunten placeholder
                                     return (
                                         <th
                                             key={header.id}
                                             className={cn(
-                                                stickyCorner,
-                                                "w-[160px] min-w-[160px] px-3 py-1.5 border-b border-r border-border",
+                                                stickyKnelpuntCorner,
+                                                "w-12 min-w-[48px] px-1 py-1.5 border-b border-r border-border",
                                             )}
                                         />
                                     )
                                 }
-                                const cat = header.column.id as IndicatorCategory
+                                const cat = header.column
+                                    .id as IndicatorCategory
                                 return (
                                     <th
                                         key={header.id}
@@ -250,6 +338,22 @@ export function HeatmapTable({
                                         </th>
                                     )
                                 }
+                                if (header.column.id === "knelpunten") {
+                                    return (
+                                        <th
+                                            key={header.id}
+                                            className={cn(
+                                                stickyKnelpuntCorner,
+                                                "w-12 min-w-[48px] px-1 pb-2 text-center border-b border-r border-border align-middle",
+                                            )}
+                                        >
+                                            {flexRender(
+                                                header.column.columnDef.header,
+                                                header.getContext(),
+                                            )}
+                                        </th>
+                                    )
+                                }
                                 return (
                                     <th
                                         key={header.id}
@@ -263,30 +367,35 @@ export function HeatmapTable({
                                                 type="button"
                                                 className={cn(
                                                     "flex justify-center items-end h-full w-full overflow-hidden cursor-pointer hover:bg-muted/40",
-                                                    selectedIndicatorId === header.column.id &&
+                                                    selectedIndicatorId ===
+                                                        header.column.id &&
                                                         "bg-muted/60 ring-2 ring-inset ring-primary/50",
                                                 )}
                                                 aria-pressed={
-                                                    selectedIndicatorId === header.column.id
+                                                    selectedIndicatorId ===
+                                                    header.column.id
                                                 }
                                                 aria-label={`${selectedIndicatorId === header.column.id ? "Unpin" : "Pin"} indicator ${header.column.id}`}
                                                 onClick={() =>
                                                     onIndicatorClick(
-                                                        selectedIndicatorId === header.column.id
+                                                        selectedIndicatorId ===
+                                                            header.column.id
                                                             ? null
                                                             : header.column.id,
                                                     )
                                                 }
                                             >
                                                 {flexRender(
-                                                    header.column.columnDef.header,
+                                                    header.column.columnDef
+                                                        .header,
                                                     header.getContext(),
                                                 )}
                                             </button>
                                         ) : (
                                             <div className="flex justify-center items-end h-full overflow-hidden">
                                                 {flexRender(
-                                                    header.column.columnDef.header,
+                                                    header.column.columnDef
+                                                        .header,
                                                     header.getContext(),
                                                 )}
                                             </div>
@@ -298,38 +407,56 @@ export function HeatmapTable({
                     </thead>
 
                     <tbody>
-                        {/* Painpoint row — always first */}
-                        {hasPainpoints && (
-                            <tr>
-                                <td
+                        {/* Painpoint row — always visible; crossing cell shows total */}
+                        <tr>
+                            <td
+                                className={cn(
+                                    stickyCol,
+                                    "px-3 py-2 text-xs font-semibold border-b-2 border-r border-border",
+                                    totalKnelpunten > 0
+                                        ? "text-red-700 dark:text-red-400"
+                                        : "text-green-700 dark:text-green-400",
+                                )}
+                            >
+                                <span className="flex items-center gap-1.5">
+                                    Knelpunten
+                                </span>
+                            </td>
+                            {/* Crossing cell: total knelpunten across all fields */}
+                            <td
+                                className={cn(
+                                    stickyKnelpunt,
+                                    "text-center px-1 py-2 border-b-2 border-r border-border",
+                                )}
+                            >
+                                <span
                                     className={cn(
-                                        stickyCol,
-                                        "px-3 py-2 text-xs font-semibold text-red-700 dark:text-red-400 border-b-2 border-r border-border",
+                                        "inline-flex items-center justify-center w-7 h-7 rounded-full text-xs font-bold",
+                                        totalKnelpunten > 0
+                                            ? "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400"
+                                            : "bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400",
                                     )}
                                 >
-                                    <span className="flex items-center gap-1.5">
-                                        <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
-                                        Knelpunten
-                                    </span>
-                                </td>
-                                {indicatorLeafHeaders.map((header) => {
-                                    const count =
-                                        painpointCounts.get(header.column.id) ?? 0
-                                    return (
-                                        <td
-                                            key={header.id}
-                                            className={cn(tdBase, "border-b-2")}
-                                        >
-                                            {count > 0 ? (
-                                                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 text-xs font-bold">
-                                                    {count}
-                                                </span>
-                                            ) : null}
-                                        </td>
-                                    )
-                                })}
-                            </tr>
-                        )}
+                                    {totalKnelpunten}
+                                </span>
+                            </td>
+                            {indicatorLeafHeaders.map((header) => {
+                                const count =
+                                    painpointCounts.get(header.column.id) ?? 0
+                                return (
+                                    <td
+                                        key={header.id}
+                                        className={cn(tdBase, "border-b-2")}
+                                    >
+                                        {count > 0 ? (
+                                            <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-400 text-xs font-bold">
+                                                {count}
+                                            </span>
+                                        ) : null}
+                                    </td>
+                                )
+                            })}
+                        </tr>
 
                         {/* Data rows */}
                         {table.getRowModel().rows.map((row) => (
@@ -354,11 +481,24 @@ export function HeatmapTable({
                                             </td>
                                         )
                                     }
+                                    if (cell.column.id === "knelpunten") {
+                                        return (
+                                            <td
+                                                key={cell.id}
+                                                className={cn(
+                                                    stickyKnelpunt,
+                                                    "text-center px-1 py-2 border-b border-r border-border",
+                                                )}
+                                            >
+                                                {flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext(),
+                                                )}
+                                            </td>
+                                        )
+                                    }
                                     return (
-                                        <td
-                                            key={cell.id}
-                                            className={tdBase}
-                                        >
+                                        <td key={cell.id} className={tdBase}>
                                             {flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),

--- a/fdm-app/app/components/blocks/indicators/table.tsx
+++ b/fdm-app/app/components/blocks/indicators/table.tsx
@@ -85,8 +85,9 @@ export function HeatmapTable({
                       activeCategories.includes(i.category),
                   )
                 : INDICATORS
+        const scoreByBid = new Map(fieldScores.map((s) => [s.b_id, s]))
         return fields.map((field) => {
-            const fs = fieldScores.find((s) => s.b_id === field.b_id)
+            const fs = scoreByBid.get(field.b_id)
             const scores: FieldRow["scores"] = {}
             if (fs?.score) {
                 for (const ind of fs.score.indicators) {

--- a/fdm-app/app/components/blocks/sidebar/apps.tsx
+++ b/fdm-app/app/components/blocks/sidebar/apps.tsx
@@ -129,14 +129,24 @@ export function SidebarApps() {
                 <SidebarGroupContent>
                     <SidebarMenu>
                         <Collapsible
-                            defaultOpen={location.pathname.includes("/atlas") && !location.pathname.includes("/indicators")}
+                            defaultOpen={
+                                location.pathname.includes("/atlas") &&
+                                !location.pathname.includes("/indicators")
+                            }
                             className="group/collapsible"
                         >
                             <SidebarMenuItem>
                                 {atlasLink ? (
                                     <CollapsibleTrigger asChild>
                                         <SidebarMenuButton
-                                            isActive={location.pathname.includes("/atlas") && !location.pathname.includes("/indicators")}
+                                            isActive={
+                                                location.pathname.includes(
+                                                    "/atlas",
+                                                ) &&
+                                                !location.pathname.includes(
+                                                    "/indicators",
+                                                )
+                                            }
                                         >
                                             <MapIcon />
                                             <span>Atlas</span>
@@ -355,7 +365,9 @@ export function SidebarApps() {
                             )}
                         </SidebarMenuItem>
                         <Collapsible
-                            defaultOpen={location.pathname.includes("/indicators")}
+                            defaultOpen={location.pathname.includes(
+                                "/indicators",
+                            )}
                             className="group/collapsible"
                         >
                             <SidebarMenuItem>
@@ -398,12 +410,15 @@ export function SidebarApps() {
                                                 <SidebarMenuSubButton
                                                     asChild
                                                     isActive={
-                                                        !!indicatorsLink &&
-                                                        (location.pathname === indicatorsLink ||
-                                                         location.pathname === indicatorsLink + '/')
+                                                        location.pathname ===
+                                                            indicatorsLink ||
+                                                        location.pathname ===
+                                                            `${indicatorsLink}/`
                                                     }
                                                 >
-                                                    <NavLink to={indicatorsLink}>
+                                                    <NavLink
+                                                        to={indicatorsLink}
+                                                    >
                                                         <span>Tabel</span>
                                                     </NavLink>
                                                 </SidebarMenuSubButton>
@@ -417,7 +432,9 @@ export function SidebarApps() {
                                                         indicatorsKaartLink,
                                                     )}
                                                 >
-                                                    <NavLink to={indicatorsKaartLink}>
+                                                    <NavLink
+                                                        to={indicatorsKaartLink}
+                                                    >
                                                         <span>Kaart</span>
                                                     </NavLink>
                                                 </SidebarMenuSubButton>

--- a/fdm-app/app/components/blocks/sidebar/apps.tsx
+++ b/fdm-app/app/components/blocks/sidebar/apps.tsx
@@ -398,12 +398,9 @@ export function SidebarApps() {
                                                 <SidebarMenuSubButton
                                                     asChild
                                                     isActive={
-                                                        location.pathname.includes(
-                                                            indicatorsLink,
-                                                        ) &&
-                                                        !location.pathname.includes(
-                                                            "/atlas",
-                                                        )
+                                                        !!indicatorsLink &&
+                                                        (location.pathname === indicatorsLink ||
+                                                         location.pathname === indicatorsLink + '/')
                                                     }
                                                 >
                                                     <NavLink to={indicatorsLink}>

--- a/fdm-app/app/integrations/bln3.server.ts
+++ b/fdm-app/app/integrations/bln3.server.ts
@@ -11,17 +11,30 @@ import {
     collectInputForBln3Score,
     getBln3Score,
     type Bln3Score,
+    type Bln3ScoreCollectedInputs,
 } from "@nmi-agro/fdm-calculator"
-import { getFields, type Field, type PrincipalId, type Timeframe } from "@nmi-agro/fdm-core"
+import {
+    getFields,
+    getMeasures,
+    type Field,
+    type Measure,
+    type PrincipalId,
+    type Timeframe,
+} from "@nmi-agro/fdm-core"
 import { getNmiApiKey } from "~/integrations/nmi.server"
 import { fdm } from "~/lib/fdm.server"
 
-export type { Bln3Score }
+export type { Bln3Score, Bln3ScoreCollectedInputs }
 
 export type FieldBln3Score = {
     b_id: string
     score: Bln3Score | null
     error: string | null
+}
+
+export type FieldBln3Result = {
+    score: Bln3Score | null
+    inputs: Bln3ScoreCollectedInputs
 }
 
 /**
@@ -37,7 +50,7 @@ export async function getIndicatorsForField({
     principal_id: PrincipalId
     b_id: string
     timeframe?: Timeframe
-}): Promise<Bln3Score | null> {
+}): Promise<FieldBln3Result> {
     const nmiApiKey = getNmiApiKey()
 
     const inputs = await collectInputForBln3Score(
@@ -50,7 +63,7 @@ export async function getIndicatorsForField({
         ...inputs,
         nmiApiKey,
     })
-    return score
+    return { score, inputs }
 }
 
 /**
@@ -86,7 +99,7 @@ export async function getIndicatorsForFarm({
     return results.map((result, index) => {
         const b_id = fields[index].b_id
         if (result.status === "fulfilled") {
-            return { b_id, score: result.value, error: null }
+            return { b_id, score: result.value.score, error: null }
         }
         const errorMessage =
             result.reason instanceof Error
@@ -95,6 +108,23 @@ export async function getIndicatorsForFarm({
         console.error(`BLN3 score failed for field ${b_id}:`, errorMessage)
         return { b_id, score: null, error: errorMessage }
     })
+}
+
+/**
+ * Returns all measures applied to a single field, enriched with catalogue names.
+ * Used by the field-level indicator detail page to display active measures
+ * in the expandable indicator card panels.
+ */
+export async function getFieldMeasuresForIndicators({
+    principal_id,
+    b_id,
+    timeframe,
+}: {
+    principal_id: PrincipalId
+    b_id: string
+    timeframe?: Timeframe
+}): Promise<Measure[]> {
+    return getMeasures(fdm, principal_id, b_id, timeframe)
 }
 
 /**

--- a/fdm-app/app/lib/indicators.ts
+++ b/fdm-app/app/lib/indicators.ts
@@ -103,7 +103,7 @@ export const INDICATORS: IndicatorInfo[] = [
         id: "C_P",
         name: "Fosfaatbeschikbaarheid",
         description:
-            "De beschikbaarheid van fosfor vanuit de bodem voor het gewas",
+            "De beschikbaarheid van fosfaat vanuit de bodem voor het gewas",
         category: "Chemisch",
     },
     {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -1,0 +1,725 @@
+import {
+    getCultivations,
+    getField,
+    getFields,
+    getSoilParametersDescription,
+} from "@nmi-agro/fdm-core"
+import { simplify } from "@turf/simplify"
+import type { FeatureCollection, Geometry } from "geojson"
+import { lazy, Suspense, useEffect, useMemo, useState } from "react"
+import { Sprout } from "lucide-react"
+import { getCultivationColor } from "~/components/custom/cultivation-colors"
+import { Badge } from "~/components/ui/badge"
+import {
+    data,
+    type LoaderFunctionArgs,
+    type MetaFunction,
+    useLoaderData,
+    useParams,
+} from "react-router"
+import { CategoryFilter } from "~/components/blocks/indicators/category-filter"
+import { IndicatorCard } from "~/components/blocks/indicators/indicator-card"
+import { IndicatorRadarChart } from "~/components/blocks/indicators/radar-chart"
+import { FieldInputDialog } from "~/components/blocks/indicators/field-input-dialog"
+import { MeasuresToggle } from "~/components/blocks/indicators/measures-toggle"
+import { AggregationCard } from "~/components/blocks/indicators/aggregation-card"
+import { FarmTitle } from "~/components/blocks/farm/farm-title"
+import { Separator } from "~/components/ui/separator"
+import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectTrigger,
+    SelectValue,
+} from "~/components/ui/select"
+import {
+    getIndicatorsForField,
+    getFieldMeasuresForIndicators,
+} from "~/integrations/bln3.server"
+import {
+    getIndicatorsForFarm,
+    type FieldBln3Score,
+} from "~/integrations/bln3.server"
+import {
+    findHoofdteelt,
+    type CultivationForHoofdteelt,
+} from "@nmi-agro/fdm-calculator"
+import { getMapStyle } from "~/integrations/map"
+import { getSession } from "~/lib/auth.server"
+import { getTimeframe } from "~/lib/calendar"
+import { clientConfig } from "~/lib/config"
+import { handleLoaderError, reportError } from "~/lib/error"
+import { fdm } from "~/lib/fdm.server"
+import {
+    INDICATORS,
+    INDICATOR_CATEGORIES,
+    type IndicatorCategory,
+    OBI_INDICATOR_IDS,
+    BBWP_INDICATOR_IDS,
+    scoreToDisplay,
+} from "~/lib/indicators"
+
+const FieldMap = lazy(() => import("~/components/blocks/indicators/field-map"))
+
+// ── Map score selector options ─────────────────────────────────────────────
+
+type ScoreOption = { value: string; label: string }
+type ScoreOptionGroup = { group: string; options: ScoreOption[] }
+
+const MAP_SCORE_OPTION_GROUPS: ScoreOptionGroup[] = [
+    {
+        group: "Samenvatting",
+        options: [
+            { value: "avg", label: "Gemiddelde (alle indicatoren)" },
+            { value: "obi", label: "OBI – Open Bodem Index" },
+            { value: "bbwp", label: "BBWP – BedrijfsBodemWaterPlan" },
+        ],
+    },
+    ...INDICATOR_CATEGORIES.map((cat) => ({
+        group: cat,
+        options: INDICATORS.filter((i) => i.category === cat).map((i) => ({
+            value: i.id,
+            label: i.name,
+        })),
+    })),
+]
+
+function findScoreLabel(value: string): string {
+    for (const group of MAP_SCORE_OPTION_GROUPS) {
+        const opt = group.options.find((o) => o.value === value)
+        if (opt) return opt.label
+    }
+    return value
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+    const fieldName = data?.field?.b_name ?? "Perceel"
+    return [
+        {
+            title: `${fieldName} | Indicatoren | ${clientConfig.name}`,
+        },
+        {
+            name: "description",
+            content: `BLN3 bodemkwaliteitsindicatoren voor ${fieldName}.`,
+        },
+    ]
+}
+
+function computeFieldScores(
+    fs: FieldBln3Score | undefined,
+): Record<string, number> {
+    const result: Record<string, number> = { avg: -1, obi: -1, bbwp: -1 }
+    if (!fs?.score) return result
+
+    const indicators = fs.score.indicators
+
+    for (const ind of indicators) {
+        result[ind.indicator_id] = scoreToDisplay(ind.score)
+    }
+
+    const allVals = indicators
+        .map((i) => i.score)
+        .filter((s) => s != null && !Number.isNaN(s))
+    result.avg =
+        allVals.length > 0
+            ? Math.round(
+                  (allVals.reduce((a, b) => a + b, 0) / allVals.length) * 100,
+              )
+            : -1
+
+    const obiVals = OBI_INDICATOR_IDS.flatMap((id) => {
+        const r = indicators.find((i) => i.indicator_id === id)
+        return r ? [r.score] : []
+    })
+    result.obi =
+        obiVals.length > 0
+            ? Math.round(
+                  (obiVals.reduce((a, b) => a + b, 0) / obiVals.length) * 100,
+              )
+            : -1
+
+    const bbwpVals = BBWP_INDICATOR_IDS.flatMap((id) => {
+        const r = indicators.find((i) => i.indicator_id === id)
+        return r ? [r.score] : []
+    })
+    result.bbwp =
+        bbwpVals.length > 0
+            ? Math.round(
+                  (bbwpVals.reduce((a, b) => a + b, 0) / bbwpVals.length) * 100,
+              )
+            : -1
+
+    return result
+}
+
+export async function loader({ request, params }: LoaderFunctionArgs) {
+    try {
+        const b_id_farm = params.b_id_farm
+        const b_id = params.b_id
+        const calendar = params.calendar
+        if (!b_id_farm) {
+            throw data("invalid: b_id_farm", {
+                status: 400,
+                statusText: "invalid: b_id_farm",
+            })
+        }
+        if (!b_id) {
+            throw data("invalid: b_id", {
+                status: 400,
+                statusText: "invalid: b_id",
+            })
+        }
+
+        const session = await getSession(request)
+        const timeframe = getTimeframe(params)
+
+        // Load in parallel: current field, all fields, BLN3 score + inputs, active measures, cultivations
+        // Cultivations are fetched without timeframe to cover multi-year history (for display)
+        const [field, fields, bln3Result, fieldMeasures, cultivations] =
+            await Promise.all([
+                getField(fdm, session.principal_id, b_id),
+                getFields(fdm, session.principal_id, b_id_farm, timeframe),
+                getIndicatorsForField({
+                    principal_id: session.principal_id,
+                    b_id,
+                    timeframe,
+                }),
+                getFieldMeasuresForIndicators({
+                    principal_id: session.principal_id,
+                    b_id,
+                    timeframe,
+                }),
+                getCultivations(fdm, session.principal_id, b_id),
+            ])
+        const fieldScore = bln3Result.score
+        const bln3Inputs = bln3Result.inputs
+
+        if (!field) {
+            throw data("not found: b_id", {
+                status: 404,
+                statusText: "not found: b_id",
+            })
+        }
+
+        // Also fetch all farm scores (for map colouring)
+        const farmScores = await getIndicatorsForFarm({
+            principal_id: session.principal_id,
+            b_id_farm,
+            timeframe,
+            preloadedFields: fields,
+        })
+
+        for (const result of farmScores) {
+            if (result.error) {
+                reportError(
+                    new Error(
+                        `BLN3 score failed for field ${result.b_id}: ${result.error}`,
+                    ),
+                )
+            }
+        }
+
+        // Build GeoJSON for mini map (all farm fields, coloured by avg score by default)
+        const fieldsGeoJSON: FeatureCollection = {
+            type: "FeatureCollection",
+            features: fields.map((f) => {
+                const fs = farmScores.find((s) => s.b_id === f.b_id)
+                const scores = computeFieldScores(fs)
+                return {
+                    type: "Feature" as const,
+                    properties: {
+                        b_id: f.b_id,
+                        b_name: f.b_name ?? null,
+                        b_area: f.b_area ?? null,
+                        avgScore: scores.avg, // kept for backward compat
+                        ...scores,
+                    },
+                    geometry: simplify(f.b_geometry as Geometry, {
+                        tolerance: 0.00001,
+                        highQuality: true,
+                    }),
+                }
+            }),
+        }
+
+        // GeoJSON for the highlighted (selected) field
+        const selectedFeature = fieldsGeoJSON.features.find(
+            (f) => f.properties?.b_id === b_id,
+        )
+        const selectedFieldGeoJSON: FeatureCollection = {
+            type: "FeatureCollection",
+            features: selectedFeature ? [selectedFeature] : [],
+        }
+
+        // Extract soil inputs already collected by collectInputForBln3Score.
+        // Use getSoilParametersDescription for proper Dutch names and units.
+        const soilParamLabel = new Map(
+            getSoilParametersDescription().map((p) => [
+                p.parameter as string,
+                { name: p.name, unit: p.unit ?? null },
+            ]),
+        )
+        const soilMeasurements = Object.entries(bln3Inputs)
+            .filter(
+                ([key, value]) =>
+                    key.startsWith("a_") &&
+                    key !== "a_lat" &&
+                    key !== "a_lon" &&
+                    typeof value === "number",
+            )
+            .map(([key, value]) => {
+                const meta = soilParamLabel.get(key)
+                return {
+                    key,
+                    label:
+                        meta?.name ?? key.replace(/^a_/, "").replace(/_/g, " "),
+                    unit: meta?.unit ?? null,
+                    value: value as number,
+                }
+            })
+
+        // Derive the current cultivation (FarmTitle badge) using the May 15th point check.
+        const currentCultivation = getDefaultCultivation(cultivations, calendar)
+
+        // Build cultivation display list using findHoofdteelt (May 15–July 15 duration
+        // window) — exactly consistent with what is submitted to the BLN3 API.
+        // Only show years within the range of known cultivation data; gaps get groene braak.
+        const maxCalendarYear = parseInt(calendar)
+        const cultivationsForHoofdteelt: CultivationForHoofdteelt[] =
+            cultivations.map((c) => ({
+                b_lu_catalogue: c.b_lu_catalogue,
+                b_lu_start: c.b_lu_start ?? null,
+                b_lu_end: c.b_lu_end ?? null,
+            }))
+        const minCalendarYear = cultivations.reduce((min, c) => {
+            const y = c.b_lu_start?.getFullYear()
+            return y !== undefined && y < min ? y : min
+        }, maxCalendarYear)
+        const cultivationSummaries: Array<{
+            name: string
+            year: number
+            croprotation: string | null
+        }> = []
+        for (
+            let year = maxCalendarYear;
+            year >= minCalendarYear;
+            year--
+        ) {
+            const catalogue = findHoofdteelt(cultivationsForHoofdteelt, year)
+            const match = cultivations.find(
+                (c) => c.b_lu_catalogue === catalogue,
+            )
+            cultivationSummaries.push({
+                name: match?.b_lu_name ?? catalogue,
+                year,
+                croprotation: match?.b_lu_croprotation ?? null,
+            })
+        }
+
+        return {
+            field,
+            fieldScore,
+            fieldMeasures,
+            fieldsGeoJSON,
+            selectedFieldGeoJSON,
+            mapStyle: getMapStyle("satellite"),
+            currentCultivationName:
+                currentCultivation?.b_lu_name ?? null,
+            currentCultivationCropRotation:
+                currentCultivation?.b_lu_croprotation ?? null,
+            cultivationSummaries,
+            soilData: {
+                soilType: bln3Inputs.b_soiltype_agr ?? null,
+                gwlClass: bln3Inputs.b_gwl_class ?? null,
+                measurements: soilMeasurements,
+            },
+            fieldList: fields.map((f) => ({
+                b_id: f.b_id,
+                b_name: f.b_name ?? null,
+            })),
+        }
+    } catch (error) {
+        const normalized = handleLoaderError(error)
+        throw normalized ?? error
+    }
+}
+
+const SESSION_KEY_CATEGORY = "bln3_field_categories"
+const SESSION_KEY_MEASURES = "bln3_field_measures_toggle"
+const SESSION_KEY_MAP_SCORE = "bln3_map_score"
+
+function readSessionCategories(): IndicatorCategory[] {
+    if (typeof window === "undefined") return []
+    try {
+        const stored = sessionStorage.getItem(SESSION_KEY_CATEGORY)
+        return stored ? (JSON.parse(stored) as IndicatorCategory[]) : []
+    } catch {
+        return []
+    }
+}
+
+function readSessionMeasures(): boolean {
+    if (typeof window === "undefined") return true
+    try {
+        const stored = sessionStorage.getItem(SESSION_KEY_MEASURES)
+        return stored === null ? true : stored === "true"
+    } catch {
+        return true
+    }
+}
+
+function readSessionMapScore(): string {
+    if (typeof window === "undefined") return "avg"
+    try {
+        return sessionStorage.getItem(SESSION_KEY_MAP_SCORE) ?? "avg"
+    } catch {
+        return "avg"
+    }
+}
+
+export default function IndicatorsFieldDetail() {
+    const {
+        field,
+        fieldScore,
+        fieldMeasures,
+        fieldsGeoJSON,
+        selectedFieldGeoJSON,
+        mapStyle,
+        currentCultivationName,
+        currentCultivationCropRotation,
+        cultivationSummaries,
+        soilData,
+    } = useLoaderData<typeof loader>()
+    const { b_id_farm, calendar, b_id } = useParams()
+
+    // Restore filter state from sessionStorage
+    const [activeCategories, setActiveCategories] = useState<
+        IndicatorCategory[]
+    >(() => readSessionCategories())
+    const [withMeasures, setWithMeasures] = useState<boolean>(() =>
+        readSessionMeasures(),
+    )
+    const [mapScoreKey, setMapScoreKey] = useState<string>(() =>
+        readSessionMapScore(),
+    )
+
+    // Persist to sessionStorage on change
+    useEffect(() => {
+        try {
+            sessionStorage.setItem(
+                SESSION_KEY_CATEGORY,
+                JSON.stringify(activeCategories),
+            )
+        } catch {}
+    }, [activeCategories])
+
+    useEffect(() => {
+        try {
+            sessionStorage.setItem(SESSION_KEY_MEASURES, String(withMeasures))
+        } catch {}
+    }, [withMeasures])
+
+    useEffect(() => {
+        try {
+            sessionStorage.setItem(SESSION_KEY_MAP_SCORE, mapScoreKey)
+        } catch {}
+    }, [mapScoreKey])
+
+    const handleCategoryToggle = (category: IndicatorCategory) => {
+        setActiveCategories((prev) =>
+            prev.includes(category)
+                ? prev.filter((c) => c !== category)
+                : [...prev, category],
+        )
+    }
+
+    const handleCategoryAll = () => setActiveCategories([])
+    const handleMeasuresToggle = (value: boolean) => setWithMeasures(value)
+
+    // Filter indicators by active category
+    const visibleIndicatorInfos = useMemo(
+        () =>
+            activeCategories.length === 0
+                ? INDICATORS
+                : INDICATORS.filter((i) =>
+                      activeCategories.includes(i.category),
+                  ),
+        [activeCategories],
+    )
+
+    // Sort indicator results: red (< 40) → yellow (40–69) → green (≥ 70), then alphabetical
+    const sortedIndicatorResults = useMemo(() => {
+        if (!fieldScore) return []
+
+        const results = visibleIndicatorInfos.flatMap((info) => {
+            const result = fieldScore.indicators.find(
+                (r) => r.indicator_id === info.id,
+            )
+            if (!result) return []
+            return [{ info, result }]
+        })
+
+        return results.sort((a, b) => {
+            const scoreA = scoreToDisplay(
+                withMeasures ? a.result.score : a.result.index,
+            )
+            const scoreB = scoreToDisplay(
+                withMeasures ? b.result.score : b.result.index,
+            )
+            const tierOrder = (s: number) => (s < 40 ? 0 : s < 70 ? 1 : 2)
+            const tierDiff = tierOrder(scoreA) - tierOrder(scoreB)
+            if (tierDiff !== 0) return tierDiff
+            return a.info.id.localeCompare(b.info.id)
+        })
+    }, [fieldScore, visibleIndicatorInfos, withMeasures])
+
+    // Farm aggregation scores for OBI / BBWP
+    const obiScore = useMemo(() => {
+        if (!fieldScore) return null
+        const scores = OBI_INDICATOR_IDS.flatMap((id) => {
+            const r = fieldScore.indicators.find((i) => i.indicator_id === id)
+            return r ? [r.score] : []
+        })
+        return scores.length > 0
+            ? scores.reduce((a, b) => a + b, 0) / scores.length
+            : null
+    }, [fieldScore])
+
+    const obiIndex = useMemo(() => {
+        if (!fieldScore) return null
+        const scores = OBI_INDICATOR_IDS.flatMap((id) => {
+            const r = fieldScore.indicators.find((i) => i.indicator_id === id)
+            return r ? [r.index] : []
+        })
+        return scores.length > 0
+            ? scores.reduce((a, b) => a + b, 0) / scores.length
+            : null
+    }, [fieldScore])
+
+    const bbwpScore = useMemo(() => {
+        if (!fieldScore) return null
+        const scores = BBWP_INDICATOR_IDS.flatMap((id) => {
+            const r = fieldScore.indicators.find((i) => i.indicator_id === id)
+            return r ? [r.score] : []
+        })
+        return scores.length > 0
+            ? scores.reduce((a, b) => a + b, 0) / scores.length
+            : null
+    }, [fieldScore])
+
+    const bbwpIndex = useMemo(() => {
+        if (!fieldScore) return null
+        const scores = BBWP_INDICATOR_IDS.flatMap((id) => {
+            const r = fieldScore.indicators.find((i) => i.indicator_id === id)
+            return r ? [r.index] : []
+        })
+        return scores.length > 0
+            ? scores.reduce((a, b) => a + b, 0) / scores.length
+            : null
+    }, [fieldScore])
+
+    const measuresHref = `/farm/${b_id_farm}/${calendar}/measures/${b_id}`
+    const basePath = `/farm/${b_id_farm}/${calendar}/indicators`
+
+    return (
+        <>
+            <FarmTitle
+                title={field.b_name ?? `Perceel ${b_id}`}
+                description={
+                    currentCultivationName ?? "Geen teelt geregistreerd"
+                }
+                descriptionNode={
+                    currentCultivationName ? (
+                        <span className="flex items-center gap-1.5 mt-0.5">
+                            <Badge
+                                style={{
+                                    backgroundColor: getCultivationColor(
+                                        currentCultivationCropRotation ??
+                                            undefined,
+                                    ),
+                                }}
+                                className="text-white gap-1"
+                                variant="default"
+                            >
+                                {currentCultivationName}
+                            </Badge>
+                        </span>
+                    ) : (
+                        <p className="text-sm text-muted-foreground">
+                            Geen teelt geregistreerd
+                        </p>
+                    )
+                }
+            />
+
+            <div className="px-4 sm:px-6 lg:px-8 pb-16">
+                <div className="flex flex-col lg:flex-row gap-6">
+                    {/* ── Main content column ──────────────────────────── */}
+                    <div className="flex-1 min-w-0 space-y-4">
+                        {/* Aggregation cards + input dialog */}
+                        <div className="flex items-start justify-between gap-4 flex-wrap">
+                            {(obiScore !== null || bbwpScore !== null) && (
+                                <div className="flex flex-wrap gap-3">
+                                    {obiScore !== null && (
+                                        <AggregationCard
+                                            label="OBI"
+                                            name="Open Bodem Index"
+                                            score01={obiScore}
+                                            index01={obiIndex}
+                                            showIndex={!withMeasures}
+                                        />
+                                    )}
+                                    {bbwpScore !== null && (
+                                        <AggregationCard
+                                            label="BBWP"
+                                            name="BedrijfsBodemWaterPlan"
+                                            score01={bbwpScore}
+                                            index01={bbwpIndex}
+                                            showIndex={!withMeasures}
+                                        />
+                                    )}
+                                </div>
+                            )}
+                            <FieldInputDialog
+                                cultivations={cultivationSummaries}
+                                fieldMeasures={fieldMeasures as any}
+                                soilData={soilData}
+                            />
+                        </div>
+
+                        <Separator />
+
+                        {/* Filters */}
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                            <CategoryFilter
+                                activeCategories={activeCategories}
+                                onToggle={handleCategoryToggle}
+                                onClearAll={handleCategoryAll}
+                            />
+                            <MeasuresToggle
+                                withMeasures={withMeasures}
+                                onToggle={handleMeasuresToggle}
+                            />
+                        </div>
+
+                        {/* Radar chart — always shows all indicators */}
+                        {fieldScore && fieldScore.indicators.length > 0 && (
+                            <div className="rounded-lg border bg-card p-4">
+                                <p className="text-sm font-medium mb-1">
+                                    Indicatorenweb
+                                </p>
+                                <p className="text-xs text-muted-foreground mb-3">
+                                    Stippellijn = perceel, doorgetrokken = met
+                                    maatregelen. Labels gekleurd per categorie.
+                                </p>
+                                <IndicatorRadarChart
+                                    indicators={fieldScore.indicators}
+                                    indicatorInfos={INDICATORS}
+                                />
+                            </div>
+                        )}
+
+                        {/* No score state */}
+                        {!fieldScore && (
+                            <div className="rounded-lg border bg-muted/30 p-8 text-center text-sm text-muted-foreground">
+                                <p className="font-medium">
+                                    Geen indicatoren beschikbaar
+                                </p>
+                                <p className="mt-1">
+                                    Er is geen bodemanalyse beschikbaar voor dit
+                                    perceel, of de berekening is mislukt.
+                                </p>
+                            </div>
+                        )}
+
+                        {/* Indicator cards */}
+                        {sortedIndicatorResults.length > 0 && (
+                            <div className="space-y-2">
+                                {sortedIndicatorResults.map(
+                                    ({ info, result }) => (
+                                        <IndicatorCard
+                                            key={info.id}
+                                            info={info}
+                                            result={result}
+                                            fieldMeasures={fieldMeasures as any}
+                                            measuresHref={measuresHref}
+                                            showIndex={!withMeasures}
+                                        />
+                                    ),
+                                )}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* ── Map — right on desktop, below on mobile ──────── */}
+                    <aside className="w-full lg:w-72 xl:w-80 shrink-0">
+                        <div className="relative h-64 sm:h-80 lg:h-[560px] lg:sticky lg:top-4 rounded-lg overflow-hidden border">
+                            {/* Score selector overlaid on top of the map */}
+                            <div className="absolute top-2 right-2 z-10">
+                                <Select
+                                    value={mapScoreKey}
+                                    onValueChange={setMapScoreKey}
+                                >
+                                    <SelectTrigger className="w-48 text-xs h-7 bg-background/90 backdrop-blur-sm shadow-sm">
+                                        <SelectValue placeholder="Kies score" />
+                                    </SelectTrigger>
+                                    <SelectContent align="end">
+                                        {MAP_SCORE_OPTION_GROUPS.map(
+                                            (group) => (
+                                                <SelectGroup key={group.group}>
+                                                    <SelectLabel className="text-xs">
+                                                        {group.group}
+                                                    </SelectLabel>
+                                                    {group.options.map(
+                                                        (opt) => (
+                                                            <SelectItem
+                                                                key={opt.value}
+                                                                value={
+                                                                    opt.value
+                                                                }
+                                                                className="text-xs"
+                                                            >
+                                                                {opt.label}
+                                                            </SelectItem>
+                                                        ),
+                                                    )}
+                                                </SelectGroup>
+                                            ),
+                                        )}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <Suspense
+                                fallback={
+                                    <div className="h-full bg-muted animate-pulse" />
+                                }
+                            >
+                                <FieldMap
+                                    fieldsGeoJSON={
+                                        fieldsGeoJSON as FeatureCollection
+                                    }
+                                    selectedFieldGeoJSON={
+                                        selectedFieldGeoJSON as FeatureCollection
+                                    }
+                                    mapStyle={mapStyle}
+                                    basePath={basePath}
+                                    scoreKey={mapScoreKey}
+                                    scoreLabel={findScoreLabel(mapScoreKey)}
+                                    height="100%"
+                                />
+                            </Suspense>
+                        </div>
+                        <p className="mt-2 px-1 text-[11px] text-muted-foreground">
+                            Percelen gekleurd op gekozen score. Klik om te
+                            wisselen van perceel.
+                        </p>
+                    </aside>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -7,7 +7,6 @@ import {
 import { simplify } from "@turf/simplify"
 import type { FeatureCollection, Geometry } from "geojson"
 import { lazy, Suspense, useEffect, useMemo, useState } from "react"
-import { Sprout } from "lucide-react"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -171,6 +171,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 statusText: "invalid: b_id",
             })
         }
+        const calendarYear = Number(calendar)
+        if (!Number.isFinite(calendarYear)) {
+            throw data("invalid: calendar", {
+                status: 400,
+                statusText: "invalid: calendar",
+            })
+        }
 
         const session = await getSession(request)
         const timeframe = getTimeframe(params)
@@ -286,7 +293,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // Build cultivation display list using findHoofdteelt (May 15–July 15 duration
         // window) — exactly consistent with what is submitted to the BLN3 API.
         // Only show years within the range of known cultivation data; gaps get groene braak.
-        const maxCalendarYear = parseInt(calendar)
+        const maxCalendarYear = calendarYear
         const cultivationsForHoofdteelt: CultivationForHoofdteelt[] =
             cultivations.map((c) => ({
                 b_lu_catalogue: c.b_lu_catalogue,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -4,6 +4,7 @@ import {
     getFields,
     getSoilParametersDescription,
 } from "@nmi-agro/fdm-core"
+import { getCultivationCatalogue } from "@nmi-agro/fdm-data"
 import { simplify } from "@turf/simplify"
 import type { FeatureCollection, Geometry } from "geojson"
 import { lazy, Suspense, useEffect, useMemo, useState } from "react"
@@ -182,9 +183,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         const session = await getSession(request)
         const timeframe = getTimeframe(params)
 
-        // Load in parallel: current field, all fields, BLN3 score + inputs, active measures, cultivations
+        // Load in parallel: current field, all fields, BLN3 score + inputs, active measures, cultivations, BRP catalogue
         // Cultivations are fetched without timeframe to cover multi-year history (for display)
-        const [field, fields, bln3Result, fieldMeasures, cultivations] =
+        const [field, fields, bln3Result, fieldMeasures, cultivations, brpCatalogue] =
             await Promise.all([
                 getField(fdm, session.principal_id, b_id),
                 getFields(fdm, session.principal_id, b_id_farm, timeframe),
@@ -199,6 +200,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                     timeframe,
                 }),
                 getCultivations(fdm, session.principal_id, b_id),
+                getCultivationCatalogue("brp"),
             ])
         const fieldScore = bln3Result.score
         const bln3Inputs = bln3Result.inputs
@@ -304,6 +306,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             const y = c.b_lu_start?.getFullYear()
             return y !== undefined && y < min ? y : min
         }, maxCalendarYear)
+
+        // Build a lookup map from the BRP catalogue for fallback name resolution
+        // (e.g. nl_6794 = "groene braak, spontane opkomst" when no field record exists).
+        const brpNameByCode = new Map(
+            brpCatalogue.map((item) => [item.b_lu_catalogue, item.b_lu_name]),
+        )
+
         const cultivationSummaries: Array<{
             name: string
             year: number
@@ -319,7 +328,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 (c) => c.b_lu_catalogue === catalogue,
             )
             cultivationSummaries.push({
-                name: match?.b_lu_name ?? catalogue,
+                name: match?.b_lu_name ?? brpNameByCode.get(catalogue) ?? catalogue,
                 year,
                 croprotation: match?.b_lu_croprotation ?? null,
             })
@@ -619,7 +628,7 @@ export default function IndicatorsFieldDetail() {
                                 </p>
                                 <p className="text-xs text-muted-foreground mb-3">
                                     Stippellijn = perceel, doorgetrokken = met
-                                    maatregelen. Labels gekleurd per categorie.
+                                    maatregelen.
                                 </p>
                                 <IndicatorRadarChart
                                     indicators={fieldScore.indicators}

--- a/fdm-calculator/src/bln3/input.test.ts
+++ b/fdm-calculator/src/bln3/input.test.ts
@@ -471,12 +471,18 @@ describe("collectInputForBln3Score", () => {
             { start: new Date("2026-01-01"), end: new Date("2026-12-31") },
         )
 
-        // 2024 excluded (grass starts Oct 2024, after the May-July window)
-        // 2025 and 2026 included (grass covers the full May-July window)
+        // Range is 2024–2026 (earliest b_lu_start is Oct 2024 → minYear = 2024)
+        // 2026 and 2025: grass covers the full May-July window → b_lu_brp 265
+        // 2024: grass starts Oct 2024, after the window → groene braak → b_lu_brp 6794
         expect(result.cultivations).toEqual([
             { b_lu_brp: 265, b_lu_year: 2026 },
             { b_lu_brp: 265, b_lu_year: 2025 },
+            { b_lu_brp: 6794, b_lu_year: 2024 },
         ])
-        expect(result.cultivations?.find((c) => c.b_lu_year === 2024)).toBeUndefined()
+        expect(
+            result.cultivations?.find(
+                (c) => c.b_lu_year === 2024 && c.b_lu_brp === 265,
+            ),
+        ).toBeUndefined()
     })
 })

--- a/fdm-calculator/src/bln3/input.test.ts
+++ b/fdm-calculator/src/bln3/input.test.ts
@@ -486,3 +486,56 @@ describe("collectInputForBln3Score", () => {
         ).toBeUndefined()
     })
 })
+
+import { findHoofdteelt } from "../shared/hoofdteelt"
+
+describe("findHoofdteelt boundary and tie-break cases", () => {
+    it("counts a cultivation that spans exactly May 15–July 15 as in-window", () => {
+        const result = findHoofdteelt(
+            [
+                {
+                    b_lu_catalogue: "nl_265",
+                    b_lu_start: new Date("2024-05-15"),
+                    b_lu_end: new Date("2024-07-15"),
+                },
+            ],
+            2024,
+        )
+        expect(result).toBe("nl_265")
+    })
+
+    it("excludes a cultivation that starts exactly on July 15 (zero-length overlap)", () => {
+        // effectiveStart === effectiveEnd → condition effectiveEnd > effectiveStart is false
+        const result = findHoofdteelt(
+            [
+                {
+                    b_lu_catalogue: "nl_265",
+                    b_lu_start: new Date("2024-07-15"),
+                    b_lu_end: null,
+                },
+            ],
+            2024,
+        )
+        expect(result).toBe("nl_6794") // groene braak
+    })
+
+    it("resolves a tie by choosing the alphabetically-first b_lu_catalogue", () => {
+        // Both cultivations cover the exact same May 15–July 15 window
+        const result = findHoofdteelt(
+            [
+                {
+                    b_lu_catalogue: "nl_999",
+                    b_lu_start: new Date("2024-05-15"),
+                    b_lu_end: new Date("2024-07-15"),
+                },
+                {
+                    b_lu_catalogue: "nl_100",
+                    b_lu_start: new Date("2024-05-15"),
+                    b_lu_end: new Date("2024-07-15"),
+                },
+            ],
+            2024,
+        )
+        expect(result).toBe("nl_100")
+    })
+})

--- a/fdm-calculator/src/bln3/input.test.ts
+++ b/fdm-calculator/src/bln3/input.test.ts
@@ -145,7 +145,7 @@ describe("collectInputForBln3Score", () => {
         expect(result.b_gwl_class).toBe("IIb")
     })
 
-    it("should include numeric a_* fields from the most recent soil analysis", async () => {
+    it("should include only BLN3-relevant soil analysis fields (a_p_cc, a_p_al, a_p_wa)", async () => {
         mockedGetField.mockResolvedValue(mockField)
         mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
         mockedGetCultivations.mockResolvedValue([])
@@ -157,13 +157,17 @@ describe("collectInputForBln3Score", () => {
             b_id,
         )
 
-        expect(result.a_som_loi).toBe(4.5)
-        expect(result.a_clay_mi).toBe(10)
         expect(result.a_p_cc).toBe(1.2)
-        expect(result.a_n_rt).toBe(2500)
+        expect(result.a_p_al).toBe(42)
+        // a_p_wa is not in mockSoilAnalysis so should be absent
+        expect(result).not.toHaveProperty("a_p_wa")
+        // Extra soil params that are NOT part of the BLN3 API should be excluded
+        expect(result).not.toHaveProperty("a_som_loi")
+        expect(result).not.toHaveProperty("a_clay_mi")
+        expect(result).not.toHaveProperty("a_n_rt")
     })
 
-    it("should exclude non-numeric fields from soil analysis (metadata and integers used for depth)", async () => {
+    it("should exclude non-numeric and metadata fields from soil analysis", async () => {
         mockedGetField.mockResolvedValue(mockField)
         mockedGetSoilAnalyses.mockResolvedValue([mockSoilAnalysis])
         mockedGetCultivations.mockResolvedValue([])
@@ -185,7 +189,7 @@ describe("collectInputForBln3Score", () => {
             ...mockSoilAnalysis,
             a_id: "sa-old",
             b_soiltype_agr: "veen",
-            a_som_loi: 99,
+            a_p_cc: 99,
         }
         mockedGetField.mockResolvedValue(mockField)
         // getSoilAnalyses returns most-recent first (DESC by sampling date)
@@ -203,7 +207,7 @@ describe("collectInputForBln3Score", () => {
         )
 
         expect(result.b_soiltype_agr).toBe("dekzand") // from first (mockSoilAnalysis)
-        expect(result.a_som_loi).toBe(4.5)
+        expect(result.a_p_cc).toBe(1.2) // from first (mockSoilAnalysis)
     })
 
     it("should omit b_soiltype_agr and b_gwl_class when no soil analyses exist", async () => {
@@ -402,7 +406,9 @@ describe("collectInputForBln3Score", () => {
         expect(result.a_lon).toBe(5.2)
         expect(result.b_soiltype_agr).toBe("dekzand")
         expect(result.b_gwl_class).toBe("IIb")
-        expect(result.a_som_loi).toBe(4.5)
+        expect(result.a_p_cc).toBe(1.2)
+        expect(result.a_p_al).toBe(42)
+        expect(result).not.toHaveProperty("a_som_loi")
         expect(result.cultivations).toEqual([
             { b_lu_brp: 266, b_lu_year: 2024 },
         ])

--- a/fdm-calculator/src/bln3/input.test.ts
+++ b/fdm-calculator/src/bln3/input.test.ts
@@ -258,7 +258,7 @@ describe("collectInputForBln3Score", () => {
         expect(result.cultivations).toBeUndefined()
     })
 
-    it("should skip cultivations where b_lu_start is null and no timeframe is provided", async () => {
+    it("should skip cultivations where b_lu_start is null", async () => {
         const noStart: Cultivation = { ...mockCultivation, b_lu_start: null }
         mockedGetField.mockResolvedValue(mockField)
         mockedGetSoilAnalyses.mockResolvedValue([])
@@ -274,7 +274,7 @@ describe("collectInputForBln3Score", () => {
         expect(result.cultivations).toBeUndefined()
     })
 
-    it("should use timeframe.end year as fallback when cultivation b_lu_start is null", async () => {
+    it("should skip cultivations where b_lu_start is null even when timeframe is provided", async () => {
         const noStart: Cultivation = { ...mockCultivation, b_lu_start: null }
         mockedGetField.mockResolvedValue(mockField)
         mockedGetSoilAnalyses.mockResolvedValue([])
@@ -288,9 +288,7 @@ describe("collectInputForBln3Score", () => {
             timeframe,
         )
 
-        expect(result.cultivations).toEqual([
-            { b_lu_brp: 266, b_lu_year: 2024 },
-        ])
+        expect(result.cultivations).toBeUndefined()
     })
 
     it("should omit cultivations key entirely when no valid cultivations exist", async () => {
@@ -424,7 +422,7 @@ describe("collectInputForBln3Score", () => {
         )
     })
 
-    it("should pass the timeframe to all fdm-core calls", async () => {
+    it("should pass the timeframe to soil and measures calls but NOT to cultivations", async () => {
         mockedGetField.mockResolvedValue(mockField)
         mockedGetSoilAnalyses.mockResolvedValue([])
         mockedGetCultivations.mockResolvedValue([])
@@ -438,11 +436,11 @@ describe("collectInputForBln3Score", () => {
             b_id,
             timeframe,
         )
+        // Cultivations are fetched without timeframe to get the full history
         expect(mockedGetCultivations).toHaveBeenCalledWith(
             mockFdm,
             principal_id,
             b_id,
-            timeframe,
         )
         expect(mockedGetMeasures).toHaveBeenCalledWith(
             mockFdm,
@@ -450,5 +448,35 @@ describe("collectInputForBln3Score", () => {
             b_id,
             timeframe,
         )
+    })
+
+    it("should assign years using the May 15–July 15 hoofdteelt rule, not b_lu_start year", async () => {
+        // Grass sown Oct 15, 2024 — NOT the hoofdteelt for 2024 (sown after the window),
+        // but IS the hoofdteelt for 2025 and 2026.
+        const grass: Cultivation = {
+            ...mockCultivation,
+            b_lu_catalogue: "nl_265",
+            b_lu_start: new Date("2024-10-15"),
+            b_lu_end: null,
+        }
+        mockedGetField.mockResolvedValue(mockField)
+        mockedGetSoilAnalyses.mockResolvedValue([])
+        mockedGetCultivations.mockResolvedValue([grass])
+        mockedGetMeasures.mockResolvedValue([])
+
+        const result = await collectInputForBln3Score(
+            mockFdm,
+            principal_id,
+            b_id,
+            { start: new Date("2026-01-01"), end: new Date("2026-12-31") },
+        )
+
+        // 2024 excluded (grass starts Oct 2024, after the May-July window)
+        // 2025 and 2026 included (grass covers the full May-July window)
+        expect(result.cultivations).toEqual([
+            { b_lu_brp: 265, b_lu_year: 2026 },
+            { b_lu_brp: 265, b_lu_year: 2025 },
+        ])
+        expect(result.cultivations?.find((c) => c.b_lu_year === 2024)).toBeUndefined()
     })
 })

--- a/fdm-calculator/src/bln3/input.ts
+++ b/fdm-calculator/src/bln3/input.ts
@@ -15,6 +15,7 @@ import type {
     Bln3Measure,
     Bln3ScoreCollectedInputs,
 } from "./types"
+import { findHoofdteelt, findHoofdteeltBrpCode } from "../shared/hoofdteelt"
 
 /**
  * Collects all field data needed for a BLN3 score calculation from the FDM database.
@@ -38,11 +39,12 @@ export async function collectInputForBln3Score(
     timeframe?: Timeframe,
 ): Promise<Bln3ScoreCollectedInputs> {
     try {
+        // Fetch all cultivations without timeframe to cover multi-year history
         const [field, soilAnalyses, cultivations, measures] = await Promise.all(
             [
                 getField(fdm, principal_id, b_id),
                 getSoilAnalyses(fdm, principal_id, b_id, timeframe),
-                getCultivations(fdm, principal_id, b_id, timeframe),
+                getCultivations(fdm, principal_id, b_id),
                 getMeasures(fdm, principal_id, b_id, timeframe),
             ],
         )
@@ -61,19 +63,23 @@ export async function collectInputForBln3Score(
             }
         }
 
-        // Map cultivations: "nl_266" → { b_lu_brp: 266, b_lu_year: 2025 }
-        const fallbackYear = timeframe?.end?.getFullYear()
-        const bln3Cultivations: Bln3Cultivation[] = cultivations
-            .map((c) => {
-                const match = /^nl_(\d+)$/.exec(c.b_lu_catalogue)
-                if (!match) return null
-                const year = c.b_lu_start?.getFullYear() ?? fallbackYear
-                if (year === undefined) return null
-                return { b_lu_brp: Number(match[1]), b_lu_year: year }
-            })
-            .filter((c): c is Bln3Cultivation => c !== null)
+        // Build cultivation history using the Dutch "hoofdteelt" rule (May 15–July 15).
+        // Fetching without timeframe gives the full history needed for multi-year expansion.
+        const maxYear =
+            timeframe?.end?.getFullYear() ?? new Date().getFullYear()
+        const HISTORY_YEARS = 10
+        const bln3Cultivations: Bln3Cultivation[] = []
+
+        for (let year = maxYear; year >= maxYear - HISTORY_YEARS; year--) {
+            const hoofdteelt = findHoofdteelt(cultivations, year)
+            const match = /^nl_(\d+)$/.exec(hoofdteelt)
+            const b_lu_brp = match ? Number(match[1]) : null
+            if (b_lu_brp === null) continue
+            bln3Cultivations.push({ b_lu_brp: b_lu_brp, b_lu_year: year })
+        }
 
         // Map measures: "bln_BM3" → { measure_id: "BM3", year: 2025 }
+        const fallbackYear = timeframe?.end?.getFullYear()
         const bln3Measures: Bln3Measure[] = measures
             .filter((m) => m.m_id.startsWith("bln_"))
             .map((m) => {
@@ -89,10 +95,10 @@ export async function collectInputForBln3Score(
         return {
             a_lat,
             a_lon,
-            b_soiltype_agr:
-                (latestAnalysis?.b_soiltype_agr ?? undefined) as Bln3ScoreCollectedInputs["b_soiltype_agr"],
-            b_gwl_class:
-                (latestAnalysis?.b_gwl_class ?? undefined) as Bln3ScoreCollectedInputs["b_gwl_class"],
+            b_soiltype_agr: (latestAnalysis?.b_soiltype_agr ??
+                undefined) as Bln3ScoreCollectedInputs["b_soiltype_agr"],
+            b_gwl_class: (latestAnalysis?.b_gwl_class ??
+                undefined) as Bln3ScoreCollectedInputs["b_gwl_class"],
             ...(bln3Cultivations.length > 0 && {
                 cultivations: bln3Cultivations,
             }),

--- a/fdm-calculator/src/bln3/input.ts
+++ b/fdm-calculator/src/bln3/input.ts
@@ -54,15 +54,19 @@ export async function collectInputForBln3Score(
         // b_centroid = [lon, lat] (ST_X = longitude, ST_Y = latitude)
         const [a_lon, a_lat] = field.b_centroid
 
-        // Pick non-null numeric a_* fields from the most recent soil analysis
+        // Pick the BLN3-relevant soil analysis parameters from the most recent analysis.
         const latestAnalysis = soilAnalyses[0]
-        const soilData: Record<string, number> = {}
+        const soilData: Pick<
+            Bln3ScoreCollectedInputs,
+            "a_p_cc" | "a_p_al" | "a_p_wa"
+        > = {}
         if (latestAnalysis) {
-            for (const [key, value] of Object.entries(latestAnalysis)) {
-                if (key.startsWith("a_") && typeof value === "number") {
-                    soilData[key] = value
-                }
-            }
+            if (typeof latestAnalysis.a_p_cc === "number")
+                soilData.a_p_cc = latestAnalysis.a_p_cc
+            if (typeof latestAnalysis.a_p_al === "number")
+                soilData.a_p_al = latestAnalysis.a_p_al
+            if (typeof latestAnalysis.a_p_wa === "number")
+                soilData.a_p_wa = latestAnalysis.a_p_wa
         }
 
         // Build cultivation history using the Dutch "hoofdteelt" rule (May 15–July 15).

--- a/fdm-calculator/src/bln3/input.ts
+++ b/fdm-calculator/src/bln3/input.ts
@@ -28,7 +28,9 @@ import { findHoofdteelt } from "../shared/hoofdteelt"
  * @param fdm - The FDM instance for database interaction.
  * @param principal_id - The principal making the request.
  * @param b_id - The field ID for which to collect inputs.
- * @param timeframe - Optional timeframe to filter cultivations and measures.
+ * @param timeframe - Optional timeframe applied to soil analyses and measures only.
+ *   Cultivations are always fetched without a timeframe to cover the full multi-year
+ *   history needed for the BLN3 calculation.
  * @returns A promise resolving to the collected BLN3 score inputs (without `nmiApiKey`).
  * @throws {Error} If data collection fails.
  */

--- a/fdm-calculator/src/bln3/input.ts
+++ b/fdm-calculator/src/bln3/input.ts
@@ -15,7 +15,7 @@ import type {
     Bln3Measure,
     Bln3ScoreCollectedInputs,
 } from "./types"
-import { findHoofdteelt, findHoofdteeltBrpCode } from "../shared/hoofdteelt"
+import { findHoofdteelt } from "../shared/hoofdteelt"
 
 /**
  * Collects all field data needed for a BLN3 score calculation from the FDM database.
@@ -64,18 +64,44 @@ export async function collectInputForBln3Score(
         }
 
         // Build cultivation history using the Dutch "hoofdteelt" rule (May 15–July 15).
-        // Fetching without timeframe gives the full history needed for multi-year expansion.
-        const maxYear =
-            timeframe?.end?.getFullYear() ?? new Date().getFullYear()
-        const HISTORY_YEARS = 10
+        // Only process years within the span of known cultivation data. Years in that
+        // span without a cultivation in the window receive groene braak (nl_6794).
+        // Cultivations without b_lu_start are excluded from the range calculation.
+        const cultivationsWithStart = cultivations.filter(
+            (c) => c.b_lu_start != null,
+        )
         const bln3Cultivations: Bln3Cultivation[] = []
 
-        for (let year = maxYear; year >= maxYear - HISTORY_YEARS; year--) {
-            const hoofdteelt = findHoofdteelt(cultivations, year)
-            const match = /^nl_(\d+)$/.exec(hoofdteelt)
-            const b_lu_brp = match ? Number(match[1]) : null
-            if (b_lu_brp === null) continue
-            bln3Cultivations.push({ b_lu_brp: b_lu_brp, b_lu_year: year })
+        if (cultivationsWithStart.length > 0) {
+            // maxYear: timeframe end year takes precedence; otherwise the latest
+            // year covered by any cultivation (end date or start date).
+            const cultivationMaxYear = cultivationsWithStart.reduce(
+                (max, c) => {
+                    const y =
+                        c.b_lu_end?.getFullYear() ??
+                        c.b_lu_start!.getFullYear()
+                    return y > max ? y : max
+                },
+                0,
+            )
+            const maxYear = Math.max(
+                timeframe?.end?.getFullYear() ?? 0,
+                cultivationMaxYear,
+            )
+            const minYear = cultivationsWithStart.reduce((min, c) => {
+                const y = c.b_lu_start!.getFullYear()
+                return y < min ? y : min
+            }, maxYear)
+
+            for (let year = maxYear; year >= minYear; year--) {
+                const catalogue = findHoofdteelt(cultivations, year)
+                const match = /^nl_(\d+)$/.exec(catalogue)
+                if (!match) continue
+                bln3Cultivations.push({
+                    b_lu_brp: Number(match[1]),
+                    b_lu_year: year,
+                })
+            }
         }
 
         // Map measures: "bln_BM3" → { measure_id: "BM3", year: 2025 }

--- a/fdm-calculator/src/bln3/types.d.ts
+++ b/fdm-calculator/src/bln3/types.d.ts
@@ -89,9 +89,6 @@ export type Bln3ScoreCollectedInputs = {
     // ── Measures ─────────────────────────────────────────────────────────────
     /** Implemented soil management measures */
     measures?: Bln3Measure[]
-
-    // ── Additional fields accepted by the API (undocumented in schema) ───────
-    [key: string]: unknown
 }
 
 /**

--- a/fdm-calculator/src/index.ts
+++ b/fdm-calculator/src/index.ts
@@ -133,3 +133,8 @@ export type { NlvSupplyBySomParams } from "./other/nlv-supply-by-som"
 export { calculateNlvSupplyBySom } from "./other/nlv-supply-by-som"
 export type { WaterSupplyBySomParams } from "./other/water-supply-by-som"
 export { calculateWaterSupplyBySom } from "./other/water-supply-by-som"
+export {
+    findHoofdteelt,
+    GROENE_BRAAK,
+} from "./shared/hoofdteelt"
+export type { CultivationForHoofdteelt } from "./shared/hoofdteelt"

--- a/fdm-calculator/src/norms/nl/2025/value/hoofdteelt.ts
+++ b/fdm-calculator/src/norms/nl/2025/value/hoofdteelt.ts
@@ -1,76 +1,25 @@
+import { findHoofdteelt } from "../../../../shared/hoofdteelt"
 import type { NL2025NormsInputForCultivation } from "./types"
 
 /**
- * Determines the main cultivation ('hoofdteelt') for the NL 2025  and 2026 norms based on the legal definition.
- * The main cultivation is the one that is present for the longest duration within the period
- * from May 15th to July 15th.
+ * Determines the main cultivation ('hoofdteelt') for the NL 2025 and 2026 norms.
  *
- * @param cultivations An array of cultivation inputs, each containing start and end dates.
- * @returns The `b_lu_catalogue` of the main cultivation, or `null` if no cultivation is present in the period.
- * In case of a tie in duration, the cultivation with the alphabetically first `b_lu_catalogue` is chosen.
- * @example
- * const cultivations = [
- *   { cultivation: { b_lu_start: '2025-05-01', b_lu_end: '2025-06-10', b_lu_catalogue: 'cat_A' } },
- *   { cultivation: { b_lu_start: '2025-06-01', b_lu_end: '2025-07-20', b_lu_catalogue: 'cat_B' } }
- * ];
- * const hoofdteelt = await determineNLHoofdteelt(cultivations, 2025);
- * // returns 'cat_B'
+ * Delegates to `findHoofdteelt`. Cultivations without a `b_lu_start` are treated
+ * as always present (epoch), preserving the original norms behaviour where an
+ * unknown start date means the cultivation was already in the ground at the start
+ * of the reference period.
+ *
+ * @param cultivations - Array of cultivation inputs for the field.
+ * @param year - The norm year (2025 or 2026).
+ * @returns The `b_lu_catalogue` of the hoofdteelt, or `"nl_6794"` if none found.
  */
 export function determineNLHoofdteelt(
     cultivations: NL2025NormsInputForCultivation[],
     year: 2025 | 2026,
 ): string {
-    const HOOFDTEELT_START = new Date(`${year}-05-15`)
-    const HOOFDTEELT_END = new Date(`${year}-07-15`)
-
-    let maxDuration = -1
-    let hoofdteeltCatalogue: string | null = null
-
-    // In case of no cultivation return "Groene braak, spontane opkomst"
-    if (cultivations.length === 0) {
-        return "nl_6794"
-    }
-
-    for (const cultivation of cultivations) {
-        const cultivationStart = cultivation.b_lu_start
-            ? new Date(cultivation.b_lu_start)
-            : new Date(0)
-        const cultivationEnd = cultivation.b_lu_end
-            ? new Date(cultivation.b_lu_end)
-            : HOOFDTEELT_END
-
-        const effectiveStart =
-            cultivationStart > HOOFDTEELT_START
-                ? cultivationStart
-                : HOOFDTEELT_START
-        const effectiveEnd =
-            cultivationEnd < HOOFDTEELT_END ? cultivationEnd : HOOFDTEELT_END
-
-        if (effectiveEnd > effectiveStart) {
-            const currentDuration =
-                (effectiveEnd.getTime() - effectiveStart.getTime()) /
-                (1000 * 3600 * 24)
-
-            if (currentDuration > maxDuration) {
-                maxDuration = currentDuration
-                hoofdteeltCatalogue = cultivation.b_lu_catalogue
-            } else if (currentDuration === maxDuration) {
-                if (
-                    hoofdteeltCatalogue === null ||
-                    cultivation.b_lu_catalogue.localeCompare(
-                        hoofdteeltCatalogue,
-                    ) < 0
-                ) {
-                    hoofdteeltCatalogue = cultivation.b_lu_catalogue
-                }
-            }
-        }
-    }
-
-    // If no cultivation is present between May 15th and July 15th, return "Groene braak, spontane opkomst"
-    if (!hoofdteeltCatalogue) {
-        return "nl_6794"
-    }
-
-    return hoofdteeltCatalogue
+    const normalized = cultivations.map((c) => ({
+        ...c,
+        b_lu_start: c.b_lu_start ?? new Date(0),
+    }))
+    return findHoofdteelt(normalized, year)
 }

--- a/fdm-calculator/src/shared/hoofdteelt.ts
+++ b/fdm-calculator/src/shared/hoofdteelt.ts
@@ -27,8 +27,8 @@ export const GROENE_BRAAK = "nl_6794"
  *
  * @param cultivations - List of cultivations to evaluate.
  * @param year - The calendar year to evaluate.
- * @returns The `b_lu_catalogue` of the hoofdteelt, or `null` if no cultivation
- *          overlaps with the May 15–July 15 window.
+ * @returns The `b_lu_catalogue` of the hoofdteelt, or `GROENE_BRAAK` (`"nl_6794"`)
+ *          if no cultivation overlaps with the May 15–July 15 window.
  */
 export function findHoofdteelt(
     cultivations: CultivationForHoofdteelt[],

--- a/fdm-calculator/src/shared/hoofdteelt.ts
+++ b/fdm-calculator/src/shared/hoofdteelt.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal cultivation shape required to determine the hoofdteelt.
+ * Compatible with both `Cultivation` (fdm-core) and `NL2025NormsInputForCultivation`.
+ */
+export type CultivationForHoofdteelt = {
+    b_lu_catalogue: string
+    b_lu_start: Date | null | undefined
+    b_lu_end: Date | null | undefined
+}
+
+/**
+ * BRP/catalogue code for "Groene braak, spontane opkomst" — the Dutch regulatory
+ * default when no cultivation is present in the reference period.
+ */
+export const GROENE_BRAAK = "nl_6794"
+
+/**
+ * Finds the main cultivation ('hoofdteelt') for a given year using the legal
+ * Dutch definition: the cultivation present for the longest duration within
+ * the period May 15–July 15 of that year.
+ *
+ * In case of a tie in duration, the cultivation with the alphabetically first
+ * `b_lu_catalogue` is chosen.
+ *
+ * Cultivations without a `b_lu_start` are skipped. A missing `b_lu_end` is
+ * treated as still being present through the end of the window (July 15).
+ *
+ * @param cultivations - List of cultivations to evaluate.
+ * @param year - The calendar year to evaluate.
+ * @returns The `b_lu_catalogue` of the hoofdteelt, or `null` if no cultivation
+ *          overlaps with the May 15–July 15 window.
+ */
+export function findHoofdteelt(
+    cultivations: CultivationForHoofdteelt[],
+    year: number,
+): string {
+    const windowStart = new Date(`${year}-05-15`)
+    const windowEnd = new Date(`${year}-07-15`)
+
+    let maxDuration = -1
+    let result: string | null = null
+
+    for (const c of cultivations) {
+        if (!c.b_lu_start) continue
+        const start = new Date(c.b_lu_start)
+        const end = c.b_lu_end ? new Date(c.b_lu_end) : windowEnd
+
+        const effectiveStart = start > windowStart ? start : windowStart
+        const effectiveEnd = end < windowEnd ? end : windowEnd
+
+        if (effectiveEnd > effectiveStart) {
+            const duration = effectiveEnd.getTime() - effectiveStart.getTime()
+            if (duration > maxDuration) {
+                maxDuration = duration
+                result = c.b_lu_catalogue
+            } else if (duration === maxDuration && result !== null) {
+                if (c.b_lu_catalogue.localeCompare(result) < 0) {
+                    result = c.b_lu_catalogue
+                }
+            }
+        }
+    }
+
+    return result ?? GROENE_BRAAK
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field-level indicator detail page with aggregation cards, expandable indicator cards, radar chart, and an interactive mini-map
  * Input-data dialog showing soil analyses, cultivations and BLN measures
  * Farm title accepts a custom description render
  * Heatmap table adds a “Knelpunten” column and a dedicated summary row
  * Breadcrumb/map toggle updated for field vs overview modes

* **Chores**
  * Improved cultivation selection and BLN3 input handling; tightened input types and exports

* **Tests**
  * Updated cultivation and hoofdteelt boundary tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nmi-agro/fdm/pull/619)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #576 