### PR TITLE
Add cultivation information to farm balance field lists

### DIFF
--- a/.changeset/quiet-pets-deny.md
+++ b/.changeset/quiet-pets-deny.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+At the farm balance pages show in the field list for each field the main cultivation with a badge. When clicked on the badge the cultivation details are shown besides non-main cultivations on the field

--- a/.changeset/quiet-pets-deny.md
+++ b/.changeset/quiet-pets-deny.md
@@ -2,4 +2,8 @@
 "@nmi-agro/fdm-app": minor
 ---
 
-At the farm balance pages show in the field list for each field the main cultivation with a badge. When clicked on the badge the cultivation details are shown besides non-main cultivations on the field
+---
+"`@nmi-agro/fdm-app`": minor
+---
+
+Farm balance pages now display the main cultivation for each field as a badge in the field list. Clicking the badge opens a dialog showing cultivation details alongside any additional cultivations for that field.

--- a/fdm-app/app/components/blocks/balance/field-cultivations-badge.tsx
+++ b/fdm-app/app/components/blocks/balance/field-cultivations-badge.tsx
@@ -1,0 +1,119 @@
+import type { Cultivation, Harvest } from "@nmi-agro/fdm-core"
+import { getCultivationColor } from "~/components/custom/cultivation-colors"
+import { Badge } from "~/components/ui/badge"
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog"
+import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+
+interface FieldCultivationsBadgeProps {
+    cultivations: Cultivation[]
+    calendarYear: string
+    harvestsMap: Map<string, Harvest[]>
+    fieldName: string
+}
+
+function formatDate(date: Date | string | null | undefined): string {
+    if (!date) return "–"
+    return new Date(date).toLocaleDateString("nl-NL", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+    })
+}
+
+function formatHarvestDates(harvests: Harvest[] | undefined): string {
+    if (!harvests || harvests.length === 0) return "–"
+    return harvests
+        .map((h) => formatDate(h.b_lu_harvest_date))
+        .filter((d) => d !== "–")
+        .join(", ") || "–"
+}
+
+export function FieldCultivationsBadge({
+    cultivations,
+    calendarYear,
+    harvestsMap,
+    fieldName,
+}: FieldCultivationsBadgeProps) {
+    if (cultivations.length === 0) return null
+
+    const mainCultivation = getDefaultCultivation(cultivations, calendarYear)
+    if (!mainCultivation) return null
+
+    const extraCount = cultivations.length - 1
+    const color = getCultivationColor(
+        mainCultivation.b_lu_croprotation ?? undefined,
+    )
+
+    const sortedCultivations = [...cultivations].sort(
+        (a, b) => +(a.b_lu_start ?? 0) - +(b.b_lu_start ?? 0),
+    )
+
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <button
+                    type="button"
+                    className="flex items-center gap-1 cursor-pointer"
+                    aria-label={`Bekijk teelten voor ${fieldName}`}
+                >
+                    <Badge
+                        variant="default"
+                        className="text-white text-xs font-normal shrink-0"
+                        style={{
+                            backgroundColor: color,
+                        }}
+                    >
+                        {mainCultivation.b_lu_name ?? "Onbekend"}
+                    </Badge>
+                    {extraCount > 0 && (
+                        <span className="text-xs text-muted-foreground font-medium whitespace-nowrap">
+                            +{extraCount}
+                        </span>
+                    )}
+                </button>
+            </DialogTrigger>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Teelten voor {fieldName}</DialogTitle>
+                </DialogHeader>
+                <div className="mt-2 space-y-3">
+                    {/* Header row */}
+                    <div className="grid grid-cols-4 gap-2 text-xs font-semibold text-muted-foreground border-b pb-2">
+                        <span>Gewas</span>
+                        <span>Start</span>
+                        <span>Einde</span>
+                        <span>Oogst</span>
+                    </div>
+                    {/* Cultivation rows */}
+                    {sortedCultivations.map((cultivation) => (
+                        <div
+                            key={cultivation.b_lu}
+                            className="grid grid-cols-4 gap-2 text-sm items-start"
+                        >
+                            <span className="font-medium truncate">
+                                {cultivation.b_lu_name ?? "Onbekend gewas"}
+                            </span>
+                            <span className="text-muted-foreground">
+                                {formatDate(cultivation.b_lu_start)}
+                            </span>
+                            <span className="text-muted-foreground">
+                                {formatDate(cultivation.b_lu_end)}
+                            </span>
+                            <span className="text-muted-foreground">
+                                {formatHarvestDates(
+                                    harvestsMap.get(cultivation.b_lu),
+                                )}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.balance.nitrogen._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.balance.nitrogen._index.tsx
@@ -1,5 +1,11 @@
 import type { NitrogenBalanceFieldResultNumeric } from "@nmi-agro/fdm-calculator"
-import { getFarm, getFields } from "@nmi-agro/fdm-core"
+import type { Cultivation, Harvest } from "@nmi-agro/fdm-core"
+import {
+    getCultivationsForFarm,
+    getFarm,
+    getFields,
+    getHarvestsForFarm,
+} from "@nmi-agro/fdm-core"
 import {
     ArrowDown,
     ArrowRight,
@@ -33,9 +39,10 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "~/components/ui/tooltip"
+import { FieldCultivationsBadge } from "~/components/blocks/balance/field-cultivations-badge"
 import { getNitrogenBalanceForFarm } from "~/integrations/calculator"
 import { getSession } from "~/lib/auth.server"
-import { getTimeframe } from "~/lib/calendar"
+import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError, reportError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
@@ -82,6 +89,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // Get details of fields
         const fields = await getFields(fdm, session.principal_id, b_id_farm)
 
+        // Fetch cultivations and harvests for all fields in one batch each
+        const [cultivationsMap, harvestsMap] = await Promise.all([
+            getCultivationsForFarm(fdm, session.principal_id, b_id_farm, timeframe),
+            getHarvestsForFarm(fdm, session.principal_id, b_id_farm, timeframe),
+        ])
+
         const asyncData = (async () => {
             const nitrogenBalanceResult = await getNitrogenBalanceForFarm({
                 fdm,
@@ -113,6 +126,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         return {
             farm: farm,
             fields: fields,
+            calendar: getCalendar(params),
+            cultivationsEntries: [...cultivationsMap.entries()] as [string, Cultivation[]][],
+            harvestsEntries: [...harvestsMap.entries()] as [string, Harvest[]][],
             asyncData: asyncData,
         }
     } catch (error) {
@@ -147,9 +163,15 @@ export default function FarmBalanceNitrogenOverviewBlock() {
 function FarmBalanceNitrogenOverview({
     farm,
     fields,
+    calendar,
+    cultivationsEntries,
+    harvestsEntries,
     asyncData,
 }: Awaited<ReturnType<typeof loader>>) {
     const { nitrogenBalanceResult } = use(asyncData)
+
+    const cultivationsMap = new Map(cultivationsEntries)
+    const harvestsMap = new Map(harvestsEntries)
 
     const resolvedNitrogenBalanceResult = nitrogenBalanceResult
 
@@ -363,16 +385,30 @@ function FarmBalanceNitrogenOverview({
                                             )}
 
                                             <div className="ml-4 space-y-1">
-                                                <NavLink
-                                                    to={`./${fieldResult.b_id}`}
-                                                >
-                                                    <p className="text-sm font-medium leading-none hover:underline">
-                                                        {fieldData?.b_name}
+                                                <div className="flex items-baseline gap-2">
+                                                    <NavLink
+                                                        to={`./${fieldResult.b_id}`}
+                                                    >
+                                                        <p className="text-sm font-medium leading-none hover:underline">
+                                                            {fieldData?.b_name}
+                                                        </p>
+                                                    </NavLink>
+                                                    <p className="text-xs text-muted-foreground">
+                                                        {fieldData?.b_area} ha
                                                     </p>
-                                                </NavLink>
-                                                <p className="text-sm text-muted-foreground">
-                                                    {fieldData?.b_area} ha
-                                                </p>
+                                                </div>
+                                                <FieldCultivationsBadge
+                                                    cultivations={
+                                                        cultivationsMap.get(
+                                                            fieldResult.b_id,
+                                                        ) ?? []
+                                                    }
+                                                    calendarYear={calendar}
+                                                    harvestsMap={harvestsMap}
+                                                    fieldName={
+                                                        fieldData?.b_name ?? ""
+                                                    }
+                                                />
                                             </div>
                                             <div className="ml-auto font-medium">
                                                 {fieldResult.balance ? (

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.balance.organic-matter._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.balance.organic-matter._index.tsx
@@ -1,5 +1,11 @@
 import type { OrganicMatterBalanceFieldResultNumeric } from "@nmi-agro/fdm-calculator"
-import { getFarm, getFields } from "@nmi-agro/fdm-core"
+import type { Cultivation, Harvest } from "@nmi-agro/fdm-core"
+import {
+    getCultivationsForFarm,
+    getFarm,
+    getFields,
+    getHarvestsForFarm,
+} from "@nmi-agro/fdm-core"
 import {
     ArrowDownToLine,
     ArrowRightLeft,
@@ -26,9 +32,10 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card"
+import { FieldCultivationsBadge } from "~/components/blocks/balance/field-cultivations-badge"
 import { getOrganicMatterBalanceForFarm } from "~/integrations/calculator"
 import { getSession } from "~/lib/auth.server"
-import { getTimeframe } from "~/lib/calendar"
+import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError, reportError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
@@ -68,6 +75,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
         const fields = await getFields(fdm, session.principal_id, b_id_farm)
 
+        const [cultivationsMap, harvestsMap] = await Promise.all([
+            getCultivationsForFarm(fdm, session.principal_id, b_id_farm, timeframe),
+            getHarvestsForFarm(fdm, session.principal_id, b_id_farm, timeframe),
+        ])
+
         const asyncData = (async () => {
             const organicMatterBalanceResult =
                 await getOrganicMatterBalanceForFarm({
@@ -100,6 +112,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         return {
             farm: farm,
             fields: fields,
+            calendar: getCalendar(params),
+            cultivationsEntries: [...cultivationsMap.entries()] as [string, Cultivation[]][],
+            harvestsEntries: [...harvestsMap.entries()] as [string, Harvest[]][],
             asyncData: asyncData,
         }
     } catch (error) {
@@ -125,9 +140,15 @@ export default function FarmBalanceOrganicMatterOverviewBlock() {
 function FarmBalanceOrganicMatterOverview({
     farm,
     fields,
+    calendar,
+    cultivationsEntries,
+    harvestsEntries,
     asyncData,
 }: Awaited<ReturnType<typeof loader>>) {
     const { organicMatterBalanceResult } = use(asyncData)
+
+    const cultivationsMap = new Map(cultivationsEntries)
+    const harvestsMap = new Map(harvestsEntries)
 
     if (organicMatterBalanceResult.errorMessage) {
         return (
@@ -282,16 +303,30 @@ function FarmBalanceOrganicMatterOverview({
                                             )}
 
                                             <div className="ml-4 space-y-1">
-                                                <NavLink
-                                                    to={`./${fieldResult.b_id}`}
-                                                >
-                                                    <p className="text-sm font-medium leading-none hover:underline">
-                                                        {fieldData?.b_name}
+                                                <div className="flex items-baseline gap-2">
+                                                    <NavLink
+                                                        to={`./${fieldResult.b_id}`}
+                                                    >
+                                                        <p className="text-sm font-medium leading-none hover:underline">
+                                                            {fieldData?.b_name}
+                                                        </p>
+                                                    </NavLink>
+                                                    <p className="text-xs text-muted-foreground">
+                                                        {fieldData?.b_area} ha
                                                     </p>
-                                                </NavLink>
-                                                <p className="text-sm text-muted-foreground">
-                                                    {fieldData?.b_area} ha
-                                                </p>
+                                                </div>
+                                                <FieldCultivationsBadge
+                                                    cultivations={
+                                                        cultivationsMap.get(
+                                                            fieldResult.b_id,
+                                                        ) ?? []
+                                                    }
+                                                    calendarYear={calendar}
+                                                    harvestsMap={harvestsMap}
+                                                    fieldName={
+                                                        fieldData?.b_name ?? ""
+                                                    }
+                                                />
                                             </div>
                                             <div className="ml-auto font-medium">
                                                 {fieldResult.balance ? (


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cultivation badges to field lists on farm balance pages. Each field now displays its main cultivation with a badge indicator for additional cultivations. Clicking the badge opens a dialog showing all cultivations with their start, end, and harvest dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nmi-agro/fdm/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #616 