### PR TITLE
Fix fertilizer retrieval for organization members

### DIFF
--- a/.changeset/humble-mugs-joke.md
+++ b/.changeset/humble-mugs-joke.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-core": patch
----
-
-Fixes to retrieve custom fertilizers when user has access to farm via organization

--- a/.changeset/humble-mugs-joke.md
+++ b/.changeset/humble-mugs-joke.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-core": patch
+---
+
+Fixes to retrieve custom fertilizers when user has access to farm via organization

--- a/fdm-core/CHANGELOG.md
+++ b/fdm-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-core
 
+## 0.32.1
+
+### Patch Changes
+
+- [#624](https://github.com/nmi-agro/fdm/pull/624) [`463e0c1`](https://github.com/nmi-agro/fdm/commit/463e0c1127bd9f5fe33fe971458719fe1459d0e3) Thanks [@SvenVw](https://github.com/SvenVw)! - Fixes to retrieve custom fertilizers when user has access to farm via organization
+
 ## 0.32.0
 
 ### Minor Changes

--- a/fdm-core/package.json
+++ b/fdm-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-core",
     "private": false,
-    "version": "0.32.0",
+    "version": "0.32.1",
     "description": "Interface for the Farm Data Model",
     "license": "MIT",
     "homepage": "https://svenvw.github.io/fdm/",

--- a/fdm-core/src/fertilizer.test.ts
+++ b/fdm-core/src/fertilizer.test.ts
@@ -12,6 +12,7 @@ import {
     enableFertilizerCatalogue,
     getEnabledFertilizerCataloguesForFarms,
 } from "./catalogues"
+import * as authNSchema from "./db/schema-authn"
 import * as schema from "./db/schema"
 import { applicationMethodOptions, fertilizersCatalogue } from "./db/schema"
 import { addFarm } from "./farm"
@@ -35,6 +36,7 @@ import {
     updateFertilizerFromCatalogue,
 } from "./fertilizer"
 import { addField } from "./field"
+import { grantRole } from "./authorization"
 import { createId } from "./id"
 import { mockFdmThatThrowsOnSelectFrom } from "./test-util"
 
@@ -1022,6 +1024,112 @@ describe("Fertilizer Data Model", () => {
             // 4. Get the fertilizer and assert that p_type is "compost".
             fertilizer = await getFertilizer(fdm, p_id)
             expect(fertilizer.p_type).toBe("compost")
+        })
+
+        it("(getFertilizersFromCatalogue) should return fertilizers for a user who accesses the farm via organization membership", async () => {
+            // Regression test for: org-member users getting empty fertilizerDetailsMap FDM-623
+            // because the inline auth check in getFertilizersFromCatalogues only matched
+            // direct role.principal_id, not membership via an organization.
+
+            const orgId = createId()
+            const memberId = createId()
+
+            // Create the organization and user records
+            await fdm.insert(authNSchema.organization).values({
+                id: orgId,
+                name: "Test Org",
+                slug: `test-org-${createId(8).toLowerCase()}`,
+                createdAt: new Date(),
+            })
+            await fdm.insert(authNSchema.user).values({
+                id: memberId,
+                name: "Org Member",
+                email: `member-${createId(8).toLowerCase()}@example.com`,
+                emailVerified: false,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            })
+            await fdm.insert(authNSchema.member).values({
+                id: createId(),
+                organizationId: orgId,
+                userId: memberId,
+                role: "member",
+                createdAt: new Date(),
+            })
+
+            // Grant the organization (not the member directly) a role on the farm
+            await grantRole(fdm, "farm", "advisor", b_id_farm, orgId)
+
+            // The farm owner adds a custom fertilizer
+            // (catalogue is already enabled by beforeAll via enableFertilizerCatalogue)
+            const p_id_catalogue = await addFertilizerToCatalogue(
+                fdm,
+                principal_id,
+                b_id_farm,
+                {
+                    p_name_nl: "Org Member Visible Fertilizer",
+                    p_name_en: "Org Member Visible Fertilizer EN",
+                    p_description: "Visible via org membership",
+                    p_app_method_options: [],
+                    p_app_amount_unit: undefined,
+                    p_dm: 10,
+                    p_density: 1,
+                    p_om: 5,
+                    p_a: 0,
+                    p_hc: 0,
+                    p_eom: 0,
+                    p_eoc: 0,
+                    p_c_rt: 0,
+                    p_c_of: 0,
+                    p_c_if: 0,
+                    p_c_fr: 0,
+                    p_cn_of: 0,
+                    p_n_rt: 10,
+                    p_n_if: 0,
+                    p_n_of: 0,
+                    p_n_wc: 1,
+                    p_no3_rt: 0,
+                    p_nh4_rt: 0,
+                    p_p_rt: 0,
+                    p_k_rt: 0,
+                    p_mg_rt: 0,
+                    p_ca_rt: 0,
+                    p_ne: 0,
+                    p_s_rt: 0,
+                    p_s_wc: 0,
+                    p_cu_rt: 0,
+                    p_zn_rt: 0,
+                    p_na_rt: 0,
+                    p_si_rt: 0,
+                    p_b_rt: 0,
+                    p_mn_rt: 0,
+                    p_ni_rt: 0,
+                    p_fe_rt: 0,
+                    p_mo_rt: 0,
+                    p_co_rt: 0,
+                    p_as_rt: 0,
+                    p_cd_rt: 0,
+                    p_cr_rt: 0,
+                    p_cr_vi: 0,
+                    p_pb_rt: 0,
+                    p_hg_rt: 0,
+                    p_cl_rt: 0,
+                    p_ef_nh3: null,
+                    p_type: "manure",
+                    p_type_rvo: "10",
+                },
+            )
+
+            // The org member (not direct role holder) should see the fertilizer
+            const fertilizers = await getFertilizersFromCatalogue(
+                fdm,
+                memberId,
+                b_id_farm,
+            )
+            const found = fertilizers.find(
+                (f) => f.p_id_catalogue === p_id_catalogue,
+            )
+            expect(found).toBeDefined()
         })
     })
 

--- a/fdm-core/src/fertilizer.ts
+++ b/fdm-core/src/fertilizer.ts
@@ -3,11 +3,23 @@ import {
     type CatalogueFertilizerItem,
     hashFertilizer,
 } from "@nmi-agro/fdm-data"
-import { and, asc, desc, eq, gte, inArray, isNull, lte } from "drizzle-orm"
+import {
+    and,
+    asc,
+    desc,
+    eq,
+    gte,
+    inArray,
+    isNotNull,
+    isNull,
+    lte,
+    or,
+} from "drizzle-orm"
 import { checkPermission } from "./authorization"
 import type { PrincipalId } from "./authorization.types"
 import { getEnabledFertilizerCatalogues } from "./catalogues"
 import * as schema from "./db/schema"
+import * as authNSchema from "./db/schema-authn"
 import * as authZSchema from "./db/schema-authz"
 import { handleError } from "./error"
 import type { FdmType } from "./fdm.types"
@@ -81,7 +93,10 @@ export async function getFertilizersFromCatalogues(
             return []
         }
 
-        // Filter to only catalogue sources that are enabled for farms the principal can access
+        // Filter to only catalogue sources that are enabled for farms the principal can access.
+        // Access may be granted directly (role.principal_id matches the user) or through
+        // organization membership (role assigned to an org the user belongs to).
+        const principal_ids = [principal_id].flat()
         const authorizedRows = await fdm
             .selectDistinct({
                 p_source: schema.fertilizerCatalogueEnabling.p_source,
@@ -95,17 +110,29 @@ export async function getFertilizersFromCatalogues(
                         authZSchema.role.resource_id,
                         schema.fertilizerCatalogueEnabling.b_id_farm,
                     ),
-                    inArray(
-                        authZSchema.role.principal_id,
-                        [principal_id].flat(),
-                    ),
                     isNull(authZSchema.role.deleted),
                 ),
             )
+            .leftJoin(
+                authNSchema.member,
+                eq(
+                    authZSchema.role.principal_id,
+                    authNSchema.member.organizationId,
+                ),
+            )
             .where(
-                inArray(
-                    schema.fertilizerCatalogueEnabling.p_source,
-                    catalogueIds,
+                and(
+                    inArray(
+                        schema.fertilizerCatalogueEnabling.p_source,
+                        catalogueIds,
+                    ),
+                    or(
+                        inArray(authZSchema.role.principal_id, principal_ids),
+                        and(
+                            isNotNull(authNSchema.member.userId),
+                            inArray(authNSchema.member.userId, principal_ids),
+                        ),
+                    ),
                 ),
             )
         const authorizedSources = new Set(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where users accessing a farm through organization membership could not retrieve custom fertilizers. Users now see all available fertilizers regardless of whether they have direct farm access or access through their organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nmi-agro/fdm/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #623 