### PR TITLE
Replace Microsoft OAuth client-secret with certificate auth

### DIFF
--- a/.changeset/bold-symbols-deny.md
+++ b/.changeset/bold-symbols-deny.md
@@ -2,4 +2,4 @@
 "@nmi-agro/fdm-docs": minor
 ---
 
-Add section about setting up certificates for signing up with microsoft
+Add section about setting up certificates for signing in with Microsoft

--- a/.changeset/bold-symbols-deny.md
+++ b/.changeset/bold-symbols-deny.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-docs": minor
+---
+
+Add section about setting up certificates for signing up with microsoft

--- a/.changeset/little-schools-allow.md
+++ b/.changeset/little-schools-allow.md
@@ -3,4 +3,4 @@
 "@nmi-agro/fdm-app": minor
 ---
 
-Switch to use certificates for signin with Microsoft instead of using a client secret to improve security
+Switch to use certificates for sign-in with Microsoft instead of using a client secret to improve security

--- a/.changeset/little-schools-allow.md
+++ b/.changeset/little-schools-allow.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-core": minor
+"@nmi-agro/fdm-app": minor
+---
+
+Switch to use certificates for signin with Microsoft instead of using a client secret to improve security

--- a/fdm-app/.dockerignore
+++ b/fdm-app/.dockerignore
@@ -64,3 +64,5 @@ tsconfig.tsbuildinfo
 
 # Debug
 .debug 
+
+/secrets

--- a/fdm-app/.dockerignore
+++ b/fdm-app/.dockerignore
@@ -63,6 +63,6 @@ LICENSE
 tsconfig.tsbuildinfo
 
 # Debug
-.debug 
+.debug
 
 /secrets

--- a/fdm-app/.env.example
+++ b/fdm-app/.env.example
@@ -64,9 +64,21 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # Microsoft OAuth Credentials (Optional: Leave empty to disable Microsoft Sign-In)
+# Authentication uses a certificate credential (private_key_jwt) instead of a client secret.
+# Upload the public certificate in Entra: App registration → Certificates & secrets → Certificates.
+# Store the private key in Google Secret Manager and surface it as an env var.
 # Required: No
 MS_CLIENT_ID=
-MS_CLIENT_SECRET=
+# Tenant ID: "common" accepts users from any Microsoft organisation (incl. personal accounts).
+# Set to your Entra tenant GUID to restrict to a single organisation.
+MS_TENANT_ID=common
+# Inline PKCS#8 PEM private key (-----BEGIN PRIVATE KEY-----).
+# Generate: openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
+# Then upload ms-signin-public.crt to Entra and store the contents of ms-signin-private.pem here.
+MS_PRIVATE_KEY=
+# Provide EITHER the full PEM certificate OR its SHA-1 thumbprint (base64url, shown in Entra after upload).
+MS_CERTIFICATE=
+MS_CERT_THUMBPRINT=
 
 # RVO OAuth Credentials (Optional: Leave empty to disable RVO Integration)
 # Required: No

--- a/fdm-app/.env.example
+++ b/fdm-app/.env.example
@@ -68,11 +68,13 @@ GOOGLE_CLIENT_SECRET=
 # Upload the public certificate in Entra: App registration → Certificates & secrets → Certificates.
 # Store the private key in a secret manager (e.g. Google Secret Manager, AWS Secrets Manager,
 # Azure Key Vault) or supply it via your platform's environment variables.
-# Required: No
+# Required: No (leave MS_CLIENT_ID empty to disable). If MS_CLIENT_ID is set, all fields below
+# marked "Required when MS_CLIENT_ID is set" must also be configured.
 MS_CLIENT_ID=
 # Tenant ID: "common" accepts users from any Microsoft organisation (incl. personal accounts).
 # Set to your Entra tenant GUID to restrict to a single organisation.
 MS_TENANT_ID=common
+# Required when MS_CLIENT_ID is set.
 # Inline PKCS#8 PEM private key (-----BEGIN PRIVATE KEY-----). Never commit this value.
 # Accepts either the inline PEM content OR a file path to the PEM file.
 # Generate key pair. From PowerShell (recommended on Windows) or Linux/macOS:
@@ -81,11 +83,13 @@ MS_TENANT_ID=common
 #   MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
 # Upload ms-signin-public.crt to Entra, then store the contents of ms-signin-private.pem here.
 MS_PRIVATE_KEY=
+# Required when MS_CLIENT_ID is set: provide EITHER MS_CERTIFICATE OR MS_CERT_THUMBPRINT (not both required).
 # Public certificate PEM (-----BEGIN CERTIFICATE-----). This is the PUBLIC certificate — not a secret.
 # Paste the full contents of ms-signin-public.crt, OR provide a file path to the .crt file.
 # The thumbprint is derived from it automatically; you do not need MS_CERT_THUMBPRINT when this is set.
 MS_CERTIFICATE=
-# Alternative to MS_CERTIFICATE: pre-computed base64url SHA-1 thumbprint.
+# Alternative to MS_CERTIFICATE (provide one or the other, not required if MS_CERTIFICATE is set).
+# Pre-computed base64url SHA-1 thumbprint.
 # Compute locally: openssl x509 -in ms-signin-public.crt -outform DER | openssl dgst -sha1 -binary | base64 | tr '+/' '-_' | tr -d '='
 # (The Entra portal truncates the thumbprint display, so compute it locally if needed.)
 MS_CERT_THUMBPRINT=

--- a/fdm-app/.env.example
+++ b/fdm-app/.env.example
@@ -66,7 +66,8 @@ GOOGLE_CLIENT_SECRET=
 # Microsoft OAuth Credentials (Optional: Leave empty to disable Microsoft Sign-In)
 # Authentication uses a certificate credential (private_key_jwt) instead of a client secret.
 # Upload the public certificate in Entra: App registration → Certificates & secrets → Certificates.
-# Store the private key in Google Secret Manager and surface it as an env var.
+# Store the private key in a secret manager (e.g. Google Secret Manager, AWS Secrets Manager,
+# Azure Key Vault) or supply it via your platform's environment variables.
 # Required: No
 MS_CLIENT_ID=
 # Tenant ID: "common" accepts users from any Microsoft organisation (incl. personal accounts).
@@ -80,12 +81,13 @@ MS_TENANT_ID=common
 #   MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
 # Upload ms-signin-public.crt to Entra, then store the contents of ms-signin-private.pem here.
 MS_PRIVATE_KEY=
-# Public certificate PEM (-----BEGIN CERTIFICATE-----). Paste the full contents of ms-signin-public.crt,
-# OR provide a file path to the .crt file. The thumbprint is derived automatically.
+# Public certificate PEM (-----BEGIN CERTIFICATE-----). This is the PUBLIC certificate — not a secret.
+# Paste the full contents of ms-signin-public.crt, OR provide a file path to the .crt file.
+# The thumbprint is derived from it automatically; you do not need MS_CERT_THUMBPRINT when this is set.
 MS_CERTIFICATE=
 # Alternative to MS_CERTIFICATE: pre-computed base64url SHA-1 thumbprint.
 # Compute locally: openssl x509 -in ms-signin-public.crt -outform DER | openssl dgst -sha1 -binary | base64 | tr '+/' '-_' | tr -d '='
-# (The Entra portal truncates the thumbprint, so derive it locally if needed.)
+# (The Entra portal truncates the thumbprint display, so compute it locally if needed.)
 MS_CERT_THUMBPRINT=
 
 # RVO OAuth Credentials (Optional: Leave empty to disable RVO Integration)

--- a/fdm-app/.env.example
+++ b/fdm-app/.env.example
@@ -72,12 +72,20 @@ MS_CLIENT_ID=
 # Tenant ID: "common" accepts users from any Microsoft organisation (incl. personal accounts).
 # Set to your Entra tenant GUID to restrict to a single organisation.
 MS_TENANT_ID=common
-# Inline PKCS#8 PEM private key (-----BEGIN PRIVATE KEY-----).
-# Generate: openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
-# Then upload ms-signin-public.crt to Entra and store the contents of ms-signin-private.pem here.
+# Inline PKCS#8 PEM private key (-----BEGIN PRIVATE KEY-----). Never commit this value.
+# Accepts either the inline PEM content OR a file path to the PEM file.
+# Generate key pair. From PowerShell (recommended on Windows) or Linux/macOS:
+#   openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
+# From Git Bash on Windows (MSYS_NO_PATHCONV=1 prevents path expansion):
+#   MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 -nodes -keyout ms-signin-private.pem -out ms-signin-public.crt -days 730 -subj "/CN=fdm-microsoft-signin"
+# Upload ms-signin-public.crt to Entra, then store the contents of ms-signin-private.pem here.
 MS_PRIVATE_KEY=
-# Provide EITHER the full PEM certificate OR its SHA-1 thumbprint (base64url, shown in Entra after upload).
+# Public certificate PEM (-----BEGIN CERTIFICATE-----). Paste the full contents of ms-signin-public.crt,
+# OR provide a file path to the .crt file. The thumbprint is derived automatically.
 MS_CERTIFICATE=
+# Alternative to MS_CERTIFICATE: pre-computed base64url SHA-1 thumbprint.
+# Compute locally: openssl x509 -in ms-signin-public.crt -outform DER | openssl dgst -sha1 -binary | base64 | tr '+/' '-_' | tr -d '='
+# (The Entra portal truncates the thumbprint, so derive it locally if needed.)
 MS_CERT_THUMBPRINT=
 
 # RVO OAuth Credentials (Optional: Leave empty to disable RVO Integration)

--- a/fdm-app/.gitignore
+++ b/fdm-app/.gitignore
@@ -9,3 +9,5 @@ node_modules
 .react-router/
 # Sentry Config File
 .env.sentry-build-plugin
+
+/secrets

--- a/fdm-app/app/lib/auth-client.ts
+++ b/fdm-app/app/lib/auth-client.ts
@@ -1,9 +1,18 @@
 import { apiKeyClient } from "@better-auth/api-key/client"
-import { magicLinkClient, organizationClient } from "better-auth/client/plugins"
+import {
+    genericOAuthClient,
+    magicLinkClient,
+    organizationClient,
+} from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
-    plugins: [organizationClient(), magicLinkClient(), apiKeyClient()],
+    plugins: [
+        organizationClient(),
+        magicLinkClient(),
+        apiKeyClient(),
+        genericOAuthClient(),
+    ],
 })
 
 export const { signIn, signOut, signUp, useSession } = authClient

--- a/fdm-app/app/lib/config.server.ts
+++ b/fdm-app/app/lib/config.server.ts
@@ -1,5 +1,45 @@
 import type { ServerConfig } from "~/types/config.d"
 
+// ---------------------------------------------------------------------------
+// Microsoft cert config — validated at startup so misconfigurations surface
+// immediately rather than during the first sign-in attempt.
+// ---------------------------------------------------------------------------
+function buildMicrosoftConfig(): ServerConfig["auth"]["microsoft"] {
+    if (!process.env.MS_CLIENT_ID) return undefined
+
+    if (!process.env.MS_PRIVATE_KEY) {
+        throw new Error(
+            "MS_PRIVATE_KEY is required when MS_CLIENT_ID is set. " +
+                "Set MS_PRIVATE_KEY to the PKCS#8 PEM private key or a path to the PEM file.",
+        )
+    }
+
+    const base = {
+        clientId: process.env.MS_CLIENT_ID,
+        tenantId: process.env.MS_TENANT_ID || "common",
+        privateKey: process.env.MS_PRIVATE_KEY,
+    }
+
+    if (process.env.MS_CERTIFICATE) {
+        return {
+            ...base,
+            certificate: process.env.MS_CERTIFICATE,
+            ...(process.env.MS_CERT_THUMBPRINT && {
+                certThumbprint: process.env.MS_CERT_THUMBPRINT,
+            }),
+        }
+    }
+
+    if (process.env.MS_CERT_THUMBPRINT) {
+        return { ...base, certThumbprint: process.env.MS_CERT_THUMBPRINT }
+    }
+
+    throw new Error(
+        "Either MS_CERTIFICATE (public certificate PEM or path) or " +
+            "MS_CERT_THUMBPRINT (base64url SHA-1 thumbprint) is required when MS_CLIENT_ID is set.",
+    )
+}
+
 // Export the full config for server-side use
 export const serverConfig: ServerConfig = {
     name: String(process.env.PUBLIC_FDM_NAME),
@@ -15,19 +55,7 @@ export const serverConfig: ServerConfig = {
             clientId: String(process.env.GOOGLE_CLIENT_ID),
             clientSecret: String(process.env.GOOGLE_CLIENT_SECRET),
         },
-        microsoft: process.env.MS_CLIENT_ID
-            ? {
-                  clientId: String(process.env.MS_CLIENT_ID),
-                  tenantId: process.env.MS_TENANT_ID || "common",
-                  privateKey: String(process.env.MS_PRIVATE_KEY),
-                  ...(process.env.MS_CERTIFICATE
-                      ? { certificate: process.env.MS_CERTIFICATE }
-                      : {}),
-                  ...(process.env.MS_CERT_THUMBPRINT
-                      ? { certThumbprint: process.env.MS_CERT_THUMBPRINT }
-                      : {}),
-              }
-            : undefined,
+        microsoft: buildMicrosoftConfig(),
     },
 
     // Database

--- a/fdm-app/app/lib/config.server.ts
+++ b/fdm-app/app/lib/config.server.ts
@@ -15,10 +15,19 @@ export const serverConfig: ServerConfig = {
             clientId: String(process.env.GOOGLE_CLIENT_ID),
             clientSecret: String(process.env.GOOGLE_CLIENT_SECRET),
         },
-        microsoft: {
-            clientId: String(process.env.MS_CLIENT_ID),
-            clientSecret: String(process.env.MS_CLIENT_SECRET),
-        },
+        microsoft: process.env.MS_CLIENT_ID
+            ? {
+                  clientId: String(process.env.MS_CLIENT_ID),
+                  tenantId: process.env.MS_TENANT_ID || "common",
+                  privateKey: String(process.env.MS_PRIVATE_KEY),
+                  ...(process.env.MS_CERTIFICATE
+                      ? { certificate: process.env.MS_CERTIFICATE }
+                      : {}),
+                  ...(process.env.MS_CERT_THUMBPRINT
+                      ? { certThumbprint: process.env.MS_CERT_THUMBPRINT }
+                      : {}),
+              }
+            : undefined,
     },
 
     // Database

--- a/fdm-app/app/routes/signin._index.tsx
+++ b/fdm-app/app/routes/signin._index.tsx
@@ -360,8 +360,8 @@ export default function SignIn() {
                                                         "microsoft",
                                                     )
                                                     try {
-                                                        await signIn.social({
-                                                            provider:
+                                                        await signIn.oauth2({
+                                                            providerId:
                                                                 "microsoft",
                                                             callbackURL:
                                                                 redirectTo,

--- a/fdm-app/app/types/config.d.ts
+++ b/fdm-app/app/types/config.d.ts
@@ -17,8 +17,15 @@ export interface ServerConfig {
                   clientId: string
                   tenantId?: string
                   privateKey: string
-                  certificate?: string
+                  certificate: string
                   certThumbprint?: string
+              }
+            | {
+                  clientId: string
+                  tenantId?: string
+                  privateKey: string
+                  certificate?: string
+                  certThumbprint: string
               }
             | undefined
     }

--- a/fdm-app/app/types/config.d.ts
+++ b/fdm-app/app/types/config.d.ts
@@ -15,7 +15,10 @@ export interface ServerConfig {
         microsoft?:
             | {
                   clientId: string
-                  clientSecret: string
+                  tenantId?: string
+                  privateKey: string
+                  certificate?: string
+                  certThumbprint?: string
               }
             | undefined
     }

--- a/fdm-core/package.json
+++ b/fdm-core/package.json
@@ -64,6 +64,7 @@
         "@better-auth/api-key": "catalog:",
         "@types/geojson": "^7946.0.16",
         "better-auth": "catalog:",
+        "jose": "catalog:",
         "decimal.js": "^10.6.0",
         "drizzle-orm": "catalog:",
         "nanoid": "^5.1.11",

--- a/fdm-core/src/authentication-ms.test.ts
+++ b/fdm-core/src/authentication-ms.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { writeFileSync, unlinkSync } from "node:fs"
 import { SignJWT, importPKCS8 } from "jose"
-import { beforeAll, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import {
     createMicrosoftClientAssertion,
     createMicrosoftOAuthConfig,
@@ -261,6 +261,16 @@ describe("createMicrosoftOAuthConfig", () => {
                 ok,
                 arrayBuffer: async () => body ?? new ArrayBuffer(0),
             } as unknown as Response)
+
+        let originalFetch: typeof global.fetch
+
+        beforeEach(() => {
+            originalFetch = global.fetch
+        })
+
+        afterEach(() => {
+            global.fetch = originalFetch
+        })
 
         it("returns null when idToken is missing", async () => {
             const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)

--- a/fdm-core/src/authentication-ms.test.ts
+++ b/fdm-core/src/authentication-ms.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Unit tests for authentication-ms.ts
+ *
+ * Key test strategy:
+ * - Private key: generated with Node's crypto (no OpenSSL binary needed)
+ * - Certificate PEM: a minimal fake PEM wrapping known bytes so the
+ *   thumbprint is predictable without needing a real X.509 structure
+ * - Network calls (token endpoint, Graph photo): mocked via global.fetch
+ * - Jose's SignJWT is used to build id_tokens for getUserInfo tests
+ */
+import { createHash, generateKeyPairSync, randomUUID } from "node:crypto"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { writeFileSync, unlinkSync } from "node:fs"
+import { SignJWT, importPKCS8 } from "jose"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+import {
+    createMicrosoftClientAssertion,
+    createMicrosoftOAuthConfig,
+    type MicrosoftCertConfig,
+    type MicrosoftOAuthHelpers,
+} from "./authentication-ms"
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+/** A real PKCS#8 PEM private key generated once for all signing tests. */
+let privateKeyPem: string
+
+/**
+ * A minimal fake certificate PEM. The DER body is arbitrary bytes (the
+ * string "fdm-test-certificate-der-bytes" base64-encoded). The thumbprint
+ * is pre-computed from those same bytes so tests stay deterministic.
+ */
+const FAKE_CERT_DER_BYTES = Buffer.from("fdm-test-certificate-der-bytes")
+const FAKE_CERT_PEM = [
+    "-----BEGIN CERTIFICATE-----",
+    FAKE_CERT_DER_BYTES.toString("base64"),
+    "-----END CERTIFICATE-----",
+].join("\n")
+const FAKE_CERT_THUMBPRINT = createHash("sha1")
+    .update(FAKE_CERT_DER_BYTES)
+    .digest()
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "")
+
+beforeAll(() => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString()
+})
+
+/** Base config that uses certThumbprint (no cert PEM needed for signing). */
+const baseConfig = (): MicrosoftCertConfig => ({
+    clientId: "test-client-id",
+    tenantId: "test-tenant",
+    privateKey: privateKeyPem,
+    certThumbprint: FAKE_CERT_THUMBPRINT,
+})
+
+const mockHelpers: MicrosoftOAuthHelpers = {
+    splitFullName: (name) => {
+        const parts = (name ?? "").trim().split(/\s+/)
+        return {
+            firstname: parts[0] ?? null,
+            surname: parts[1] ?? null,
+        }
+    },
+    createUsername: async (email) => email.split("@")[0],
+    createDisplayUsername: (firstname, surname) =>
+        [firstname, surname].filter(Boolean).join(" ") || null,
+}
+
+// ---------------------------------------------------------------------------
+// createMicrosoftClientAssertion
+// ---------------------------------------------------------------------------
+
+describe("createMicrosoftClientAssertion", () => {
+    it("produces a JWT with RS256 alg and x5t header from certThumbprint", async () => {
+        const { decodeProtectedHeader } = await import("jose")
+        const token = await createMicrosoftClientAssertion(baseConfig())
+        const header = decodeProtectedHeader(token)
+        expect(header.alg).toBe("RS256")
+        expect(header.x5t).toBe(FAKE_CERT_THUMBPRINT)
+    })
+
+    it("derives x5t thumbprint from certificate PEM when no certThumbprint given", async () => {
+        const { decodeProtectedHeader } = await import("jose")
+        const config: MicrosoftCertConfig = {
+            ...baseConfig(),
+            certThumbprint: undefined,
+            certificate: FAKE_CERT_PEM,
+        }
+        const token = await createMicrosoftClientAssertion(config)
+        expect(decodeProtectedHeader(token).x5t).toBe(FAKE_CERT_THUMBPRINT)
+    })
+
+    it("caches thumbprint — second call with same cert PEM does not re-hash", async () => {
+        // Use a unique cert body so this test has its own cache entry
+        const uniqueDer = Buffer.from(`fdm-cache-test-${randomUUID()}`)
+        const uniquePem = [
+            "-----BEGIN CERTIFICATE-----",
+            uniqueDer.toString("base64"),
+            "-----END CERTIFICATE-----",
+        ].join("\n")
+        const config: MicrosoftCertConfig = {
+            ...baseConfig(),
+            certThumbprint: undefined,
+            certificate: uniquePem,
+        }
+        const { decodeProtectedHeader } = await import("jose")
+
+        const t1 = await createMicrosoftClientAssertion(config)
+        const t2 = await createMicrosoftClientAssertion(config)
+
+        // Both calls should produce the same x5t (cached)
+        expect(decodeProtectedHeader(t1).x5t).toBe(decodeProtectedHeader(t2).x5t)
+    })
+
+    it("sets correct JWT claims (iss, sub, aud, exp)", async () => {
+        const { decodeJwt } = await import("jose")
+        const token = await createMicrosoftClientAssertion(baseConfig())
+        const claims = decodeJwt(token)
+        const expectedAud =
+            "https://login.microsoftonline.com/test-tenant/oauth2/v2.0/token"
+        expect(claims.iss).toBe("test-client-id")
+        expect(claims.sub).toBe("test-client-id")
+        expect(claims.aud).toBe(expectedAud)
+        expect(typeof claims.jti).toBe("string")
+        const lifetime = (claims.exp as number) - (claims.iat as number)
+        expect(lifetime).toBeLessThanOrEqual(300)
+        expect(lifetime).toBeGreaterThan(0)
+    })
+
+    it("defaults tenantId to 'common'", async () => {
+        const { decodeJwt } = await import("jose")
+        const config: MicrosoftCertConfig = {
+            ...baseConfig(),
+            tenantId: undefined,
+        }
+        const token = await createMicrosoftClientAssertion(config)
+        expect((decodeJwt(token).aud as string)).toContain("/common/")
+    })
+
+    it("throws when neither certificate nor certThumbprint is provided", async () => {
+        const config: MicrosoftCertConfig = {
+            ...baseConfig(),
+            certThumbprint: undefined,
+            certificate: undefined,
+        }
+        await expect(createMicrosoftClientAssertion(config)).rejects.toThrow(
+            "provide either 'certificate' (PEM) or 'certThumbprint'",
+        )
+    })
+
+    it("reads privateKey from a file path", async () => {
+        const { decodeProtectedHeader } = await import("jose")
+        const tmpFile = join(tmpdir(), `fdm-test-key-${randomUUID()}.pem`)
+        writeFileSync(tmpFile, privateKeyPem, "utf8")
+        try {
+            const token = await createMicrosoftClientAssertion({
+                ...baseConfig(),
+                privateKey: tmpFile,
+            })
+            expect(decodeProtectedHeader(token).alg).toBe("RS256")
+        } finally {
+            unlinkSync(tmpFile)
+        }
+    })
+
+    it("reads certificate from a file path", async () => {
+        const { decodeProtectedHeader } = await import("jose")
+        const tmpFile = join(tmpdir(), `fdm-test-cert-${randomUUID()}.crt`)
+        writeFileSync(tmpFile, FAKE_CERT_PEM, "utf8")
+        try {
+            const token = await createMicrosoftClientAssertion({
+                ...baseConfig(),
+                certThumbprint: undefined,
+                certificate: tmpFile,
+            })
+            expect(decodeProtectedHeader(token).x5t).toBe(FAKE_CERT_THUMBPRINT)
+        } finally {
+            unlinkSync(tmpFile)
+        }
+    })
+
+    it("throws when privateKey file path does not exist", async () => {
+        await expect(
+            createMicrosoftClientAssertion({
+                ...baseConfig(),
+                privateKey: "/nonexistent/path/key.pem",
+            }),
+        ).rejects.toThrow("MS_PRIVATE_KEY file not found")
+    })
+
+    it("throws when certificate file path does not exist", async () => {
+        await expect(
+            createMicrosoftClientAssertion({
+                ...baseConfig(),
+                certThumbprint: undefined,
+                certificate: "/nonexistent/path/cert.crt",
+            }),
+        ).rejects.toThrow("MS_CERTIFICATE file not found")
+    })
+})
+
+// ---------------------------------------------------------------------------
+// createMicrosoftOAuthConfig
+// ---------------------------------------------------------------------------
+
+describe("createMicrosoftOAuthConfig", () => {
+    it("returns a GenericOAuthConfig with providerId 'microsoft'", () => {
+        const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+        expect(cfg.providerId).toBe("microsoft")
+    })
+
+    it("sets authorizationUrl and tokenUrl for the given tenantId", () => {
+        const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+        expect(cfg.authorizationUrl).toContain("/test-tenant/")
+        expect(cfg.tokenUrl).toContain("/test-tenant/")
+    })
+
+    it("defaults tenantId to 'common'", () => {
+        const cfg = createMicrosoftOAuthConfig(
+            { ...baseConfig(), tenantId: undefined },
+            mockHelpers,
+        )
+        expect(cfg.authorizationUrl).toContain("/common/")
+    })
+
+    it("requests the expected scopes including User.Read", () => {
+        const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+        expect(cfg.scopes).toContain("openid")
+        expect(cfg.scopes).toContain("email")
+        expect(cfg.scopes).toContain("User.Read")
+        expect(cfg.scopes).toContain("offline_access")
+    })
+
+    it("enables PKCE", () => {
+        expect(createMicrosoftOAuthConfig(baseConfig(), mockHelpers).pkce).toBe(true)
+    })
+
+    // -----------------------------------------------------------------------
+    // getUserInfo
+    // -----------------------------------------------------------------------
+
+    describe("getUserInfo", () => {
+        const buildIdToken = async (claims: Record<string, unknown>) => {
+            const key = await importPKCS8(privateKeyPem, "RS256")
+            return new SignJWT(claims)
+                .setProtectedHeader({ alg: "RS256" })
+                .setIssuedAt()
+                .setExpirationTime("1h")
+                .sign(key)
+        }
+
+        const fetchReturning = (ok: boolean, body?: ArrayBuffer) =>
+            vi.fn().mockResolvedValue({
+                ok,
+                arrayBuffer: async () => body ?? new ArrayBuffer(0),
+            } as unknown as Response)
+
+        it("returns null when idToken is missing", async () => {
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({ accessToken: "tok" } as any)
+            expect(result).toBeNull()
+        })
+
+        it("extracts id, email, name, emailVerified from idToken", async () => {
+            const idToken = await buildIdToken({
+                sub: "user-123",
+                email: "jane@example.com",
+                name: "Jane Doe",
+                email_verified: true,
+            })
+            global.fetch = fetchReturning(false)
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({
+                idToken,
+                accessToken: "tok",
+            } as any)
+            expect(result?.id).toBe("user-123")
+            expect(result?.email).toBe("jane@example.com")
+            expect(result?.name).toBe("Jane Doe")
+            expect(result?.emailVerified).toBe(true)
+            expect(result?.image).toBeUndefined()
+        })
+
+        it("falls back to 'mail' claim when 'email' is absent", async () => {
+            const idToken = await buildIdToken({
+                sub: "s",
+                mail: "mail@example.com",
+                name: "Mail User",
+            })
+            global.fetch = fetchReturning(false)
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({ idToken, accessToken: "tok" } as any)
+            expect(result?.email).toBe("mail@example.com")
+        })
+
+        it("derives name from email when name claim is absent", async () => {
+            const idToken = await buildIdToken({
+                sub: "s",
+                email: "noname@example.com",
+            })
+            global.fetch = fetchReturning(false)
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({ idToken, accessToken: "tok" } as any)
+            expect(result?.name).toBe("noname")
+        })
+
+        it("attaches base64 profile photo when Graph returns ok", async () => {
+            const idToken = await buildIdToken({
+                sub: "s",
+                email: "photo@example.com",
+                name: "Photo User",
+            })
+            const imgBytes = Buffer.from("img-bytes")
+            global.fetch = fetchReturning(true, imgBytes.buffer)
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({ idToken, accessToken: "tok" } as any)
+            expect(result?.image).toMatch(/^data:image\/jpeg;base64,/)
+        })
+
+        it("throws microsoft_no_email when no email/mail in idToken", async () => {
+            const idToken = await buildIdToken({ sub: "s", name: "No Email" })
+            global.fetch = fetchReturning(false)
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            await expect(
+                cfg.getUserInfo!({ idToken, accessToken: "tok" } as any),
+            ).rejects.toThrow("microsoft_no_email")
+        })
+
+        it("does not throw when Graph photo fetch fails", async () => {
+            const idToken = await buildIdToken({
+                sub: "s",
+                email: "e@example.com",
+                name: "Err User",
+            })
+            global.fetch = vi.fn().mockRejectedValue(new Error("network"))
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.getUserInfo!({ idToken, accessToken: "tok" } as any)
+            expect(result?.email).toBe("e@example.com")
+            expect(result?.image).toBeUndefined()
+        })
+    })
+
+    // -----------------------------------------------------------------------
+    // mapProfileToUser
+    // -----------------------------------------------------------------------
+
+    describe("mapProfileToUser", () => {
+        it("maps email and name to FDM user fields", async () => {
+            const cfg = createMicrosoftOAuthConfig(baseConfig(), mockHelpers)
+            const result = await cfg.mapProfileToUser!({
+                email: "john@example.com",
+                name: "John Doe",
+            }) as Record<string, unknown>
+            expect(result.email).toBe("john@example.com")
+            expect(result.firstname).toBe("John")
+            expect(result.surname).toBe("Doe")
+            expect(result.username).toBe("john")
+            expect(result.displayUsername).toBe("John Doe")
+            expect(result.emailVerified).toBe(true)
+        })
+    })
+})

--- a/fdm-core/src/authentication-ms.ts
+++ b/fdm-core/src/authentication-ms.ts
@@ -50,20 +50,21 @@ const thumbprintCache = new Map<string, string>()
  * Mirrors the pattern used by fdm-rvo for `RVO_PKIO_PRIVATE_KEY`.
  */
 function resolveFileOrInline(value: string, label: string): string {
-    const looksLikePath =
-        value.startsWith("/") ||
-        value.startsWith("./") ||
-        value.startsWith("../") ||
-        /^[a-zA-Z]:[/\\]/.test(value)
-
-    if (looksLikePath) {
-        if (fs.existsSync(value)) {
-            return fs.readFileSync(value, "utf8")
-        }
-        throw new Error(`Microsoft cert auth: ${label} file not found: ${value}`)
+    // If the value contains PEM headers, it's inline
+    if (value.includes("-----BEGIN")) {
+        let key = value.replace(/\\n/g, "\n").trim()
+        key = key.replace(/^["']|["']$/g, "").trim()
+        key = key.replace(/\\r/g, "")
+        return key
     }
 
-    return value
+    // Otherwise, treat it as a file path
+    if (fs.existsSync(value)) {
+        return fs.readFileSync(value, "utf8").replace(/^\uFEFF/, "").trim()
+    }
+    
+    // If it doesn't exist but has no PEM headers, it's likely a missing file
+    throw new Error(`Microsoft cert auth: ${label} file not found: ${value}`)
 }
 
 // ---------------------------------------------------------------------------

--- a/fdm-core/src/authentication-ms.ts
+++ b/fdm-core/src/authentication-ms.ts
@@ -1,0 +1,306 @@
+import { createHash, randomUUID } from "node:crypto"
+import type { GenericOAuthConfig } from "better-auth/plugins"
+import { decodeJwt, SignJWT, importPKCS8 } from "jose"
+
+const AUTHORITY = "https://login.microsoftonline.com"
+const PROFILE_PHOTO_SIZE = 48
+const SCOPES = ["openid", "profile", "email", "User.Read", "offline_access"]
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+async function loadPrivateKey(pemKey: string) {
+    return importPKCS8(pemKey, "RS256")
+}
+
+/**
+ * Computes the `x5t` (X.509 certificate SHA-1 thumbprint) from a PEM
+ * certificate. The value is base64url-encoded per RFC 7517 §4.8.
+ */
+async function computeX5t(certificatePem: string): Promise<string> {
+    const der = pemToDer(certificatePem)
+    const sha1 = createHash("sha1").update(der).digest()
+    return Buffer.from(sha1)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "")
+}
+
+/**
+ * Strips the PEM header/footer and base64-decodes the body to get raw DER.
+ */
+function pemToDer(pem: string): Buffer {
+    const body = pem
+        .replace(/-----BEGIN[^-]+-----/, "")
+        .replace(/-----END[^-]+-----/, "")
+        .replace(/\s/g, "")
+    return Buffer.from(body, "base64")
+}
+
+// Cache the x5t per certificate PEM so we don't re-hash on every request
+const thumbprintCache = new Map<string, string>()
+
+// ---------------------------------------------------------------------------
+// Exported types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for Microsoft Entra ID sign-in using a certificate credential.
+ *
+ * Only the public certificate is uploaded to the Entra app registration.
+ * The private key stays on the server and is never transmitted.
+ *
+ * @see https://learn.microsoft.com/en-us/entra/identity-platform/certificate-credentials
+ */
+export interface MicrosoftCertConfig {
+    /** Azure app registration client ID */
+    clientId: string
+    /**
+     * Tenant segment for the token/authorization endpoints.
+     * Use `"common"` to allow any Microsoft account (default), `"organizations"` for work/school
+     * accounts only, or a specific tenant GUID to restrict to one organisation.
+     * @default "common"
+     */
+    tenantId?: string
+    /**
+     * Inline PKCS#8 PEM private key (`-----BEGIN PRIVATE KEY-----`).
+     * This is the private half of the certificate pair; it must never be
+     * exposed to the browser or committed to source control.
+     */
+    privateKey: string
+    /**
+     * PEM certificate (public; `-----BEGIN CERTIFICATE-----`).
+     * Used to compute the `x5t` thumbprint for the JWT header.
+     * Provide either this or `certThumbprint`.
+     */
+    certificate?: string
+    /**
+     * Pre-computed SHA-1 thumbprint of the certificate, base64url-encoded.
+     * Shown in the Entra portal after uploading the certificate.
+     * Alternative to providing the full `certificate` PEM.
+     */
+    certThumbprint?: string
+}
+
+// ---------------------------------------------------------------------------
+// Exported functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds an RS256 client-assertion JWT for authenticating to Microsoft Entra ID
+ * with a certificate credential (private_key_jwt).
+ *
+ * The assertion is short-lived (5 minutes) and must be regenerated per request.
+ *
+ * @see https://learn.microsoft.com/en-us/entra/identity-platform/certificate-credentials
+ */
+export async function createMicrosoftClientAssertion(
+    config: MicrosoftCertConfig,
+    authority = AUTHORITY,
+): Promise<string> {
+    const {
+        clientId,
+        tenantId = "common",
+        privateKey,
+        certificate,
+        certThumbprint,
+    } = config
+
+    // Resolve the x5t thumbprint
+    let x5t: string
+    if (certThumbprint) {
+        x5t = certThumbprint
+    } else if (certificate) {
+        if (!thumbprintCache.has(certificate)) {
+            thumbprintCache.set(certificate, await computeX5t(certificate))
+        }
+        x5t = thumbprintCache.get(certificate)!
+    } else {
+        throw new Error(
+            "Microsoft certificate auth: provide either 'certificate' (PEM) or 'certThumbprint'",
+        )
+    }
+
+    const tokenEndpoint = `${authority}/${tenantId}/oauth2/v2.0/token`
+    const now = Math.floor(Date.now() / 1000)
+    const key = await loadPrivateKey(privateKey)
+
+    return new SignJWT({})
+        .setProtectedHeader({ alg: "RS256", typ: "JWT", x5t })
+        .setIssuer(clientId)
+        .setSubject(clientId)
+        .setAudience(tokenEndpoint)
+        .setJti(randomUUID())
+        .setIssuedAt(now)
+        .setNotBefore(now)
+        .setExpirationTime(now + 300) // 5 minutes
+        .sign(key)
+}
+
+/**
+ * Helpers that `createMicrosoftOAuthConfig` needs from `fdm-core/authentication`.
+ * Passed as parameters to avoid a circular import between the two modules.
+ */
+export interface MicrosoftOAuthHelpers {
+    splitFullName: (fullName?: string) => {
+        firstname: string | null
+        surname: string | null
+    }
+    createUsername: (email: string) => Promise<string>
+    createDisplayUsername: (
+        firstname?: string | null,
+        surname?: string | null,
+    ) => string | null
+}
+
+/**
+ * Builds a `GenericOAuthConfig` for Microsoft Entra ID that authenticates
+ * with a certificate credential (private_key_jwt) instead of a client secret.
+ *
+ * All Microsoft-specific logic lives here: token exchange, profile photo fetch,
+ * id_token decoding, and FDM user-field mapping.
+ *
+ * @param config Certificate configuration (client ID, tenant, private key, cert/thumbprint).
+ * @param helpers FDM user-mapping helpers — passed to avoid a circular dependency.
+ */
+export function createMicrosoftOAuthConfig(
+    config: MicrosoftCertConfig,
+    helpers: MicrosoftOAuthHelpers,
+): GenericOAuthConfig {
+    const { clientId, tenantId = "common" } = config
+    const authority = AUTHORITY
+    const tokenEndpoint = `${authority}/${tenantId}/oauth2/v2.0/token`
+
+    return {
+        providerId: "microsoft",
+        authorizationUrl: `${authority}/${tenantId}/oauth2/v2.0/authorize`,
+        tokenUrl: tokenEndpoint,
+        clientId,
+        scopes: SCOPES,
+        pkce: true,
+        prompt: "select_account",
+
+        // ---------------------------------------------------------------
+        // Token exchange: code → tokens using a certificate client assertion
+        // ---------------------------------------------------------------
+        getToken: async ({ code, redirectURI, codeVerifier }) => {
+            const assertion = await createMicrosoftClientAssertion(
+                config,
+                authority,
+            )
+            const body = new URLSearchParams({
+                grant_type: "authorization_code",
+                code,
+                redirect_uri: redirectURI,
+                client_id: clientId,
+                scope: SCOPES.join(" "),
+                client_assertion_type:
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                client_assertion: assertion,
+            })
+            if (codeVerifier) body.set("code_verifier", codeVerifier)
+
+            const resp = await fetch(tokenEndpoint, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/x-www-form-urlencoded",
+                    accept: "application/json",
+                },
+                body,
+            })
+            if (!resp.ok) {
+                const errorText = await resp.text()
+                throw new Error(
+                    `Microsoft token request failed (${resp.status}): ${errorText}`,
+                )
+            }
+            const data = (await resp.json()) as {
+                access_token: string
+                token_type: string
+                expires_in: number
+                refresh_token?: string
+                id_token?: string
+                scope?: string
+            }
+            return {
+                accessToken: data.access_token,
+                tokenType: data.token_type,
+                accessTokenExpiresAt: new Date(
+                    Date.now() + data.expires_in * 1000,
+                ),
+                refreshToken: data.refresh_token,
+                idToken: data.id_token,
+                scopes: data.scope?.split(" "),
+                raw: data as unknown as Record<string, unknown>,
+            }
+        },
+
+        // ---------------------------------------------------------------
+        // User info: decode id_token + fetch profile photo from Graph
+        // ---------------------------------------------------------------
+        getUserInfo: async (tokens) => {
+            if (!tokens.idToken) return null
+            const claims = decodeJwt(tokens.idToken)
+
+            // Profile photo from Graph (best-effort)
+            let picture: string | undefined
+            try {
+                const photoResp = await fetch(
+                    `https://graph.microsoft.com/v1.0/me/photos/${PROFILE_PHOTO_SIZE}x${PROFILE_PHOTO_SIZE}/$value`,
+                    { headers: { Authorization: `Bearer ${tokens.accessToken}` } },
+                )
+                if (photoResp.ok) {
+                    const buf = await photoResp.arrayBuffer()
+                    picture = `data:image/jpeg;base64, ${Buffer.from(buf).toString("base64")}`
+                }
+            } catch {
+                // photo is best-effort
+            }
+
+            const email =
+                (claims.email as string | undefined) ||
+                (claims.mail as string | undefined)
+            if (!email) throw new Error("microsoft_no_email")
+
+            const name =
+                (claims.name as string | undefined) ||
+                (claims.displayName as string | undefined) ||
+                email.split("@")[0]
+
+            const emailVerified =
+                claims.email_verified !== undefined
+                    ? Boolean(claims.email_verified)
+                    : !!(email &&
+                        (
+                            claims.verified_primary_email as
+                                | string[]
+                                | undefined
+                        )?.includes(email))
+
+            return { id: claims.sub as string, name, email, image: picture, emailVerified }
+        },
+
+        // ---------------------------------------------------------------
+        // Map provider profile to FDM-specific user fields
+        // ---------------------------------------------------------------
+        mapProfileToUser: async (profile) => {
+            const email = profile.email as string
+            const name = profile.name as string
+            const { firstname, surname } = helpers.splitFullName(name)
+            return {
+                name,
+                email,
+                emailVerified: true,
+                firstname,
+                surname,
+                username: await helpers.createUsername(email),
+                displayUsername: helpers.createDisplayUsername(
+                    firstname,
+                    surname,
+                ),
+            }
+        },
+    }
+}

--- a/fdm-core/src/authentication-ms.ts
+++ b/fdm-core/src/authentication-ms.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto"
+import fs from "node:fs"
 import type { GenericOAuthConfig } from "better-auth/plugins"
 import { decodeJwt, SignJWT, importPKCS8 } from "jose"
 
@@ -41,6 +42,29 @@ function pemToDer(pem: string): Buffer {
 
 // Cache the x5t per certificate PEM so we don't re-hash on every request
 const thumbprintCache = new Map<string, string>()
+
+/**
+ * Resolves a value that is either an inline PEM string or a file path.
+ * If the value looks like a file path (absolute or relative) and the file
+ * exists, the file content is returned; otherwise the value is returned as-is.
+ * Mirrors the pattern used by fdm-rvo for `RVO_PKIO_PRIVATE_KEY`.
+ */
+function resolveFileOrInline(value: string, label: string): string {
+    const looksLikePath =
+        value.startsWith("/") ||
+        value.startsWith("./") ||
+        value.startsWith("../") ||
+        /^[a-zA-Z]:[/\\]/.test(value)
+
+    if (looksLikePath) {
+        if (fs.existsSync(value)) {
+            return fs.readFileSync(value, "utf8")
+        }
+        throw new Error(`Microsoft cert auth: ${label} file not found: ${value}`)
+    }
+
+    return value
+}
 
 // ---------------------------------------------------------------------------
 // Exported types
@@ -103,20 +127,22 @@ export async function createMicrosoftClientAssertion(
     const {
         clientId,
         tenantId = "common",
-        privateKey,
         certificate,
         certThumbprint,
     } = config
+
+    const privateKey = resolveFileOrInline(config.privateKey, "MS_PRIVATE_KEY")
 
     // Resolve the x5t thumbprint
     let x5t: string
     if (certThumbprint) {
         x5t = certThumbprint
     } else if (certificate) {
-        if (!thumbprintCache.has(certificate)) {
-            thumbprintCache.set(certificate, await computeX5t(certificate))
+        const certPem = resolveFileOrInline(certificate, "MS_CERTIFICATE")
+        if (!thumbprintCache.has(certPem)) {
+            thumbprintCache.set(certPem, await computeX5t(certPem))
         }
-        x5t = thumbprintCache.get(certificate)!
+        x5t = thumbprintCache.get(certPem)!
     } else {
         throw new Error(
             "Microsoft certificate auth: provide either 'certificate' (PEM) or 'certThumbprint'",

--- a/fdm-core/src/authentication.test.ts
+++ b/fdm-core/src/authentication.test.ts
@@ -16,7 +16,12 @@ describe("createFdmAuth", () => {
     let fdm: FdmType
     let fdmAuth: FdmAuth
     let googleAuth: { clientSecret: string; clientId: string }
-    let microsoftAuth: { clientSecret: string; clientId: string }
+    let microsoftAuth: {
+        clientId: string
+        tenantId: string
+        privateKey: string
+        certThumbprint: string
+    }
 
     beforeEach(() => {
         // Mock environment variables
@@ -26,7 +31,9 @@ describe("createFdmAuth", () => {
         }
         microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
 
         // Create a mock FdmServer instance
@@ -45,7 +52,9 @@ describe("createFdmAuth", () => {
 
         // Verify auth providers are correctly configured
         expect(fdmAuth.options.socialProviders?.google).toBeDefined()
-        expect(fdmAuth.options.socialProviders?.microsoft).toBeDefined()
+        expect(
+            fdmAuth.options.plugins?.some((p: any) => p.id === "generic-oauth"),
+        ).toBe(true)
 
         // Verify database adapter is properly connected
         expect(fdmAuth.options.database).toBeDefined()

--- a/fdm-core/src/authentication.test.ts
+++ b/fdm-core/src/authentication.test.ts
@@ -52,8 +52,14 @@ describe("createFdmAuth", () => {
 
         // Verify auth providers are correctly configured
         expect(fdmAuth.options.socialProviders?.google).toBeDefined()
+        const genericOAuthPlugin = fdmAuth.options.plugins?.find(
+            (p: any) => p.id === "generic-oauth",
+        ) as any
+        expect(genericOAuthPlugin).toBeDefined()
         expect(
-            fdmAuth.options.plugins?.some((p: any) => p.id === "generic-oauth"),
+            genericOAuthPlugin?.options?.config?.some(
+                (c: any) => c.providerId === "microsoft",
+            ),
         ).toBe(true)
 
         // Verify database adapter is properly connected

--- a/fdm-core/src/authentication.ts
+++ b/fdm-core/src/authentication.ts
@@ -1,8 +1,8 @@
 import { apiKey } from "@better-auth/api-key"
-import type { GoogleOptions, MicrosoftOptions, User } from "better-auth"
+import type { GoogleOptions, User } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { betterAuth } from "better-auth/minimal"
-import { magicLink, organization, username } from "better-auth/plugins"
+import { genericOAuth, magicLink, organization, username } from "better-auth/plugins"
 import { eq } from "drizzle-orm"
 import { customAlphabet } from "nanoid"
 import { generateFromEmail } from "unique-username-generator"
@@ -10,6 +10,10 @@ import * as authNSchema from "./db/schema-authn"
 import { handleError } from "./error"
 import type { FdmType } from "./fdm.types"
 import { autoAcceptInvitationsForNewUser } from "./invitation"
+import {
+    createMicrosoftOAuthConfig,
+    type MicrosoftCertConfig,
+} from "./authentication-ms"
 
 export type BetterAuth = FdmAuth
 
@@ -34,7 +38,7 @@ export type BetterAuth = FdmAuth
 export function createFdmAuth(
     fdm: FdmType,
     google?: { clientSecret: string; clientId: string },
-    microsoft?: { clientSecret: string; clientId: string },
+    microsoft?: MicrosoftCertConfig,
     sendMagicLinkEmail?: (
         email: string,
         url: string,
@@ -67,41 +71,13 @@ export function createFdmAuth(
         }
     }
 
-    let microsoftAuth: MicrosoftOptions | undefined
-    if (microsoft) {
-        microsoftAuth = {
-            clientId: microsoft.clientId,
-            clientSecret: microsoft.clientSecret,
-            tenantId: "common",
-            prompt: "select_account" as const,
-            mapProfileToUser: async (profile) => {
-                const email = profile.email || (profile as any).mail
-                if (!email) {
-                    throw new Error("microsoft_no_email")
-                }
-
-                const name =
-                    profile.name ||
-                    (profile as any).displayName ||
-                    email.split("@")[0]
-
-                const picture =
-                    (profile as any).picture ?? profile.image ?? null
-
-                const { firstname, surname } = splitFullName(name)
-                return {
-                    name: name,
-                    email: email,
-                    emailVerified: true,
-                    image: picture,
-                    firstname: firstname,
-                    surname: surname,
-                    username: await createUsername(fdm, email),
-                    displayUsername: createDisplayUsername(firstname, surname),
-                }
-            },
-        }
-    }
+    const microsoftGenericOAuthConfig = microsoft
+        ? createMicrosoftOAuthConfig(microsoft, {
+              splitFullName,
+              createUsername: (email) => createUsername(fdm, email),
+              createDisplayUsername,
+          })
+        : undefined
 
     const auth = betterAuth({
         database: drizzleAdapter(fdm, {
@@ -138,7 +114,6 @@ export function createFdmAuth(
         },
         socialProviders: {
             google: googleAuth,
-            microsoft: microsoftAuth,
         },
         rateLimit: {
             enabled: process.env.NODE_ENV === "production",
@@ -163,6 +138,11 @@ export function createFdmAuth(
                 },
             }),
             username(),
+            genericOAuth({
+                config: microsoftGenericOAuthConfig
+                    ? [microsoftGenericOAuthConfig]
+                    : [],
+            }),
             organization({
                 organizationHooks: {
                     beforeCreateOrganization: async ({ organization }) => {

--- a/fdm-core/src/authorization.test.ts
+++ b/fdm-core/src/authorization.test.ts
@@ -48,7 +48,9 @@ describe("Authorization Functions", () => {
         }
         const microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
 
         fdm = createFdmServer(host, port, user, password, database, 10) // allow some connections

--- a/fdm-core/src/db/generator/authn.ts
+++ b/fdm-core/src/db/generator/authn.ts
@@ -33,8 +33,10 @@ const googleAuth = {
 }
 const microsoftAuth = {
     clientId: process.env.MICROSOFT_CLIENT_ID || "mock_ms_client_id",
-    clientSecret:
-        process.env.MICROSOFT_CLIENT_SECRET || "mock_ms_client_secret",
+    tenantId: process.env.MICROSOFT_TENANT_ID || "common",
+    privateKey: process.env.MICROSOFT_PRIVATE_KEY || "mock_ms_private_key",
+    certThumbprint:
+        process.env.MICROSOFT_CERT_THUMBPRINT || "mock_ms_thumbprint",
 }
 
 const fdm = createFdmServer(host, port, user, password, database)

--- a/fdm-core/src/db/generator/authn.ts
+++ b/fdm-core/src/db/generator/authn.ts
@@ -32,11 +32,10 @@ const googleAuth = {
         process.env.GOOGLE_CLIENT_SECRET || "mock_google_client_secret",
 }
 const microsoftAuth = {
-    clientId: process.env.MICROSOFT_CLIENT_ID || "mock_ms_client_id",
-    tenantId: process.env.MICROSOFT_TENANT_ID || "common",
-    privateKey: process.env.MICROSOFT_PRIVATE_KEY || "mock_ms_private_key",
-    certThumbprint:
-        process.env.MICROSOFT_CERT_THUMBPRINT || "mock_ms_thumbprint",
+    clientId: process.env.MS_CLIENT_ID || "mock_ms_client_id",
+    tenantId: process.env.MS_TENANT_ID || "common",
+    privateKey: process.env.MS_PRIVATE_KEY || "mock_ms_private_key",
+    certThumbprint: process.env.MS_CERT_THUMBPRINT || "mock_ms_thumbprint",
 }
 
 const fdm = createFdmServer(host, port, user, password, database)

--- a/fdm-core/src/farm.test.ts
+++ b/fdm-core/src/farm.test.ts
@@ -59,7 +59,9 @@ describe("Farm Functions", () => {
         }
         const microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
 
         fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth, undefined, true)

--- a/fdm-core/src/invitation.test.ts
+++ b/fdm-core/src/invitation.test.ts
@@ -38,7 +38,9 @@ describe("autoAcceptInvitationsForNewUser", () => {
         }
         const microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
         fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth, undefined, true)
 
@@ -267,7 +269,9 @@ describe("acceptInvitation", () => {
             },
             {
                 clientId: "mock_ms_client_id",
-                clientSecret: "mock_ms_client_secret",
+                tenantId: "common",
+                privateKey: "mock_ms_private_key",
+                certThumbprint: "mock_ms_thumbprint",
             },
             undefined,
             true,
@@ -508,7 +512,9 @@ describe("declineInvitation", () => {
             },
             {
                 clientId: "mock_ms_client_id",
-                clientSecret: "mock_ms_client_secret",
+                tenantId: "common",
+                privateKey: "mock_ms_private_key",
+                certThumbprint: "mock_ms_thumbprint",
             },
             undefined,
             true,
@@ -766,7 +772,9 @@ describe("listPendingInvitationsForPrincipal", () => {
             },
             {
                 clientId: "mock_ms_client_id",
-                clientSecret: "mock_ms_client_secret",
+                tenantId: "common",
+                privateKey: "mock_ms_private_key",
+                certThumbprint: "mock_ms_thumbprint",
             },
             undefined,
             true,
@@ -903,7 +911,9 @@ describe("createInvitation spam prevention", () => {
         }
         const microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
         fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth, undefined, true)
 

--- a/fdm-core/src/principal.test.ts
+++ b/fdm-core/src/principal.test.ts
@@ -30,7 +30,9 @@ describe("Principals", () => {
         }
         const microsoftAuth = {
             clientId: "mock_ms_client_id",
-            clientSecret: "mock_ms_client_secret",
+            tenantId: "common",
+            privateKey: "mock_ms_private_key",
+            certThumbprint: "mock_ms_thumbprint",
         }
 
         fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth, undefined, true)

--- a/fdm-docs/docs/core-concepts/09-authentication.md
+++ b/fdm-docs/docs/core-concepts/09-authentication.md
@@ -34,24 +34,41 @@ Microsoft sign-in uses a **certificate credential** (`private_key_jwt`) rather t
 |---|---|
 | `MS_CLIENT_ID` | Azure app registration client ID |
 | `MS_TENANT_ID` | Tenant segment (`common`, `organizations`, a GUID). Defaults to `common`. |
-| `MS_PRIVATE_KEY` | Inline PKCS#8 PEM private key (`-----BEGIN PRIVATE KEY-----`) |
-| `MS_CERTIFICATE` | PEM certificate (public; used to compute the `x5t` thumbprint). Provide this **or** `MS_CERT_THUMBPRINT`. |
-| `MS_CERT_THUMBPRINT` | Pre-computed SHA-1 thumbprint (base64url). Shown in Entra after uploading the certificate. |
+| `MS_PRIVATE_KEY` | PKCS#8 PEM private key — inline content **or** a file path. Never commit this. |
+| `MS_CERTIFICATE` | Full PEM certificate — inline content **or** a file path. **Recommended** — thumbprint is computed automatically. |
+| `MS_CERT_THUMBPRINT` | Alternative to `MS_CERTIFICATE`: pre-computed base64url SHA-1 thumbprint (see below). |
+
+Provide either `MS_CERTIFICATE` or `MS_CERT_THUMBPRINT`. Both `MS_PRIVATE_KEY` and `MS_CERTIFICATE` accept either the **inline PEM content** or a **file path** to the `.pem`/`.crt` file — the same flexibility as `RVO_PKIO_PRIVATE_KEY`. Using `MS_CERTIFICATE` (rather than `MS_CERT_THUMBPRINT`) is simpler — the Entra portal truncates the thumbprint display, making it difficult to copy.
 
 **Generating the key pair:**
 
 ```bash
+# Linux/macOS or PowerShell (recommended on Windows — no path expansion issues):
 openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout ms-signin-private.pem \
+  -out ms-signin-public.crt \
+  -days 730 \
+  -subj "/CN=fdm-microsoft-signin"
+
+# Git Bash on Windows — set MSYS_NO_PATHCONV=1 to prevent path expansion:
+MSYS_NO_PATHCONV=1 openssl req -x509 -newkey rsa:2048 -nodes \
   -keyout ms-signin-private.pem \
   -out ms-signin-public.crt \
   -days 730 \
   -subj "/CN=fdm-microsoft-signin"
 ```
 
-Upload `ms-signin-public.crt` in Entra: **App registration → Certificates & secrets → Certificates → Upload certificate**.  
-Store the contents of `ms-signin-private.pem` as `MS_PRIVATE_KEY` in a secure place.
+Upload `ms-signin-public.crt` in Entra: **App registration → Certificates & secrets → Certificates → Upload certificate**.
 
-**Certificate rotation:** upload the new certificate in Entra (keep both valid during rollover), then update `MS_PRIVATE_KEY` and the thumbprint/cert env vars.
+Set `MS_CERTIFICATE` to the full contents of `ms-signin-public.crt` (including the `-----BEGIN CERTIFICATE-----` header/footer). Set `MS_PRIVATE_KEY` to the full contents of `ms-signin-private.pem` and store it in Google Secret Manager.
+
+If you prefer `MS_CERT_THUMBPRINT` over `MS_CERTIFICATE`, compute it locally (the portal display is truncated):
+
+```bash
+openssl x509 -in ms-signin-public.crt -outform DER | openssl dgst -sha1 -binary | base64 | tr '+/' '-_' | tr -d '='
+```
+
+**Certificate rotation:** upload the new certificate in Entra (keep both valid during rollover), then update `MS_PRIVATE_KEY` and the cert/thumbprint env vars.
 
 ## Session Management
 

--- a/fdm-docs/docs/core-concepts/09-authentication.md
+++ b/fdm-docs/docs/core-concepts/09-authentication.md
@@ -33,12 +33,12 @@ Microsoft sign-in uses a **certificate credential** (`private_key_jwt`) rather t
 | Variable | Description |
 |---|---|
 | `MS_CLIENT_ID` | Azure app registration client ID |
-| `MS_TENANT_ID` | Tenant segment (`common`, `organizations`, a GUID). Defaults to `common`. |
+| `MS_TENANT_ID` | Tenant ID or authority segment (e.g. `common`, `organizations`, or a tenant GUID). Defaults to `common`, which allows any Microsoft account including personal accounts. |
 | `MS_PRIVATE_KEY` | PKCS#8 PEM private key — inline content **or** a file path. Never commit this. |
-| `MS_CERTIFICATE` | Full PEM certificate — inline content **or** a file path. **Recommended** — thumbprint is computed automatically. |
+| `MS_CERTIFICATE` | Full public certificate PEM — inline content **or** a file path. **Recommended** — thumbprint is computed automatically. This is the public half; it is not secret and may be stored in config. |
 | `MS_CERT_THUMBPRINT` | Alternative to `MS_CERTIFICATE`: pre-computed base64url SHA-1 thumbprint (see below). |
 
-Provide either `MS_CERTIFICATE` or `MS_CERT_THUMBPRINT`. Both `MS_PRIVATE_KEY` and `MS_CERTIFICATE` accept either the **inline PEM content** or a **file path** to the `.pem`/`.crt` file — the same flexibility as `RVO_PKIO_PRIVATE_KEY`. Using `MS_CERTIFICATE` (rather than `MS_CERT_THUMBPRINT`) is simpler — the Entra portal truncates the thumbprint display, making it difficult to copy.
+Provide either `MS_CERTIFICATE` or `MS_CERT_THUMBPRINT`. Both `MS_PRIVATE_KEY` and `MS_CERTIFICATE` accept either the **inline PEM content** or a **file path** to the `.pem`/`.crt` file. This mirrors the behaviour of `RVO_PKIO_PRIVATE_KEY` used in the RVO integration: if the value starts with a path prefix (`/`, `./`, `../`, or a Windows drive letter), the file is read at startup; otherwise the value is treated as inline PEM content. Using `MS_CERTIFICATE` (rather than `MS_CERT_THUMBPRINT`) is simpler — the Entra portal truncates the thumbprint display, making it difficult to copy.
 
 **Generating the key pair:**
 

--- a/fdm-docs/docs/core-concepts/09-authentication.md
+++ b/fdm-docs/docs/core-concepts/09-authentication.md
@@ -24,6 +24,35 @@ FDM includes integration with **Google** and **Microsoft** OAuth providers.
 * **Profile Mapping:** Upon login, FDM maps profile information from the provider (First Name, Last Name, and Profile Picture) to the FDM user profile.
 * **User Creation:** New users authenticating via OAuth are automatically provisioned with a unique username and default settings (e.g., language preference set to `nl-NL`).
 
+#### Microsoft sign-in — certificate credential
+
+Microsoft sign-in uses a **certificate credential** (`private_key_jwt`) rather than a client secret. Only the public certificate is uploaded to the Entra app registration; the private key stays on the server and is never transmitted. Each token request is authenticated by a short-lived signed JWT assertion.
+
+**Required environment variables:**
+
+| Variable | Description |
+|---|---|
+| `MS_CLIENT_ID` | Azure app registration client ID |
+| `MS_TENANT_ID` | Tenant segment (`common`, `organizations`, a GUID). Defaults to `common`. |
+| `MS_PRIVATE_KEY` | Inline PKCS#8 PEM private key (`-----BEGIN PRIVATE KEY-----`) |
+| `MS_CERTIFICATE` | PEM certificate (public; used to compute the `x5t` thumbprint). Provide this **or** `MS_CERT_THUMBPRINT`. |
+| `MS_CERT_THUMBPRINT` | Pre-computed SHA-1 thumbprint (base64url). Shown in Entra after uploading the certificate. |
+
+**Generating the key pair:**
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout ms-signin-private.pem \
+  -out ms-signin-public.crt \
+  -days 730 \
+  -subj "/CN=fdm-microsoft-signin"
+```
+
+Upload `ms-signin-public.crt` in Entra: **App registration → Certificates & secrets → Certificates → Upload certificate**.  
+Store the contents of `ms-signin-private.pem` as `MS_PRIVATE_KEY` in a secure place.
+
+**Certificate rotation:** upload the new certificate in Entra (keep both valid during rollover), then update `MS_PRIVATE_KEY` and the thumbprint/cert env vars.
+
 ## Session Management
 
 FDM uses a database-backed session system managed by Better Auth.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ catalogs:
       version: 1.69.1
     '@types/node':
       specifier: ^25.9.1
-      version: 25.9.1
+      version: 25.7.0
     '@vitest/coverage-v8':
       specifier: 4.1.7
       version: 4.1.7
@@ -27,6 +27,9 @@ catalogs:
     drizzle-orm:
       specifier: ^0.45.2
       version: 0.45.2
+    jose:
+      specifier: ^6.2.3
+      version: 6.2.3
     tsdown:
       specifier: ^0.22.0
       version: 0.22.0
@@ -41,7 +44,7 @@ catalogs:
       version: 6.0.3
     vitest:
       specifier: ^4.1.7
-      version: 4.1.7
+      version: 4.1.6
 
 importers:
 
@@ -531,6 +534,9 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(kysely@0.28.17)(postgres@3.4.9)
+      jose:
+        specifier: 'catalog:'
+        version: 6.2.3
       nanoid:
         specifier: ^5.1.11
         version: 5.1.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ packages:
 
 catalog:
   '@better-auth/api-key': ^1.6.11
+  jose: ^6.2.3
   '@dotenvx/dotenvx': ^1.69.1
   '@types/node': ^25.9.1
   '@vitest/coverage-v8': 4.1.7


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft sign-in now uses certificate-based credentials (private-key JWT); sign-in flow and redirects remain unchanged.

* **Documentation**
  * Added comprehensive guidance and examples for configuring certificate/private-key Microsoft authentication, key/certificate setup, and thumbprint generation.

* **Chores**
  * Repo and Docker ignores updated to exclude secrets from source and build contexts.

* **Tests**
  * Added/updated unit tests covering certificate-based Microsoft auth and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->