### PR TITLE
Let agents edit the ticket subject

### DIFF
--- a/fdm-app/app/components/blocks/helpdesk/ticket-schema.ts
+++ b/fdm-app/app/components/blocks/helpdesk/ticket-schema.ts
@@ -12,6 +12,7 @@ export const TicketSchema = z.object({
 
 export const TicketSubjectSchema = z
     .string("Ongeldig onderwerp")
+    .trim()
     .min(1, "Ongeldig onderwerp")
 
 export const TicketPrioritySchema = z.enum(["low", "normal", "high", "urgent"])

--- a/fdm-app/app/components/blocks/helpdesk/ticket-schema.ts
+++ b/fdm-app/app/components/blocks/helpdesk/ticket-schema.ts
@@ -10,4 +10,8 @@ export const TicketSchema = z.object({
     body: MessageBodySchema,
 })
 
+export const TicketSubjectSchema = z
+    .string("Ongeldig onderwerp")
+    .min(1, "Ongeldig onderwerp")
+
 export const TicketPrioritySchema = z.enum(["low", "normal", "high", "urgent"])

--- a/fdm-app/app/components/blocks/helpdesk/ticket-subject.tsx
+++ b/fdm-app/app/components/blocks/helpdesk/ticket-subject.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react"
 import { useFetcher } from "react-router"
-import { Input } from "~/components/ui/input"
-import { Button } from "../../ui/button"
-import { Spinner } from "../../ui/spinner"
 import { cn } from "@/app/lib/utils"
+import { Button } from "~/components/ui/button"
+import { Input } from "~/components/ui/input"
+import { Spinner } from "~/components/ui/spinner"
 
 export function TicketSubjectEditor({
     subject = "Ticket",
@@ -32,18 +32,20 @@ export function TicketSubjectEditor({
 
     if (!isEditing && fetcher.state === "idle") {
         return (
-            <Button
-                variant="link"
-                className="text-3xl font-bold"
-                onClick={() => setIsEditing(true)}
-            >
-                {subject ?? "Ticket"}
-            </Button>
+            <h1 className="text-3xl font-bold">
+                <Button
+                    variant="link"
+                    className="h-auto p-0 text-3xl font-bold"
+                    onClick={() => setIsEditing(true)}
+                >
+                    {subject ?? "Ticket"}
+                </Button>
+            </h1>
         )
     }
 
     return (
-        <div className="relative">
+        <h1 className="relative text-3xl font-bold">
             <Input
                 type="text"
                 value={value}
@@ -58,6 +60,7 @@ export function TicketSubjectEditor({
                             formData.set("subject", value)
                             fetcher.submit(formData, { method: "POST" })
                         } else {
+                            setValue(subject)
                             setIsEditing(false)
                         }
                     }
@@ -67,6 +70,7 @@ export function TicketSubjectEditor({
                         e.currentTarget.blur()
                     }
                     if (e.key === "Escape") {
+                        setValue(subject)
                         setIsEditing(false)
                     }
                 }}
@@ -77,6 +81,6 @@ export function TicketSubjectEditor({
                     fetcher.state === "idle" && "invisible",
                 )}
             />
-        </div>
+        </h1>
     )
 }

--- a/fdm-app/app/components/blocks/helpdesk/ticket-subject.tsx
+++ b/fdm-app/app/components/blocks/helpdesk/ticket-subject.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+import { useFetcher } from "react-router"
+import { Input } from "~/components/ui/input"
+import { Button } from "../../ui/button"
+import { Spinner } from "../../ui/spinner"
+import { cn } from "@/app/lib/utils"
+
+export function TicketSubjectEditor({
+    subject = "Ticket",
+    canModify,
+}: {
+    subject?: string
+    canModify: boolean
+}) {
+    const fetcher = useFetcher()
+    const [isEditing, setIsEditing] = useState(false)
+    const [value, setValue] = useState(subject)
+
+    useEffect(() => {
+        if (fetcher.state === "idle") {
+            setIsEditing(false)
+        }
+    }, [fetcher.state])
+
+    useEffect(() => {
+        setValue(subject)
+    }, [subject])
+
+    if (!canModify) {
+        return <h1 className="text-3xl font-bold">{subject}</h1>
+    }
+
+    if (!isEditing && fetcher.state === "idle") {
+        return (
+            <Button
+                variant="link"
+                className="text-3xl font-bold"
+                onClick={() => setIsEditing(true)}
+            >
+                {subject ?? "Ticket"}
+            </Button>
+        )
+    }
+
+    return (
+        <div className="relative">
+            <Input
+                type="text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                disabled={fetcher.state !== "idle"}
+                autoFocus
+                onBlur={() => {
+                    if (isEditing) {
+                        if (value !== subject) {
+                            const formData = new FormData()
+                            formData.set("intent", "update_subject")
+                            formData.set("subject", value)
+                            fetcher.submit(formData, { method: "POST" })
+                        } else {
+                            setIsEditing(false)
+                        }
+                    }
+                }}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        e.currentTarget.blur()
+                    }
+                    if (e.key === "Escape") {
+                        setIsEditing(false)
+                    }
+                }}
+            />
+            <Spinner
+                className={cn(
+                    "absolute right-2 top-1/2 -translate-y-1/2",
+                    fetcher.state === "idle" && "invisible",
+                )}
+            />
+        </div>
+    )
+}

--- a/fdm-app/app/components/blocks/helpdesk/ticket.tsx
+++ b/fdm-app/app/components/blocks/helpdesk/ticket.tsx
@@ -23,6 +23,7 @@ import {
 } from "./ticket-status"
 import { TicketTags } from "./ticket-tags"
 import type { HelpdeskUser } from "./types"
+import { TicketSubjectEditor } from "./ticket-subject"
 
 export function Ticket({
     ticket,
@@ -110,9 +111,10 @@ export function Ticket({
                 </div>
 
                 {/* 2. Title */}
-                <h1 className="text-3xl font-bold">
-                    {ticket.subject ?? "Ticket"}
-                </h1>
+                <TicketSubjectEditor
+                    subject={ticket.subject ?? undefined}
+                    canModify={isAgent}
+                />
 
                 {/* 3. State row */}
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-2">

--- a/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
+++ b/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
@@ -20,7 +20,7 @@ import {
     updateTicketSubject,
 } from "@nmi-agro/fdm-helpdesk"
 import { useLoaderData } from "react-router"
-import { dataWithError, dataWithSuccess } from "remix-toast"
+import { dataWithSuccess } from "remix-toast"
 import z from "zod"
 import { getSession } from "@/app/lib/auth.server"
 import { sendHelpdeskNewMessageEmail } from "@/app/lib/email.server"

--- a/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
+++ b/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
@@ -17,9 +17,10 @@ import {
     unassignTicket,
     updateTicketPriority,
     updateTicketStatus,
+    updateTicketSubject,
 } from "@nmi-agro/fdm-helpdesk"
 import { useLoaderData } from "react-router"
-import { dataWithSuccess } from "remix-toast"
+import { dataWithError, dataWithSuccess } from "remix-toast"
 import z from "zod"
 import { getSession } from "@/app/lib/auth.server"
 import { sendHelpdeskNewMessageEmail } from "@/app/lib/email.server"
@@ -34,7 +35,10 @@ import {
     TicketTagsSchema,
 } from "~/components/blocks/helpdesk/tag-schema"
 import { Ticket } from "~/components/blocks/helpdesk/ticket"
-import { TicketPrioritySchema } from "~/components/blocks/helpdesk/ticket-schema"
+import {
+    TicketPrioritySchema,
+    TicketSubjectSchema,
+} from "~/components/blocks/helpdesk/ticket-schema"
 
 interface Args {
     params: { ticket_id: string }
@@ -168,6 +172,10 @@ export const ActionSchema = z.discriminatedUnion("intent", [
     z.object({ intent: z.literal("mark_ticket_as_viewed") }),
     z.object({ intent: z.literal("set_ticket_status"), status: z.string() }),
     z.object({
+        intent: z.literal("update_subject"),
+        subject: TicketSubjectSchema,
+    }),
+    z.object({
         intent: z.literal("update_priority"),
         priority: TicketPrioritySchema,
     }),
@@ -203,6 +211,19 @@ export async function action({ params, request }: Args) {
 
             return dataWithSuccess("De status is successvol bijgewerkt!", {
                 message: "De status is successvol bijgewerkt!",
+            })
+        }
+
+        if (formValues.intent === "update_subject") {
+            await updateTicketSubject(
+                fdm,
+                session.principal_id,
+                params.ticket_id,
+                formValues.subject,
+            )
+
+            return dataWithSuccess("Het onderwerp is succesvol bijgewerkt!", {
+                message: "Het onderwerp is succesvol bijgewerkt!",
             })
         }
 
@@ -453,6 +474,15 @@ export async function action({ params, request }: Args) {
             })
         }
     } catch (err) {
+        // extractFormValuesFromRequest calls handleActionError itself, so if that is detected to be the case,
+        // return the response returned from it directly.
+        if (err instanceof Promise) {
+            const awaited = await (err as Promise<any>).catch(() => {})
+            if (awaited.type === "DataWithResponseInit") {
+                return awaited
+            }
+        }
+
         throw handleActionError(err)
     }
 }

--- a/fdm-helpdesk/src/ticket.test.ts
+++ b/fdm-helpdesk/src/ticket.test.ts
@@ -20,6 +20,7 @@ import {
     markTicketAsViewed,
     updateTicketPriority,
     updateTicketStatus,
+    updateTicketSubject,
     updateTicketSubjectAndPriorityUnchecked,
     validateTicketStatusTransition,
 } from "./ticket"
@@ -556,6 +557,41 @@ describe("updateTicketSubjectAndPriorityUnchecked", () => {
         expect(ticket.subject).toBe("Ticket 1")
         expect(ticket.priority).toBe("low")
         expect(ticket.updated).not.toBeNull()
+    })
+})
+
+describe("updateTicketSubject", () => {
+    let agent_id: string
+    let requester_id: string
+    let ticket_id: string
+
+    test.beforeEach(async ({ fdm }) => {
+        agent_id = createId()
+        requester_id = createId()
+        await addAdminAgent(fdm, agent_id, "Support Agent")
+        ticket_id = await createTicket(fdm, requester_id, "Ticket 1")
+    })
+
+    test("should let agents update the subject", async ({ fdm }) => {
+        await updateTicketSubject(fdm, agent_id, ticket_id, "Ticket 1 Subject")
+        const ticket = await getTicket(fdm, agent_id, ticket_id)
+        expect(ticket.subject).toBe("Ticket 1 Subject")
+        expect(ticket.updated).not.toBeNull()
+    })
+
+    test("should not let regular users update the subject", async ({
+        fdm,
+    }) => {
+        try {
+            await updateTicketSubject(fdm, requester_id, ticket_id, "Ticket 1 Subject")
+        } catch (_err) {
+            const ticket = await getTicket(fdm, requester_id, ticket_id)
+            expect(ticket.subject).toBe("Ticket 1")
+            expect(ticket.updated).toBeNull()
+            return
+        }
+
+        throw new Error("Should have thrown")
     })
 })
 

--- a/fdm-helpdesk/src/ticket.ts
+++ b/fdm-helpdesk/src/ticket.ts
@@ -615,6 +615,43 @@ export async function updateTicketSubjectAndPriorityUnchecked(
 }
 
 /**
+ * Updates the ticket subject.
+ *
+ * @param fdm The FDM instance providing the connection to the database. The instance can be created with
+ * {@link createFdmServer} of fdm-core.
+ * @param principal_id The principal identifier(s); must have agent-side write access to the ticket.
+ * @param ticket_id ID of the ticket to update.
+ * @param subject The new ticket subject.
+ */
+export async function updateTicketSubject(
+    fdm: FdmHelpdeskType,
+    principal_id: HelpdeskPrincipalId,
+    ticket_id: schema.TicketTypeSelect["ticket_id"],
+    subject?: string,
+) {
+    try {
+        await checkHelpdeskPermission(
+            fdm,
+            "ticket-agent-side",
+            "write",
+            ticket_id,
+            principal_id,
+            "updateTicketPriority",
+        )
+
+        await fdm
+            .update(schema.tickets)
+            .set({ subject: subject, updated: sql`now()` })
+            .where(eq(schema.tickets.ticket_id, ticket_id))
+    } catch (e) {
+        throw handleError(e, "Exception for updateTicketSubject", {
+            principal_id,
+            ticket_id,
+        })
+    }
+}
+
+/**
  * Updates the ticket priority.
  *
  * @param fdm The FDM instance providing the connection to the database. The instance can be created with
@@ -645,6 +682,7 @@ export async function updateTicketPriority(
             .where(eq(schema.tickets.ticket_id, ticket_id))
     } catch (e) {
         throw handleError(e, "Exception for updateTicketPriority", {
+            principal_id,
             ticket_id,
             priority,
         })


### PR DESCRIPTION
**Enhancements**

- Agents can now click on the ticket subject to edit it. This is useful in case AI triage is disabled via the PostHog feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket subjects can now be edited directly from the ticket view when you have permission.
  * Updated subject changes are saved inline and confirmed with a success message.

* **Bug Fixes**
  * Added validation for ticket subjects to prevent empty values and show clearer error messages.
  * Restricted subject editing to authorized users only, with proper handling for failed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->