### PR TITLE
Add persisted field context, field pickers, and map card

### DIFF
--- a/.changeset/silver-laws-talk.md
+++ b/.changeset/silver-laws-talk.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Added a context-aware Perceel collapsible group at the bottom of the Bedrijf section in the sidebar to make it easier to navigate to the field-specific pages.

--- a/fdm-app/app/components/blocks/header/field.tsx
+++ b/fdm-app/app/components/blocks/header/field.tsx
@@ -41,7 +41,7 @@ export function HeaderField({
       : b_id
         ? currentPath.replace(b_id, optionId)
         : `/farm/${b_id_farm}/${calendar}/field/${optionId}/overview`
-    navigate(targetUrl)
+    void navigate(targetUrl)
   }
 
   // Get recently visited fields

--- a/fdm-app/app/components/blocks/header/field.tsx
+++ b/fdm-app/app/components/blocks/header/field.tsx
@@ -95,6 +95,7 @@ export function HeaderField({
                         ))}
                       </CommandGroup>
                     )}
+                    {regularFields.length > 0 && (
                     <CommandGroup heading="Alle percelen">
                       {regularFields.map((option) => (
                         <CommandItem
@@ -110,6 +111,7 @@ export function HeaderField({
                         </CommandItem>
                       ))}
                     </CommandGroup>
+                    )}
                   </CommandList>
                 </Command>
               </PopoverContent>

--- a/fdm-app/app/components/blocks/header/field.tsx
+++ b/fdm-app/app/components/blocks/header/field.tsx
@@ -1,14 +1,19 @@
-import { ChevronDown } from "lucide-react"
-import { NavLink, useLocation } from "react-router"
+import { ChevronDown, Check } from "lucide-react"
+import { useState } from "react"
+import { useNavigate, useLocation } from "react-router"
 import { cn } from "@/app/lib/utils"
 import { useCalendarStore } from "@/app/store/calendar"
+import { useSelectedFieldStore } from "@/app/store/selected-field"
 import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "~/components/ui/dropdown-menu"
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover"
 
 export function HeaderField({
   b_id_farm,
@@ -21,9 +26,27 @@ export function HeaderField({
   fieldOptions: HeaderFieldOption[]
   compact?: boolean
 }) {
+  const [open, setOpen] = useState(false)
   const location = useLocation()
+  const navigate = useNavigate()
   const currentPath = String(location.pathname)
   const calendar = useCalendarStore((state) => state.calendar)
+  const { recentFieldIds, setSelectedField } = useSelectedFieldStore()
+
+  const handleSelect = (optionId: string, optionName: string) => {
+    setOpen(false)
+    setSelectedField(optionId, optionName)
+    const targetUrl = currentPath.includes("/cultivation")
+      ? `/farm/${b_id_farm}/${calendar}/field/${optionId}/cultivation`
+      : b_id
+        ? currentPath.replace(b_id, optionId)
+        : `/farm/${b_id_farm}/${calendar}/field/${optionId}/overview`
+    navigate(targetUrl)
+  }
+
+  // Get recently visited fields
+  const recentFields = fieldOptions.filter((f) => recentFieldIds.includes(f.b_id))
+  const regularFields = fieldOptions.filter((f) => !recentFieldIds.includes(f.b_id))
 
   return (
     <>
@@ -35,8 +58,8 @@ export function HeaderField({
         <>
           <BreadcrumbSeparator className={cn("hidden", !compact && "xl:block")} />
           <BreadcrumbItem>
-            <DropdownMenu>
-              <DropdownMenuTrigger className="flex max-w-[120px] items-center gap-1 outline-none sm:max-w-[200px] md:max-w-none">
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger className="flex max-w-[120px] cursor-pointer items-center gap-1 outline-none sm:max-w-[200px] md:max-w-none">
                 <span className="truncate">
                   {b_id && fieldOptions
                     ? (fieldOptions.find((option) => option.b_id === b_id)?.b_name ??
@@ -44,25 +67,51 @@ export function HeaderField({
                     : "Kies een perceel"}
                 </span>
                 <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {fieldOptions.map((option) => (
-                  <DropdownMenuCheckboxItem checked={b_id === option.b_id} key={option.b_id}>
-                    <NavLink
-                      to={
-                        currentPath.includes("/cultivation")
-                          ? `/farm/${b_id_farm}/${calendar}/field/${option.b_id}/cultivation`
-                          : b_id
-                            ? currentPath.replace(b_id, option.b_id)
-                            : `/farm/${b_id_farm}/${calendar}/field/${option.b_id}`
-                      }
-                    >
-                      {option.b_name}
-                    </NavLink>
-                  </DropdownMenuCheckboxItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-[280px] p-0">
+                <Command>
+                  <CommandInput
+                    placeholder="Zoek perceel..."
+                    className="border-none focus:ring-0 focus-visible:ring-0"
+                  />
+                  <CommandList className="max-h-[300px] overflow-y-auto">
+                    <CommandEmpty>Geen percelen gevonden.</CommandEmpty>
+                    {recentFields.length > 0 && (
+                      <CommandGroup heading="Onlangs bezocht">
+                        {recentFields.map((option) => (
+                          <CommandItem
+                            key={`header-recent-${option.b_id}`}
+                            value={option.b_name ?? ""}
+                            onSelect={() => handleSelect(option.b_id, option.b_name ?? "")}
+                            className="flex cursor-pointer items-center justify-between"
+                          >
+                            <span>{option.b_name}</span>
+                            {b_id === option.b_id && (
+                              <Check className="text-primary ml-auto h-4 w-4 shrink-0" />
+                            )}
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    )}
+                    <CommandGroup heading="Alle percelen">
+                      {regularFields.map((option) => (
+                        <CommandItem
+                          key={option.b_id}
+                          value={option.b_name ?? ""}
+                          onSelect={() => handleSelect(option.b_id, option.b_name ?? "")}
+                          className="flex cursor-pointer items-center justify-between"
+                        >
+                          <span>{option.b_name}</span>
+                          {b_id === option.b_id && (
+                            <Check className="text-primary ml-auto h-4 w-4 shrink-0" />
+                          )}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </BreadcrumbItem>
         </>
       ) : (

--- a/fdm-app/app/components/blocks/header/field.tsx
+++ b/fdm-app/app/components/blocks/header/field.tsx
@@ -39,13 +39,15 @@ export function HeaderField({
     const targetUrl = currentPath.includes("/cultivation")
       ? `/farm/${b_id_farm}/${calendar}/field/${optionId}/cultivation`
       : b_id
-        ? currentPath.replace(b_id, optionId)
+        ? currentPath.replace(`/field/${b_id}`, `/field/${optionId}`)
         : `/farm/${b_id_farm}/${calendar}/field/${optionId}/overview`
     void navigate(targetUrl)
   }
 
-  // Get recently visited fields
-  const recentFields = fieldOptions.filter((f) => recentFieldIds.includes(f.b_id))
+  // LRU order: iterate recentFieldIds so most-recent-first is preserved
+  const recentFields = recentFieldIds
+    .map((id) => fieldOptions.find((f) => f.b_id === id))
+    .filter((f): f is NonNullable<typeof f> => f !== undefined)
   const regularFields = fieldOptions.filter((f) => !recentFieldIds.includes(f.b_id))
 
   return (

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -48,12 +48,10 @@ import { getFieldNavigationItems } from "~/lib/field-navigation"
 export function SidebarFarm({
   farm,
   fields = [],
-  farmWritePermission = false,
   activeFieldId,
 }: {
   farm: Awaited<ReturnType<typeof getFarm>> | undefined
   fields?: { b_id: string; b_name: string; b_area: number }[]
-  farmWritePermission?: boolean
   activeFieldId?: string | null
 }) {
   function getSuperiorRole(allRoles: { role: "owner" | "advisor" | "researcher" }[]) {
@@ -108,7 +106,6 @@ export function SidebarFarm({
     if (location.pathname.includes("/fertilizer")) return "fertilizer"
     if (location.pathname.includes("/soil")) return "soil"
     if (location.pathname.includes("/bcs")) return "bcs"
-    if (location.pathname.includes("/atlas")) return "atlas"
     if (location.pathname.includes("/delete")) return "delete"
     return "overview"
   }
@@ -131,18 +128,16 @@ export function SidebarFarm({
     void navigate(`/farm/${farmId}/${selectedCalendar}/field/${b_id}/${segment}`)
   }
 
-  const toggleCollapsible = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    e.preventDefault()
-    setIsPerceelOpen(!isPerceelOpen)
-  }
-
-  const recentFields = fields.filter((f) => recentFieldIds.includes(f.b_id))
+  // LRU order: iterate recentFieldIds so most-recent-first is preserved
+  const recentFields = recentFieldIds
+    .map((id) => fields.find((f) => f.b_id === id))
+    .filter((f): f is NonNullable<typeof f> => f !== undefined)
   const regularFields = fields.filter((f) => !recentFieldIds.includes(f.b_id))
 
+  // Never show delete from the sidebar — field-level permission is not available here
   const navigationItems = activeFieldId
-    ? getFieldNavigationItems(farmId!, selectedCalendar!, activeFieldId, farmWritePermission)
-    : getFieldNavigationItems(farmId ?? "", selectedCalendar ?? "", "", farmWritePermission)
+    ? getFieldNavigationItems(farmId!, selectedCalendar!, activeFieldId, false)
+    : getFieldNavigationItems(farmId ?? "", selectedCalendar ?? "", "", false)
 
   let rotationLink: string | undefined
   if (isCreateFarmWizard) {
@@ -395,43 +390,48 @@ export function SidebarFarm({
                 onOpenChange={setIsPerceelOpen}
               >
                 <SidebarMenuItem>
-                  <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
-                    <PopoverTrigger asChild>
-                      <SidebarMenuButton
-                        tooltip={"Perceel"}
-                        className="flex w-full items-center justify-between"
-                      >
-                        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+                  <div className="flex w-full items-center">
+                    <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+                      <PopoverTrigger asChild>
+                        <SidebarMenuButton
+                          tooltip={"Perceel"}
+                          className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden"
+                        >
                           <LandPlot className="size-4 shrink-0" />
                           <span className="truncate font-medium">
                             {activeFieldName ?? "Kies een perceel"}
                           </span>
-                        </span>
-                        <button
-                          type="button"
-                          onClick={toggleCollapsible}
-                          className="hover:bg-sidebar-accent/50 rounded-sm p-1 transition-transform duration-200"
-                          style={{
-                            transform: isPerceelOpen ? "rotate(90deg)" : "none",
-                          }}
-                        >
-                          <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
-                        </button>
-                      </SidebarMenuButton>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[280px] p-0" align="start" side="right">
-                      <Command>
-                        <CommandInput
-                          placeholder="Zoek perceel..."
-                          className="border-none focus:ring-0 focus-visible:ring-0"
-                        />
-                        <CommandList className="max-h-[300px] overflow-y-auto">
-                          <CommandEmpty>Geen percelen gevonden.</CommandEmpty>
-                          {recentFields.length > 0 && (
-                            <CommandGroup heading="Onlangs bezocht">
-                              {recentFields.map((field) => (
+                        </SidebarMenuButton>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-[280px] p-0" align="start" side="right">
+                        <Command>
+                          <CommandInput
+                            placeholder="Zoek perceel..."
+                            className="border-none focus:ring-0 focus-visible:ring-0"
+                          />
+                          <CommandList className="max-h-[300px] overflow-y-auto">
+                            <CommandEmpty>Geen percelen gevonden.</CommandEmpty>
+                            {recentFields.length > 0 && (
+                              <CommandGroup heading="Onlangs bezocht">
+                                {recentFields.map((field) => (
+                                  <CommandItem
+                                    key={`recent-${field.b_id}`}
+                                    value={field.b_name}
+                                    onSelect={() => handleSelectField(field.b_id, field.b_name)}
+                                    className="flex cursor-pointer items-center justify-between"
+                                  >
+                                    <span>{field.b_name}</span>
+                                    <span className="text-muted-foreground text-xs">
+                                      {field.b_area} ha
+                                    </span>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            )}
+                            <CommandGroup heading="Alle percelen">
+                              {regularFields.map((field) => (
                                 <CommandItem
-                                  key={`recent-${field.b_id}`}
+                                  key={field.b_id}
                                   value={field.b_name}
                                   onSelect={() => handleSelectField(field.b_id, field.b_name)}
                                   className="flex cursor-pointer items-center justify-between"
@@ -443,26 +443,19 @@ export function SidebarFarm({
                                 </CommandItem>
                               ))}
                             </CommandGroup>
-                          )}
-                          <CommandGroup heading="Alle percelen">
-                            {regularFields.map((field) => (
-                              <CommandItem
-                                key={field.b_id}
-                                value={field.b_name}
-                                onSelect={() => handleSelectField(field.b_id, field.b_name)}
-                                className="flex cursor-pointer items-center justify-between"
-                              >
-                                <span>{field.b_name}</span>
-                                <span className="text-muted-foreground text-xs">
-                                  {field.b_area} ha
-                                </span>
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                    <CollapsibleTrigger asChild>
+                      <button
+                        type="button"
+                        className="hover:bg-sidebar-accent/50 rounded-sm p-1 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+                      >
+                        <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                      </button>
+                    </CollapsibleTrigger>
+                  </div>
 
                   <CollapsibleContent>
                     <SidebarMenuSub>

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -429,6 +429,7 @@ export function SidebarFarm({
                                 ))}
                               </CommandGroup>
                             )}
+                            {regularFields.length > 0 && (
                             <CommandGroup heading="Alle percelen">
                               {regularFields.map((field) => (
                                 <CommandItem
@@ -444,6 +445,7 @@ export function SidebarFarm({
                                 </CommandItem>
                               ))}
                             </CommandGroup>
+                            )}
                           </CommandList>
                         </Command>
                       </PopoverContent>

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -49,10 +49,12 @@ export function SidebarFarm({
   farm,
   fields = [],
   activeFieldId,
+  fieldWritePermission = false,
 }: {
   farm: Awaited<ReturnType<typeof getFarm>> | undefined
   fields?: { b_id: string; b_name: string; b_area: number }[]
   activeFieldId?: string | null
+  fieldWritePermission?: boolean
 }) {
   function getSuperiorRole(allRoles: { role: "owner" | "advisor" | "researcher" }[]) {
     if (allRoles.length > 0) {
@@ -134,9 +136,8 @@ export function SidebarFarm({
     .filter((f): f is NonNullable<typeof f> => f !== undefined)
   const regularFields = fields.filter((f) => !recentFieldIds.includes(f.b_id))
 
-  // Never show delete from the sidebar — field-level permission is not available here
   const navigationItems = activeFieldId
-    ? getFieldNavigationItems(farmId!, selectedCalendar!, activeFieldId, false)
+    ? getFieldNavigationItems(farmId!, selectedCalendar!, activeFieldId, fieldWritePermission)
     : getFieldNavigationItems(farmId ?? "", selectedCalendar ?? "", "", false)
 
   let rotationLink: string | undefined
@@ -450,6 +451,7 @@ export function SidebarFarm({
                     <CollapsibleTrigger asChild>
                       <button
                         type="button"
+                        aria-label="Perceel sectie in- of uitklappen"
                         className="hover:bg-sidebar-accent/50 rounded-sm p-1 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
                       >
                         <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -6,20 +6,31 @@ import {
   Check,
   ChevronRight,
   ClipboardList,
+  Grid2x2,
   House,
+  LandPlot,
   LayoutGrid,
   Shapes,
   Sprout,
-  Square,
 } from "lucide-react"
 import { useFeatureFlagEnabled } from "posthog-js/react"
-import { useState } from "react"
-import { NavLink, useLocation, useSearchParams } from "react-router"
+import { useState, useEffect } from "react"
+import { NavLink, useLocation, useSearchParams, useNavigate } from "react-router"
 import { getCalendarSelection } from "@/app/lib/calendar"
 import { useCalendarStore } from "@/app/store/calendar"
 import { useFarmStore } from "@/app/store/farm"
+import { useSelectedFieldStore } from "@/app/store/selected-field"
 import { Badge } from "~/components/ui/badge"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/components/ui/collapsible"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command"
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover"
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -32,8 +43,19 @@ import {
   SidebarMenuSubItem,
 } from "~/components/ui/sidebar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip"
+import { getFieldNavigationItems } from "~/lib/field-navigation"
 
-export function SidebarFarm({ farm }: { farm: Awaited<ReturnType<typeof getFarm>> | undefined }) {
+export function SidebarFarm({
+  farm,
+  fields = [],
+  farmWritePermission = false,
+  activeFieldId,
+}: {
+  farm: Awaited<ReturnType<typeof getFarm>> | undefined
+  fields?: { b_id: string; b_name: string; b_area: number }[]
+  farmWritePermission?: boolean
+  activeFieldId?: string | null
+}) {
   function getSuperiorRole(allRoles: { role: "owner" | "advisor" | "researcher" }[]) {
     if (allRoles.length > 0) {
       const ordering = ["owner", "advisor", "researcher"] as const
@@ -53,6 +75,7 @@ export function SidebarFarm({ farm }: { farm: Awaited<ReturnType<typeof getFarm>
   const calendarSelection = getCalendarSelection()
 
   const location = useLocation()
+  const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   // Check if the page or its return page contains `farm/create` in url
   const isCreateFarmWizard =
@@ -64,14 +87,62 @@ export function SidebarFarm({ farm }: { farm: Awaited<ReturnType<typeof getFarm>
 
   const isFarmSelected = farmId && farmId !== "undefined" && !isCreateFarmWizard
 
-  let fieldsLink: string | undefined
-  if (isCreateFarmWizard) {
-    fieldsLink = undefined
-  } else if (farmId && farmId !== "undefined") {
-    fieldsLink = `/farm/${farmId}/${selectedCalendar}/field`
-  } else {
-    fieldsLink = undefined
+  const { recentFieldIds, addRecentFieldId } = useSelectedFieldStore()
+
+  const activeFieldName = activeFieldId
+    ? (fields.find((f) => f.b_id === activeFieldId)?.b_name ?? null)
+    : null
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
+  const [isPerceelOpen, setIsPerceelOpen] = useState(false)
+  const [targetSegment, setTargetSegment] = useState("overview")
+
+  // Auto-expand whenever a field is active
+  useEffect(() => {
+    if (activeFieldId) {
+      setIsPerceelOpen(true)
+    }
+  }, [activeFieldId])
+
+  const getActiveSegment = () => {
+    if (location.pathname.includes("/cultivation")) return "cultivation"
+    if (location.pathname.includes("/fertilizer")) return "fertilizer"
+    if (location.pathname.includes("/soil")) return "soil"
+    if (location.pathname.includes("/bcs")) return "bcs"
+    if (location.pathname.includes("/atlas")) return "atlas"
+    if (location.pathname.includes("/delete")) return "delete"
+    return "overview"
   }
+
+  const handleSubSectionClick = (e: React.MouseEvent, segment: string) => {
+    if (!activeFieldId) {
+      e.preventDefault()
+      setTargetSegment(segment)
+      setIsPickerOpen(true)
+    }
+  }
+
+  const handleSelectField = (b_id: string, _b_name: string) => {
+    setIsPickerOpen(false)
+    addRecentFieldId(b_id)
+
+    const activeSegment = getActiveSegment()
+    const segment = activeFieldId ? activeSegment : targetSegment
+
+    navigate(`/farm/${farmId}/${selectedCalendar}/field/${b_id}/${segment}`)
+  }
+
+  const toggleCollapsible = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    setIsPerceelOpen(!isPerceelOpen)
+  }
+
+  const recentFields = fields.filter((f) => recentFieldIds.includes(f.b_id))
+  const regularFields = fields.filter((f) => !recentFieldIds.includes(f.b_id))
+
+  const navigationItems = activeFieldId
+    ? getFieldNavigationItems(farmId!, selectedCalendar!, activeFieldId, farmWritePermission)
+    : getFieldNavigationItems(farmId ?? "", selectedCalendar ?? "", "", farmWritePermission)
 
   let rotationLink: string | undefined
   if (isCreateFarmWizard) {
@@ -212,39 +283,22 @@ export function SidebarFarm({ farm }: { farm: Awaited<ReturnType<typeof getFarm>
                 </Tooltip>
               </SidebarMenuItem>
             )}
-            <SidebarMenuItem>
-              {fieldsLink ? (
+            {isFarmSelected && (
+              <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
                   isActive={
-                    location.pathname.includes(`/farm/${farmId}/`) &&
-                    location.pathname.includes("/field")
+                    location.pathname === `/farm/${farmId}/${selectedCalendar}/field` ||
+                    location.pathname === `/farm/${farmId}/${selectedCalendar}/field/`
                   }
                 >
-                  <NavLink to={fieldsLink}>
-                    <Square />
+                  <NavLink to={`/farm/${farmId}/${selectedCalendar}/field`}>
+                    <Grid2x2 />
                     <span>Percelen</span>
                   </NavLink>
                 </SidebarMenuButton>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <SidebarMenuButton
-                      asChild
-                      className="cursor-not-allowed opacity-50 hover:bg-transparent"
-                    >
-                      <span className="flex items-center gap-2">
-                        <Square />
-                        <span>Percelen</span>
-                      </span>
-                    </SidebarMenuButton>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">
-                    Selecteer een bedrijf om uw percelen te beheren
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </SidebarMenuItem>
+              </SidebarMenuItem>
+            )}
             <SidebarMenuItem>
               {rotationLink ? (
                 <SidebarMenuButton
@@ -332,6 +386,125 @@ export function SidebarFarm({ farm }: { farm: Awaited<ReturnType<typeof getFarm>
                 </Tooltip>
               )}
             </SidebarMenuItem>
+            {/* Context-aware Perceel group */}
+            {isFarmSelected ? (
+              <Collapsible
+                asChild
+                open={isPerceelOpen}
+                className="group/collapsible"
+                onOpenChange={setIsPerceelOpen}
+              >
+                <SidebarMenuItem>
+                  <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+                    <PopoverTrigger asChild>
+                      <SidebarMenuButton
+                        tooltip={"Perceel"}
+                        className="flex w-full items-center justify-between"
+                      >
+                        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+                          <LandPlot className="size-4 shrink-0" />
+                          <span className="truncate font-medium">
+                            {activeFieldName ?? "Kies een perceel"}
+                          </span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={toggleCollapsible}
+                          className="hover:bg-sidebar-accent/50 rounded-sm p-1 transition-transform duration-200"
+                          style={{
+                            transform: isPerceelOpen ? "rotate(90deg)" : "none",
+                          }}
+                        >
+                          <ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                        </button>
+                      </SidebarMenuButton>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-[280px] p-0" align="start" side="right">
+                      <Command>
+                        <CommandInput
+                          placeholder="Zoek perceel..."
+                          className="border-none focus:ring-0 focus-visible:ring-0"
+                        />
+                        <CommandList className="max-h-[300px] overflow-y-auto">
+                          <CommandEmpty>Geen percelen gevonden.</CommandEmpty>
+                          {recentFields.length > 0 && (
+                            <CommandGroup heading="Onlangs bezocht">
+                              {recentFields.map((field) => (
+                                <CommandItem
+                                  key={`recent-${field.b_id}`}
+                                  value={field.b_name}
+                                  onSelect={() => handleSelectField(field.b_id, field.b_name)}
+                                  className="flex cursor-pointer items-center justify-between"
+                                >
+                                  <span>{field.b_name}</span>
+                                  <span className="text-muted-foreground text-xs">
+                                    {field.b_area} ha
+                                  </span>
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          )}
+                          <CommandGroup heading="Alle percelen">
+                            {regularFields.map((field) => (
+                              <CommandItem
+                                key={field.b_id}
+                                value={field.b_name}
+                                onSelect={() => handleSelectField(field.b_id, field.b_name)}
+                                className="flex cursor-pointer items-center justify-between"
+                              >
+                                <span>{field.b_name}</span>
+                                <span className="text-muted-foreground text-xs">
+                                  {field.b_area} ha
+                                </span>
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+
+                  <CollapsibleContent>
+                    <SidebarMenuSub>
+                      {navigationItems.map((item) => (
+                        <SidebarMenuSubItem key={item.segment}>
+                          <SidebarMenuSubButton
+                            asChild
+                            isActive={location.pathname.startsWith(item.to)}
+                          >
+                            <NavLink
+                              to={activeFieldId ? item.to : "#"}
+                              onClick={(e) => handleSubSectionClick(e, item.segment)}
+                            >
+                              <span>{item.title}</span>
+                            </NavLink>
+                          </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
+                      ))}
+                    </SidebarMenuSub>
+                  </CollapsibleContent>
+                </SidebarMenuItem>
+              </Collapsible>
+            ) : (
+              <SidebarMenuItem>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SidebarMenuButton
+                      asChild
+                      className="cursor-not-allowed opacity-50 hover:bg-transparent"
+                    >
+                      <span className="flex items-center gap-2">
+                        <LandPlot />
+                        <span>Percelen</span>
+                      </span>
+                    </SidebarMenuButton>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    Selecteer een bedrijf om uw percelen te beheren
+                  </TooltipContent>
+                </Tooltip>
+              </SidebarMenuItem>
+            )}
           </SidebarMenu>
         </SidebarGroupContent>
       </SidebarGroup>

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -128,7 +128,7 @@ export function SidebarFarm({
     const activeSegment = getActiveSegment()
     const segment = activeFieldId ? activeSegment : targetSegment
 
-    navigate(`/farm/${farmId}/${selectedCalendar}/field/${b_id}/${segment}`)
+    void navigate(`/farm/${farmId}/${selectedCalendar}/field/${b_id}/${segment}`)
   }
 
   const toggleCollapsible = (e: React.MouseEvent) => {

--- a/fdm-app/app/lib/field-navigation.ts
+++ b/fdm-app/app/lib/field-navigation.ts
@@ -1,0 +1,44 @@
+export function getFieldNavigationItems(
+  b_id_farm: string,
+  calendar: string,
+  b_id: string,
+  hasDeletePermission: boolean = false,
+) {
+  const items = [
+    {
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/overview`,
+      title: "Gegevens",
+      segment: "overview",
+    },
+    {
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/cultivation`,
+      title: "Gewassen",
+      segment: "cultivation",
+    },
+    {
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/fertilizer`,
+      title: "Bemesting",
+      segment: "fertilizer",
+    },
+    {
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/soil`,
+      title: "Bodem",
+      segment: "soil",
+    },
+    {
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/bcs`,
+      title: "BodemConditieScore",
+      segment: "bcs",
+    },
+  ]
+
+  if (hasDeletePermission) {
+    items.push({
+      to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/delete`,
+      title: "Verwijderen",
+      segment: "delete",
+    })
+  }
+
+  return items
+}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.overview.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.overview.tsx
@@ -1,3 +1,4 @@
+import type { FeatureCollection } from "geojson"
 import type { MetaFunction } from "react-router"
 import { zodResolver } from "@hookform/resolvers/zod"
 import {
@@ -6,13 +7,15 @@ import {
   listAvailableAcquiringMethods,
   updateField,
 } from "@nmi-agro/fdm-core"
-import { useEffect } from "react"
+import maplibregl from "maplibre-gl"
+import { useEffect, useRef } from "react"
 import {
   Controller,
   type ControllerRenderProps,
   type FieldValues,
   type Resolver,
 } from "react-hook-form"
+import { Layer, Map as MapGL, type MapRef } from "react-map-gl/maplibre"
 import {
   type ActionFunctionArgs,
   data,
@@ -22,7 +25,12 @@ import {
 } from "react-router"
 import { RemixFormProvider, useRemixForm } from "remix-hook-form"
 import { dataWithSuccess } from "remix-toast"
+import { ClientOnly } from "remix-utils/client-only"
 import { z } from "zod"
+import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
+import { FieldsSourceNotClickable } from "~/components/blocks/atlas/atlas-sources"
+import { getFieldsStyle } from "~/components/blocks/atlas/atlas-styles"
+import { getViewState } from "~/components/blocks/atlas/atlas-viewstate"
 import { DatePicker } from "~/components/custom/date-picker-v2"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
@@ -35,8 +43,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select"
+import { Skeleton } from "~/components/ui/skeleton"
 import { Spinner } from "~/components/ui/spinner"
 import { Switch } from "~/components/ui/switch"
+import { getMapStyle } from "~/integrations/map"
 import { getSession } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleActionError, handleLoaderError } from "~/lib/error"
@@ -46,7 +56,7 @@ import { cn } from "~/lib/utils"
 
 export const meta: MetaFunction = () => {
   return [
-    { title: `Overzicht - Perceel | ${clientConfig.name}` },
+    { title: `Gegevens - Perceel | ${clientConfig.name}` },
     {
       name: "description",
       content:
@@ -98,11 +108,33 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       false,
     )
 
+    // Build a GeoJSON feature collection for the field map (if geometry exists)
+    let fieldGeo: FeatureCollection | null = null
+    if (field.b_geometry) {
+      fieldGeo = {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {
+              b_id: field.b_id,
+              b_name: field.b_name,
+              b_area: Math.round((field.b_area ?? 0) * 10) / 10,
+              b_id_source: field.b_id_source,
+            },
+            geometry: field.b_geometry,
+          },
+        ],
+      }
+    }
+
     // Return user information from loader
     return {
       field: field,
       fieldWritePermission,
       acquiringMethodOptions: listAvailableAcquiringMethods(),
+      fieldGeo,
+      mapStyle: getMapStyle("satellite"),
     }
   } catch (error) {
     throw handleLoaderError(error)
@@ -141,115 +173,163 @@ export default function FarmFieldsOverviewBlock() {
     })
   }, [loaderData, form.reset])
 
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Overzicht</CardTitle>
-        <CardDescription>Beheer de algemene gegevens van dit perceel</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <RemixFormProvider {...form}>
-          <Form id="formFieldOverview" onSubmit={form.handleSubmit} method="post">
-            <fieldset disabled={form.formState.isSubmitting}>
-              <div className="grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
-                <Controller
-                  control={form.control}
-                  name="b_name"
-                  render={({ field, fieldState }) => (
-                    <Field data-invalid={fieldState.invalid} className="col-span-1 xl:col-span-2">
-                      <FieldLabel>Perceelsnaam</FieldLabel>
-                      <Input placeholder="bv. Achter het erf" {...field} required />
-                      <FieldError errors={[fieldState.error]} />
-                    </Field>
-                  )}
-                />
-                <Controller
-                  control={form.control}
-                  name="b_acquiring_method"
-                  render={({ field, fieldState }) => (
-                    <Field data-invalid={fieldState.invalid} className="col-span-1">
-                      <FieldLabel>Eigendom of pacht?</FieldLabel>
-                      <Select onValueChange={field.onChange} value={field.value}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Maak een keuze..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {loaderData.acquiringMethodOptions.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FieldError errors={[fieldState.error]} />
-                    </Field>
-                  )}
-                />
-                <Controller
-                  control={form.control}
-                  name="b_bufferstrip"
-                  render={({ field }) => (
-                    <div className="col-span-1 flex flex-row items-center justify-between gap-4 rounded-lg border p-4 shadow-sm">
-                      <div className="min-w-0 space-y-0.5">
-                        <FieldLabel className="cursor-pointer text-base" htmlFor="b_bufferstrip">
-                          Bufferstrook
-                        </FieldLabel>
-                        <p className="text-muted-foreground text-sm break-words">
-                          Is dit perceel een bufferstrook?{" "}
-                        </p>
-                      </div>
-                      <div className="flex-shrink-0">
-                        <Switch
-                          id="b_bufferstrip"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </div>
-                    </div>
-                  )}
-                />
-                <Controller
-                  control={form.control}
-                  name="b_start"
-                  render={({ field, fieldState }) => (
-                    <DatePicker
-                      label="Vanaf wanneer in gebruik?"
-                      field={field as unknown as ControllerRenderProps<FieldValues, string>}
-                      fieldState={fieldState}
-                      className="col-span-1"
-                    />
-                  )}
-                />
-                <Controller
-                  control={form.control}
-                  name="b_end"
-                  render={({ field, fieldState }) => (
-                    <DatePicker
-                      label="Tot wanneer in gebruik?"
-                      description="Optioneel"
-                      field={field as unknown as ControllerRenderProps<FieldValues, string>}
-                      fieldState={fieldState}
-                      className="col-span-1"
-                    />
-                  )}
-                />
-              </div>
-            </fieldset>
+  const fieldGeo = loaderData.fieldGeo
+  const mapId = "fieldsSaved"
+  const viewState = fieldGeo ? getViewState(fieldGeo) : null
+  const fieldsSavedStyle = getFieldsStyle(mapId)
+  const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
+  const mapRef = useRef<MapRef>(null)
 
-            <div className="flex justify-end pt-6">
-              <Button
-                type="submit"
-                disabled={form.formState.isSubmitting}
-                className={cn(!loaderData.fieldWritePermission && "invisible")}
-              >
-                {form.formState.isSubmitting && <Spinner />}
-                Bijwerken
-              </Button>
+  useEffect(() => {
+    if (!viewState) return
+    const vs = viewState as { bounds?: unknown; fitBoundsOptions?: unknown }
+    if (vs.bounds) {
+      mapRef.current?.fitBounds(vs.bounds as never, vs.fitBoundsOptions as never)
+    }
+  }, [viewState])
+
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 md:items-start">
+      <Card>
+        <CardHeader>
+          <CardTitle>Gegevens</CardTitle>
+          <CardDescription>Beheer de algemene gegevens van dit perceel</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RemixFormProvider {...form}>
+            <Form id="formFieldOverview" onSubmit={form.handleSubmit} method="post">
+              <fieldset disabled={form.formState.isSubmitting}>
+                <div className="grid w-full grid-cols-1 gap-6 xl:grid-cols-2">
+                  <Controller
+                    control={form.control}
+                    name="b_name"
+                    render={({ field, fieldState }) => (
+                      <Field data-invalid={fieldState.invalid} className="col-span-1 xl:col-span-2">
+                        <FieldLabel>Perceelsnaam</FieldLabel>
+                        <Input placeholder="bv. Achter het erf" {...field} required />
+                        <FieldError errors={[fieldState.error]} />
+                      </Field>
+                    )}
+                  />
+                  <Controller
+                    control={form.control}
+                    name="b_acquiring_method"
+                    render={({ field, fieldState }) => (
+                      <Field data-invalid={fieldState.invalid} className="col-span-1">
+                        <FieldLabel>Eigendom of pacht?</FieldLabel>
+                        <Select onValueChange={field.onChange} value={field.value}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Maak een keuze..." />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {loaderData.acquiringMethodOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FieldError errors={[fieldState.error]} />
+                      </Field>
+                    )}
+                  />
+                  <Controller
+                    control={form.control}
+                    name="b_bufferstrip"
+                    render={({ field }) => (
+                      <div className="col-span-1 flex flex-row items-center justify-between gap-4 rounded-lg border p-4 shadow-sm">
+                        <div className="min-w-0 space-y-0.5">
+                          <FieldLabel className="cursor-pointer text-base" htmlFor="b_bufferstrip">
+                            Bufferstrook
+                          </FieldLabel>
+                          <p className="text-muted-foreground text-sm break-words">
+                            Is dit perceel een bufferstrook?{" "}
+                          </p>
+                        </div>
+                        <div className="flex-shrink-0">
+                          <Switch
+                            id="b_bufferstrip"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </div>
+                      </div>
+                    )}
+                  />
+                  <Controller
+                    control={form.control}
+                    name="b_start"
+                    render={({ field, fieldState }) => (
+                      <DatePicker
+                        label="Vanaf wanneer in gebruik?"
+                        field={field as unknown as ControllerRenderProps<FieldValues, string>}
+                        fieldState={fieldState}
+                        className="col-span-1"
+                      />
+                    )}
+                  />
+                  <Controller
+                    control={form.control}
+                    name="b_end"
+                    render={({ field, fieldState }) => (
+                      <DatePicker
+                        label="Tot wanneer in gebruik?"
+                        description="Optioneel"
+                        field={field as unknown as ControllerRenderProps<FieldValues, string>}
+                        fieldState={fieldState}
+                        className="col-span-1"
+                      />
+                    )}
+                  />
+                </div>
+              </fieldset>
+
+              <div className="flex justify-end pt-6">
+                <Button
+                  type="submit"
+                  disabled={form.formState.isSubmitting}
+                  className={cn(!loaderData.fieldWritePermission && "invisible")}
+                >
+                  {form.formState.isSubmitting && <Spinner />}
+                  Bijwerken
+                </Button>
+              </div>
+            </Form>
+          </RemixFormProvider>
+        </CardContent>
+      </Card>
+      {fieldGeo && (
+        <Card className="overflow-hidden">
+          <CardHeader>
+            <CardTitle>Kaart</CardTitle>
+            <CardDescription>De ligging van dit perceel</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[300px] w-full overflow-hidden rounded-xl md:h-[400px]">
+              <ClientOnly fallback={<Skeleton className="h-full w-full rounded-xl" />}>
+                {() => (
+                  <MapGL
+                    {...(viewState as object)}
+                    style={{ height: "100%", width: "100%" }}
+                    interactive={false}
+                    mapStyle={loaderData.mapStyle}
+                    mapLib={maplibregl}
+                    interactiveLayerIds={[mapId]}
+                    ref={mapRef}
+                  >
+                    <MapTilerAttribution />
+                    <FieldsSourceNotClickable id={mapId} fieldsData={fieldGeo}>
+                      <Layer {...fieldsSavedStyle} />
+                      <Layer {...fieldsSavedOutlineStyle} />
+                    </FieldsSourceNotClickable>
+                  </MapGL>
+                )}
+              </ClientOnly>
             </div>
-          </Form>
-        </RemixFormProvider>
-      </CardContent>
-    </Card>
+          </CardContent>
+        </Card>
+      )}
+    </div>
   )
 }
 

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.overview.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.overview.tsx
@@ -8,7 +8,7 @@ import {
   updateField,
 } from "@nmi-agro/fdm-core"
 import maplibregl from "maplibre-gl"
-import { useEffect, useRef } from "react"
+import { useEffect, useMemo, useRef } from "react"
 import {
   Controller,
   type ControllerRenderProps,
@@ -175,7 +175,7 @@ export default function FarmFieldsOverviewBlock() {
 
   const fieldGeo = loaderData.fieldGeo
   const mapId = "fieldsSaved"
-  const viewState = fieldGeo ? getViewState(fieldGeo) : null
+  const viewState = useMemo(() => (fieldGeo ? getViewState(fieldGeo) : null), [fieldGeo])
   const fieldsSavedStyle = getFieldsStyle(mapId)
   const fieldsSavedOutlineStyle = getFieldsStyle("fieldsSavedOutline")
   const mapRef = useRef<MapRef>(null)

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
@@ -1,4 +1,4 @@
-import { getFarms, getField, getFields } from "@nmi-agro/fdm-core"
+import { checkPermission, getFarms, getField, getFields } from "@nmi-agro/fdm-core"
 import {
   data,
   type LoaderFunctionArgs,
@@ -127,6 +127,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       fieldOptions: fieldOptions,
       field: field,
       b_id: b_id,
+      fieldWritePermission: !!(await checkPermission(
+        fdm,
+        "field",
+        "write",
+        b_id,
+        session.principal_id,
+        new URL(request.url).pathname,
+        false,
+      )),
       user: session.user,
     }
   } catch (error) {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
@@ -1,4 +1,4 @@
-import { checkPermission, getFarms, getField, getFields } from "@nmi-agro/fdm-core"
+import { getFarms, getField, getFields } from "@nmi-agro/fdm-core"
 import {
   data,
   type LoaderFunctionArgs,
@@ -15,11 +15,10 @@ import { HeaderFarm } from "~/components/blocks/header/farm"
 import { HeaderField } from "~/components/blocks/header/field"
 import { SidebarInset } from "~/components/ui/sidebar"
 import { getSession } from "~/lib/auth.server"
-import { getCalendar, getTimeframe } from "~/lib/calendar"
+import { getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
-import { getFieldNavigationItems } from "~/lib/field-navigation"
 import { useCalendarStore } from "~/store/calendar"
 
 // Meta
@@ -38,15 +37,13 @@ export const meta: MetaFunction = () => {
  *
  * This function verifies that both a farm ID and a field ID are provided in the route parameters, retrieving the user session before fetching farms and fields associated with the user's principal ID.
  * It constructs selectable options for farms and fields (with field areas rounded to one decimal place), ensures field options are sorted alphabetically, and retrieves detailed information about the specified field.
- * Additionally, it builds sidebar navigation items for the page.
- *
+ * Additionally, it builds sidebar navigation items for the page. *
  * @returns An object containing:
  *  - b_id_farm: The farm identifier.
  *  - farmOptions: An array of valid farm options.
  *  - fieldOptions: A sorted array of valid field options, each including an identifier, name, and area.
  *  - field: Detailed information about the field.
  *  - b_id: The field identifier.
- *  - sidebarPageItems: An array of navigation items for the sidebar.
  *  - user: Data of the authenticated user.
  *
  * @throws {Response} If either the farm ID or field ID is missing, with a status of 400.
@@ -77,7 +74,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const session = await getSession(request)
 
     // Get timeframe from calendar store
-    const calendar = getCalendar(params)
     const timeframe = getTimeframe(params)
 
     // Get a list of possible farms of the user
@@ -124,23 +120,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       })
     }
 
-    const fieldWritePermission = await checkPermission(
-      fdm,
-      "field",
-      "write",
-      b_id,
-      session.principal_id,
-      new URL(request.url).pathname,
-      false,
-    )
-
-    const sidebarPageItems = getFieldNavigationItems(
-      b_id_farm,
-      calendar,
-      b_id,
-      !!fieldWritePermission,
-    )
-
     // Return user information from loader
     return {
       b_id_farm: b_id_farm,
@@ -148,7 +127,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       fieldOptions: fieldOptions,
       field: field,
       b_id: b_id,
-      sidebarPageItems: sidebarPageItems,
       user: session.user,
     }
   } catch (error) {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
@@ -19,6 +19,7 @@ import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
+import { getFieldNavigationItems } from "~/lib/field-navigation"
 import { useCalendarStore } from "~/store/calendar"
 
 // Meta
@@ -123,34 +124,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       })
     }
 
-    // Create the items for sidebar page
-    const sidebarPageItems = [
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/overview`,
-        title: "Overzicht",
-      },
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/cultivation`,
-        title: "Gewassen",
-      },
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/fertilizer`,
-        title: "Bemesting",
-      },
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/soil`,
-        title: "Bodem",
-      },
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/bcs`,
-        title: "BodemConditieScore",
-      },
-      {
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/atlas`,
-        title: "Kaart",
-      },
-    ]
-
     const fieldWritePermission = await checkPermission(
       fdm,
       "field",
@@ -161,12 +134,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       false,
     )
 
-    if (fieldWritePermission) {
-      sidebarPageItems.push({
-        to: `/farm/${b_id_farm}/${calendar}/field/${b_id}/delete`,
-        title: "Verwijderen",
-      })
-    }
+    const sidebarPageItems = getFieldNavigationItems(
+      b_id_farm,
+      calendar,
+      b_id,
+      !!fieldWritePermission,
+    )
 
     // Return user information from loader
     return {
@@ -219,7 +192,7 @@ export default function FarmFieldIndex() {
           title={loaderData.field?.b_name}
           description={"Beheer hier de gegevens van dit perceel"}
         />
-        <FarmContent sidebarItems={loaderData.sidebarPageItems}>
+        <FarmContent>
           <Outlet />
         </FarmContent>
       </main>

--- a/fdm-app/app/routes/farm.tsx
+++ b/fdm-app/app/routes/farm.tsx
@@ -167,22 +167,27 @@ export default function App() {
     }
   }, [initialCalendar, setCalendar])
 
-  const { setSelectedField, syncContext } = useSelectedFieldStore()
+  const { b_id: storedFieldId, setSelectedField, syncContext } = useSelectedFieldStore()
 
   // Expire stale fields across farm or calendar change
   useEffect(() => {
     syncContext(initialFarmId, initialCalendar)
   }, [initialFarmId, initialCalendar, syncContext])
 
-  // Find active field from any route that has a b_id param (field pages, indicators, etc.)
-  const fieldMatch = matches.find((match) => match.params.b_id)
-  const activeFieldId = fieldMatch?.params.b_id as string | undefined
+  // Sync store only from field-specific routes to avoid leaking indicator/measure IDs
+  const fieldMatch = matches.find(
+    (match) => match.pathname.includes("/field/") && match.params.b_id,
+  )
+  const urlFieldId = fieldMatch?.params.b_id as string | undefined
 
   useEffect(() => {
-    if (activeFieldId) {
-      setSelectedField(activeFieldId, null)
+    if (urlFieldId) {
+      setSelectedField(urlFieldId, null)
     }
-  }, [activeFieldId, setSelectedField])
+  }, [urlFieldId, setSelectedField])
+
+  // On non-field pages fall back to the last-selected field from the store
+  const activeFieldId = urlFieldId ?? storedFieldId ?? undefined
 
   // Identify user if PostHog is configured
   useEffect(() => {
@@ -203,7 +208,6 @@ export default function App() {
           <SidebarFarm
             farm={loaderData.farm}
             fields={loaderData.fieldOptions}
-            farmWritePermission={loaderData.farmWritePermission}
             activeFieldId={activeFieldId}
           />
           <SidebarApps />

--- a/fdm-app/app/routes/farm.tsx
+++ b/fdm-app/app/routes/farm.tsx
@@ -179,6 +179,9 @@ export default function App() {
     (match) => match.pathname.includes("/field/") && match.params.b_id,
   )
   const urlFieldId = fieldMatch?.params.b_id as string | undefined
+  const fieldWritePermission =
+    (fieldMatch?.loaderData as { fieldWritePermission?: boolean } | undefined)
+      ?.fieldWritePermission ?? false
 
   useEffect(() => {
     if (urlFieldId) {
@@ -209,6 +212,7 @@ export default function App() {
             farm={loaderData.farm}
             fields={loaderData.fieldOptions}
             activeFieldId={activeFieldId}
+            fieldWritePermission={fieldWritePermission}
           />
           <SidebarApps />
           <SidebarLabs />

--- a/fdm-app/app/routes/farm.tsx
+++ b/fdm-app/app/routes/farm.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router"
-import { getFarm } from "@nmi-agro/fdm-core"
+import { getFarm, getFields, checkPermission } from "@nmi-agro/fdm-core"
 import {
   checkHelpdeskPermission,
   getUnassignedTicketCount,
@@ -16,11 +16,13 @@ import { SidebarTitle } from "~/components/blocks/sidebar/title"
 import { SidebarUser } from "~/components/blocks/sidebar/user"
 import { Sidebar, SidebarContent, SidebarInset, SidebarProvider } from "~/components/ui/sidebar"
 import { checkSession, getSession } from "~/lib/auth.server"
+import { getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { useCalendarStore } from "~/store/calendar"
 import { useFarmStore } from "~/store/farm"
+import { useSelectedFieldStore } from "~/store/selected-field"
 
 export const meta: MetaFunction = () => {
   return [
@@ -59,6 +61,40 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
         ? await getFarm(fdm, session.principal_id, params.b_id_farm)
         : undefined
 
+    const farmWritePermission =
+      params.b_id_farm && params.b_id_farm !== "undefined"
+        ? await checkPermission(
+            fdm,
+            "farm",
+            "write",
+            params.b_id_farm,
+            session.principal_id,
+            new URL(request.url).pathname,
+            false,
+          )
+        : false
+
+    const timeframe = getTimeframe(params)
+
+    const fields =
+      params.b_id_farm && params.b_id_farm !== "undefined"
+        ? await getFields(fdm, session.principal_id, params.b_id_farm, timeframe)
+        : []
+
+    const fieldOptions = fields.map((field) => {
+      if (!field?.b_id || !field?.b_name) {
+        throw new Error("Invalid field data structure")
+      }
+      return {
+        b_id: field.b_id,
+        b_name: field.b_name,
+        b_area: Math.round((field.b_area ?? 0) * 10) / 10,
+      }
+    })
+
+    // Sort fields by name alphabetically
+    fieldOptions.sort((a, b) => a.b_name.localeCompare(b.b_name))
+
     const helpdeskReadPermission = await checkHelpdeskPermission(
       fdm,
       "helpdesk",
@@ -83,6 +119,8 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
       userName: session.userName,
       initials: session.initials,
       hasNotification: hasNotification,
+      farmWritePermission: farmWritePermission,
+      fieldOptions: fieldOptions,
     }
   } catch (error) {
     // If getSession throws (e.g., invalid token), it might result in a 401
@@ -129,6 +167,23 @@ export default function App() {
     }
   }, [initialCalendar, setCalendar])
 
+  const { setSelectedField, syncContext } = useSelectedFieldStore()
+
+  // Expire stale fields across farm or calendar change
+  useEffect(() => {
+    syncContext(initialFarmId, initialCalendar)
+  }, [initialFarmId, initialCalendar, syncContext])
+
+  // Find active field from any route that has a b_id param (field pages, indicators, etc.)
+  const fieldMatch = matches.find((match) => match.params.b_id)
+  const activeFieldId = fieldMatch?.params.b_id as string | undefined
+
+  useEffect(() => {
+    if (activeFieldId) {
+      setSelectedField(activeFieldId, null)
+    }
+  }, [activeFieldId, setSelectedField])
+
   // Identify user if PostHog is configured
   useEffect(() => {
     if (clientConfig.analytics.posthog && loaderData.user) {
@@ -145,7 +200,12 @@ export default function App() {
       <Sidebar>
         <SidebarTitle />
         <SidebarContent>
-          <SidebarFarm farm={loaderData.farm} />
+          <SidebarFarm
+            farm={loaderData.farm}
+            fields={loaderData.fieldOptions}
+            farmWritePermission={loaderData.farmWritePermission}
+            activeFieldId={activeFieldId}
+          />
           <SidebarApps />
           <SidebarLabs />
         </SidebarContent>

--- a/fdm-app/app/store/selected-field.ts
+++ b/fdm-app/app/store/selected-field.ts
@@ -1,0 +1,63 @@
+import { create } from "zustand"
+import { createJSONStorage, persist } from "zustand/middleware"
+import { ssrSafeSessionJSONStorage } from "./storage"
+
+interface SelectedFieldState {
+  b_id: string | null
+  b_name: string | null
+  farmId: string | null
+  calendar: string | null
+  recentFieldIds: string[]
+  setSelectedField: (b_id: string | null, b_name: string | null) => void
+  addRecentFieldId: (b_id: string) => void
+  clearSelectedField: () => void
+  syncContext: (farmId: string | undefined, calendar: string | undefined) => void
+}
+
+export const useSelectedFieldStore = create<SelectedFieldState>()(
+  persist(
+    (set, get) => ({
+      b_id: null,
+      b_name: null,
+      farmId: null,
+      calendar: null,
+      recentFieldIds: [],
+      setSelectedField: (b_id, b_name) =>
+        set((state) => {
+          const nextRecent = state.recentFieldIds.filter((id) => id !== b_id)
+          if (b_id) {
+            nextRecent.unshift(b_id)
+          }
+          return {
+            b_id,
+            b_name,
+            recentFieldIds: nextRecent.slice(0, 5),
+          }
+        }),
+      addRecentFieldId: (b_id) =>
+        set((state) => {
+          const nextRecent = state.recentFieldIds.filter((id) => id !== b_id)
+          nextRecent.unshift(b_id)
+          return { recentFieldIds: nextRecent.slice(0, 5) }
+        }),
+      clearSelectedField: () => set({ b_id: null, b_name: null }),
+      syncContext: (farmId, calendar) => {
+        const current = get()
+        const nextFarmId = farmId ?? null
+        const nextCalendar = calendar ?? null
+        if (current.farmId !== nextFarmId || current.calendar !== nextCalendar) {
+          set({
+            farmId: nextFarmId,
+            calendar: nextCalendar,
+            b_id: null,
+            b_name: null,
+          })
+        }
+      },
+    }),
+    {
+      name: "selected-field-storage",
+      storage: createJSONStorage(() => ssrSafeSessionJSONStorage),
+    },
+  ),
+)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable field picker in the header and a field-aware picker in the farm sidebar, including a “recently visited” shortcut.
  * Introduced a context-aware “Perceel(s)” section in the farm sidebar to drive field-specific navigation.
  * Added a non-interactive “Kaart” card to the field overview page when geometry is available.
* **Bug Fixes**
  * Improved selected-field synchronization when switching between farm and calendar views.
  * Updated routing so navigation targets the correct section, including delete links when permitted.
* **Chores**
  * Bumped the package version and updated the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #668 