### PR TITLE
Make message.sender_id nullable in fdm-helpdesk

### DIFF
--- a/.changeset/wide-wings-double.md
+++ b/.changeset/wide-wings-double.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-app": minor
+"@nmi-agro/fdm-helpdesk": minor
+---
+
+The server can now be configured to receive inbound emails from Postmarks, and in turn it can make these emails into tickets. It can also detect email replies and post these as messages under the corresponding ticket instead of making a new ticket.

--- a/fdm-app/app/components/blocks/helpdesk/ticket.tsx
+++ b/fdm-app/app/components/blocks/helpdesk/ticket.tsx
@@ -171,9 +171,7 @@ export function Ticket({
           <Message
             key={msg.message_id}
             principal={
-              principalLookup.get(msg.sender_id) ??
-              (msg.sender_id === ticket.ticket_id ? emailPrincipal : null) ??
-              null
+              (msg.sender_id ? principalLookup.get(msg.sender_id) : emailPrincipal) ?? null
             }
             senderType={msg.sender_type}
             isInternal={msg.is_internal}

--- a/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
+++ b/fdm-app/app/routes/support._ticketviewer.ticket.$ticket_id.tsx
@@ -73,7 +73,9 @@ export async function loader({ params, request }: Args) {
     const agents = isAgent ? await getAgents(fdm, session.principal_id) : []
 
     // Message sender's profile pictures are shown
-    const principal_ids = messages.map((msg) => msg.sender_id)
+    const principal_ids = messages
+      .map((msg) => msg.sender_id)
+      .filter((sender_id) => sender_id !== null)
     // Assignees' profile pictures are shown
     principal_ids.push(...ticket.assignees.map((assignee) => assignee.agent_id))
     // Currently logged-in user's profile picture is shown when creating a message

--- a/fdm-helpdesk/src/db/migrations/0002_sturdy_mojo.sql
+++ b/fdm-helpdesk/src/db/migrations/0002_sturdy_mojo.sql
@@ -5,5 +5,6 @@ CREATE TABLE "fdm-helpdesk"."blocked_emails" (
 	"created" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "fdm-helpdesk"."messages" ALTER COLUMN "sender_id" DROP NOT NULL;--> statement-breakpoint
 ALTER TABLE "fdm-helpdesk"."tickets" ADD COLUMN "requester_email" text;--> statement-breakpoint
 CREATE INDEX "ticket_requester_email_idx" ON "fdm-helpdesk"."tickets" USING btree (lower("requester_email"));

--- a/fdm-helpdesk/src/db/migrations/meta/0002_snapshot.json
+++ b/fdm-helpdesk/src/db/migrations/meta/0002_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "01036a46-499b-4a35-bed2-99c2f1b78f3b",
+  "id": "331d4634-1bfa-440a-adaf-d919f947138c",
   "prevId": "cb881026-9e17-49e6-9464-7aedaafa8b44",
   "version": "7",
   "dialect": "postgresql",
@@ -188,7 +188,7 @@
           "name": "sender_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "sender_type": {
           "name": "sender_type",

--- a/fdm-helpdesk/src/db/migrations/meta/_journal.json
+++ b/fdm-helpdesk/src/db/migrations/meta/_journal.json
@@ -19,7 +19,7 @@
     {
       "idx": 2,
       "version": "7",
-      "when": 1783072451603,
+      "when": 1783346948212,
       "tag": "0002_sturdy_mojo",
       "breakpoints": true
     }

--- a/fdm-helpdesk/src/db/schema-helpdesk.ts
+++ b/fdm-helpdesk/src/db/schema-helpdesk.ts
@@ -222,7 +222,7 @@ export const messages = fdmHelpdeskSchema.table(
     ticket_id: text()
       .notNull()
       .references(() => tickets.ticket_id),
-    sender_id: text().notNull(), // References fdm-authn user.id
+    sender_id: text(), // References fdm-authn user.id
     sender_type: text().notNull(), // 'customer', 'agent'
     body: text().notNull(), // Message content (supports markdown)
     is_internal: boolean().notNull().default(false), // Internal note (agent-only)

--- a/fdm-helpdesk/src/message.test.ts
+++ b/fdm-helpdesk/src/message.test.ts
@@ -283,12 +283,12 @@ describe("addMessageFromInboundEmailUnchecked", () => {
     expect(message.sender_id).toBe(sender_id)
   })
 
-  test("should fall back to ticket_id as sender_id when no sender_id is given", async ({ fdm }) => {
+  test("should set sender_id to null when no sender_id is given", async ({ fdm }) => {
     const message_id = await addMessageFromInboundEmailUnchecked(fdm, ticket_id, "Unmatched reply")
 
     const message = await getMessage(fdm, admin_id, message_id)
 
-    expect(message.sender_id).toBe(ticket_id)
+    expect(message.sender_id).toBe(null)
   })
 })
 

--- a/fdm-helpdesk/src/message.ts
+++ b/fdm-helpdesk/src/message.ts
@@ -157,7 +157,7 @@ export async function getMessagesForTicket(
 export async function addMessage(
   fdm: FdmHelpdeskType,
   ticket_id: schema.MessageTypeInsert["ticket_id"],
-  sender_id: schema.MessageTypeInsert["sender_id"],
+  sender_id: string,
   sender_type: "customer" | "agent",
   body: schema.MessageTypeInsert["body"],
   is_internal?: schema.MessageTypeInsert["is_internal"],
@@ -236,7 +236,7 @@ export async function addMessageFromInboundEmailUnchecked(
       {
         ticket_id: ticket_id,
         message_id: message_id,
-        sender_id: sender_id ?? ticket_id,
+        sender_id: sender_id ?? null,
         body: escapeHTML(body),
         sender_type: "customer",
       },

--- a/fdm-helpdesk/src/ticket.test.ts
+++ b/fdm-helpdesk/src/ticket.test.ts
@@ -886,9 +886,7 @@ describe("createTicketFromInboundEmail", () => {
     expect(messages[0].sender_type).toBe("customer")
   })
 
-  test("should fall back to ticket_id as sender_id when no requester_id is given", async ({
-    fdm,
-  }) => {
+  test("should set sender_id to null when no requester_id is given", async ({ fdm }) => {
     const ticket_id = await createTicketFromInboundEmail(fdm, requester_email, "Inbound email body")
 
     const messages = await fdm
@@ -896,7 +894,7 @@ describe("createTicketFromInboundEmail", () => {
       .from(schema.messages)
       .where(eq(schema.messages.ticket_id, ticket_id))
 
-    expect(messages[0].sender_id).toBe(ticket_id)
+    expect(messages[0].sender_id).toBe(null)
   })
 
   test("should derive the subject line from the body", async ({ fdm }) => {

--- a/fdm-helpdesk/src/ticket.ts
+++ b/fdm-helpdesk/src/ticket.ts
@@ -588,9 +588,7 @@ export async function createTicket(
  *
  * `requester_id` is optional: when the sender's email address cannot be matched to a known
  * fdm-authn user, pass `undefined`/omit it and the ticket is stored with `requester_id: null` and
- * `requester_email` set instead. In that case, the first message's `sender_id` falls back to the
- * generated `ticket_id` as a placeholder value (see {@link addMessageFromInboundEmailUnchecked} for the
- * same convention).
+ * `requester_email` set instead. In that case, the first message's `sender_id` is set to null too.
  *
  * @param fdm The FDM instance providing the connection to the database. The instance can be created with
  * {@link createFdmServer} of fdm-core.
@@ -630,7 +628,7 @@ export async function createTicketFromInboundEmail(
 
       await tx.insert(schema.messages).values({
         ticket_id: ticket_id,
-        sender_id: requester_id ?? ticket_id,
+        sender_id: requester_id ?? null,
         message_id: message_id,
         sender_type: "customer",
         body: sanitizedBody,
@@ -917,7 +915,7 @@ export async function moveInboundEmailTicketsToPrincipalUnchecked(
       .set({ sender_id: requester_id })
       .where(
         and(
-          eq(schema.messages.ticket_id, schema.messages.sender_id),
+          isNull(schema.messages.sender_id),
           exists(fdm.select().from(sq).where(eq(sq.ticket_id, schema.messages.ticket_id))),
         ),
       )


### PR DESCRIPTION
**Enhancements**
- Now it is more obvious that something is wrong with email messages that don't have an associated registered user, since we set the sender_id to null now instead of the ticket_id.

**Chores**
- Added changeset for #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbound emails from Postmark can now be turned into tickets automatically.
  * Email replies are now attached to the existing ticket as new messages instead of creating duplicate tickets.

* **Bug Fixes**
  * Improved sender handling for email-created messages, including cases where the sender can’t be matched.
  * Fixed ticket views so messages with unknown senders display and load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->