### PR TITLE
Add NMI-based cultivation suggestions and cache soil estimates

### DIFF
--- a/.changeset/strong-maps-reply.md
+++ b/.changeset/strong-maps-reply.md
@@ -1,0 +1,7 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Fields with no registered main cultivation ("hoofdteelt") for the active calendar year now get an NMI-estimate-based crop suggestion (sourced from the BRP). The suggestion appears on the farm dashboard's missing-cultivation banner, the field list, the field detail page, and the nutrient advice overview, and can be accepted to pre-fill the "add cultivation" form. The suggestion is silently omitted (never blocks the page) when no NMI API key is configured, no estimate is available for the year, or the NMI API call fails.
+
+Updated all internal call sites to use `@nmi-agro/fdm-calculator`'s new cached `getSoilParameterEstimates(fdm, ...)` signature.

--- a/.changeset/witty-bags-sing.md
+++ b/.changeset/witty-bags-sing.md
@@ -1,0 +1,7 @@
+---
+"@nmi-agro/fdm-calculator": minor
+---
+
+Added a new `estimates` module exporting `getSoilParameterEstimates` (DB-cached via `withCalculationCache`, moved here from `@nmi-agro/fdm-app`'s internal `nmi.server.ts`), its uncached counterpart `requestSoilParameterEstimates`, and `collectInputForSoilParameterEstimates(fdm, principal_id, b_id, nmiApiKey)`, which resolves a persisted field's centroid via `getField`, mirroring `collectInputForBln3Score`.
+
+This is a **breaking change**: `getSoilParameterEstimates` now takes `(fdm, { a_lat, a_lon, nmiApiKey })` instead of `(field, nmiApiKey)`.

--- a/fdm-app/app/components/blocks/cultivation/card-list.tsx
+++ b/fdm-app/app/components/blocks/cultivation/card-list.tsx
@@ -8,7 +8,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "~/components/ui/empty"
-import type { Cultivation, CultivationOption } from "./types"
+import type { Cultivation, CultivationDefaultValues, CultivationOption } from "./types"
 import { CultivationAddFormDialog } from "./form-add"
 import { CultivationList } from "./list"
 
@@ -22,11 +22,13 @@ export function CultivationListCard({
   cultivations,
   harvests,
   editable = true,
+  defaultValues,
 }: {
   cultivationsCatalogueOptions: CultivationOption[]
   cultivations: Cultivation[]
   harvests: Harvest[]
   editable?: boolean
+  defaultValues?: CultivationDefaultValues
 }) {
   return (
     <Card>
@@ -35,7 +37,10 @@ export function CultivationListCard({
           Gewassen
         </CardTitle>
         {cultivations.length !== 0 && editable ? (
-          <CultivationAddFormDialog options={cultivationsCatalogueOptions} />
+          <CultivationAddFormDialog
+            options={cultivationsCatalogueOptions}
+            defaultValues={defaultValues}
+          />
         ) : null}
       </CardHeader>
       <CardContent>
@@ -55,7 +60,10 @@ export function CultivationListCard({
             </EmptyHeader>
             {editable && (
               <EmptyContent>
-                <CultivationAddFormDialog options={cultivationsCatalogueOptions} />
+                <CultivationAddFormDialog
+                  options={cultivationsCatalogueOptions}
+                  defaultValues={defaultValues}
+                />
               </EmptyContent>
             )}
           </Empty>

--- a/fdm-app/app/components/blocks/cultivation/card-list.tsx
+++ b/fdm-app/app/components/blocks/cultivation/card-list.tsx
@@ -23,23 +23,27 @@ export function CultivationListCard({
   harvests,
   editable = true,
   defaultValues,
+  onSuggestionDialogClose,
 }: {
   cultivationsCatalogueOptions: CultivationOption[]
   cultivations: Cultivation[]
   harvests: Harvest[]
   editable?: boolean
   defaultValues?: CultivationDefaultValues
+  /** Called when the pre-filled suggestion dialog is closed (submitted or dismissed). */
+  onSuggestionDialogClose?: () => void
 }) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle className="text-xl font-semibold tracking-tight text-gray-900">
+        <CardTitle className="text-foreground text-xl font-semibold tracking-tight">
           Gewassen
         </CardTitle>
         {cultivations.length !== 0 && editable ? (
           <CultivationAddFormDialog
             options={cultivationsCatalogueOptions}
             defaultValues={defaultValues}
+            onClose={onSuggestionDialogClose}
           />
         ) : null}
       </CardHeader>
@@ -63,6 +67,7 @@ export function CultivationListCard({
                 <CultivationAddFormDialog
                   options={cultivationsCatalogueOptions}
                   defaultValues={defaultValues}
+                  onClose={onSuggestionDialogClose}
                 />
               </EmptyContent>
             )}

--- a/fdm-app/app/components/blocks/cultivation/form-add.tsx
+++ b/fdm-app/app/components/blocks/cultivation/form-add.tsx
@@ -17,8 +17,8 @@ import { Spinner } from "~/components/ui/spinner"
 import type { CultivationsFormProps } from "./types"
 import { CultivationAddFormSchema } from "./schema"
 
-export function CultivationAddFormDialog({ options }: CultivationsFormProps) {
-  const [isOpen, setIsOpen] = useState(false)
+export function CultivationAddFormDialog({ options, defaultValues }: CultivationsFormProps) {
+  const [isOpen, setIsOpen] = useState(!!defaultValues)
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -29,7 +29,11 @@ export function CultivationAddFormDialog({ options }: CultivationsFormProps) {
         <DialogHeader>
           <DialogTitle>Gewas toevoegen</DialogTitle>
         </DialogHeader>
-        <CultivationAddForm options={options} onSuccess={() => setIsOpen(false)} />
+        <CultivationAddForm
+          options={options}
+          defaultValues={defaultValues}
+          onSuccess={() => setIsOpen(false)}
+        />
       </DialogContent>
     </Dialog>
   )
@@ -37,6 +41,7 @@ export function CultivationAddFormDialog({ options }: CultivationsFormProps) {
 
 function CultivationAddForm({
   options,
+  defaultValues,
   onSuccess,
   editable = true,
 }: CultivationsFormProps & { editable?: boolean; onSuccess?: () => void }) {
@@ -44,8 +49,8 @@ function CultivationAddForm({
     mode: "onTouched",
     resolver: zodResolver(CultivationAddFormSchema) as never,
     defaultValues: {
-      b_lu_catalogue: "",
-      b_lu_start: new Date(),
+      b_lu_catalogue: defaultValues?.b_lu_catalogue ?? "",
+      b_lu_start: defaultValues?.b_lu_start ?? new Date(),
       b_lu_end: undefined,
     },
   })

--- a/fdm-app/app/components/blocks/cultivation/form-add.tsx
+++ b/fdm-app/app/components/blocks/cultivation/form-add.tsx
@@ -17,22 +17,36 @@ import { Spinner } from "~/components/ui/spinner"
 import type { CultivationsFormProps } from "./types"
 import { CultivationAddFormSchema } from "./schema"
 
-export function CultivationAddFormDialog({ options, defaultValues }: CultivationsFormProps) {
+export function CultivationAddFormDialog({
+  options,
+  defaultValues,
+  onClose,
+}: CultivationsFormProps & { onClose?: () => void }) {
   const [isOpen, setIsOpen] = useState(!!defaultValues)
+  const isSuggested = !!defaultValues
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open)
+    if (!open) {
+      onClose?.()
+    }
+  }
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button>Gewas toevoegen</Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Gewas toevoegen</DialogTitle>
+          <DialogTitle>
+            {isSuggested ? "Voorgesteld gewas bevestigen" : "Gewas toevoegen"}
+          </DialogTitle>
         </DialogHeader>
         <CultivationAddForm
           options={options}
           defaultValues={defaultValues}
-          onSuccess={() => setIsOpen(false)}
+          onSuccess={() => handleOpenChange(false)}
         />
       </DialogContent>
     </Dialog>
@@ -45,13 +59,14 @@ function CultivationAddForm({
   onSuccess,
   editable = true,
 }: CultivationsFormProps & { editable?: boolean; onSuccess?: () => void }) {
+  const isSuggested = !!defaultValues
   const form = useRemixForm<z.infer<typeof CultivationAddFormSchema>>({
     mode: "onTouched",
     resolver: zodResolver(CultivationAddFormSchema) as never,
     defaultValues: {
       b_lu_catalogue: defaultValues?.b_lu_catalogue ?? "",
       b_lu_start: defaultValues?.b_lu_start ?? new Date(),
-      b_lu_end: undefined,
+      b_lu_end: defaultValues?.b_lu_end ?? undefined,
     },
   })
 
@@ -108,6 +123,8 @@ function CultivationAddForm({
                     <Spinner />
                     <span>Opslaan...</span>
                   </div>
+                ) : isSuggested ? (
+                  "Bevestigen"
                 ) : (
                   "Voeg toe"
                 )}

--- a/fdm-app/app/components/blocks/cultivation/suggestion.tsx
+++ b/fdm-app/app/components/blocks/cultivation/suggestion.tsx
@@ -1,12 +1,19 @@
-import { Sprout } from "lucide-react"
+import { format } from "date-fns"
+import { CircleHelp, Sprout } from "lucide-react"
 import { NavLink } from "react-router"
+import type {
+  CultivationSuggestion,
+  CultivationSuggestionResult,
+} from "~/lib/cultivation-suggestion.server"
 import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
-import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip"
 
 /**
  * Builds the URL to the field's cultivation page with the suggestion pre-filled as query
- * params, consumed by the "add cultivation" dialog to auto-open pre-filled.
+ * params, consumed by the "add cultivation" dialog to auto-open pre-filled. Dates come from
+ * the cultivation catalogue's default sowing/harvest dates (`getDefaultDatesOfCultivation`),
+ * the same source used for RVO/shapefile field imports — not a fixed placeholder date.
  */
 function buildAcceptSuggestionUrl(
   b_id_farm: string,
@@ -16,8 +23,11 @@ function buildAcceptSuggestionUrl(
 ) {
   const params = new URLSearchParams({
     suggest_b_lu_catalogue: suggestion.b_lu_catalogue,
-    suggest_start: `${calendar}-01-01`,
+    suggest_start: format(suggestion.b_lu_start, "yyyy-MM-dd"),
   })
+  if (suggestion.b_lu_end) {
+    params.set("suggest_end", format(suggestion.b_lu_end, "yyyy-MM-dd"))
+  }
   return `/farm/${b_id_farm}/${calendar}/field/${b_id}/cultivation?${params.toString()}`
 }
 
@@ -33,8 +43,11 @@ type CultivationSuggestionProps = {
 /**
  * A non-dismissible inline suggestion for a field/year with no registered main cultivation,
  * sourced from the NMI Estimates endpoint's BRP cultivation guess. Renders `null` when there
- * is no suggestion (no NMI API key configured, no estimate for the year, or a lookup failure) —
- * callers can always render this component unconditionally.
+ * is no suggestion — callers can always render this component unconditionally.
+ *
+ * Deliberately styled as a *quiet, provisional* state (muted surface, not the `primary` token):
+ * this is a guess, not a recorded fact, and shouldn't visually compete with real data. The
+ * "BRP-schatting" label makes that provenance explicit rather than relying on prose alone.
  */
 export function CultivationSuggestionBanner({
   b_id_farm,
@@ -48,17 +61,21 @@ export function CultivationSuggestionBanner({
   }
 
   return (
-    <div className="border-primary/30 bg-primary/5 flex items-start gap-2 rounded-lg border p-3">
-      <Sprout className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+    <div className="bg-muted/40 flex items-start gap-2 rounded-lg border p-3">
+      <Sprout className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
       <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
         <p className="text-sm">
           {b_name && <span className="font-medium">{b_name}: </span>}
+          <Badge variant="secondary" className="mr-1.5 align-middle font-normal">
+            BRP-schatting
+          </Badge>
           We denken dat hier <span className="font-medium">{suggestion.b_lu_name}</span> geteeld
-          werd in {calendar}. Toevoegen als hoofdteelt?
+          werd in {calendar}, gebaseerd op de Basisregistratie Gewaspercelen. Toevoegen als
+          hoofdteelt?
         </p>
-        <Button size="sm" variant="outline" asChild>
+        <Button size="sm" asChild>
           <NavLink to={buildAcceptSuggestionUrl(b_id_farm, calendar, b_id, suggestion)}>
-            Toevoegen als hoofdteelt
+            Voorstel toevoegen
           </NavLink>
         </Button>
       </div>
@@ -68,7 +85,8 @@ export function CultivationSuggestionBanner({
 
 /**
  * Compact variant of {@link CultivationSuggestionBanner} for dense contexts (e.g. a table cell).
- * Renders `null` when there is no suggestion.
+ * Renders `null` when there is no suggestion. Truncated to a fixed max-width so a long crop
+ * name never sprawls a table row; the full name is always available via the tooltip.
  */
 export function CultivationSuggestionBadge({
   b_id_farm,
@@ -81,15 +99,83 @@ export function CultivationSuggestionBadge({
   }
 
   return (
-    <NavLink to={buildAcceptSuggestionUrl(b_id_farm, calendar, b_id, suggestion)}>
-      <Badge
-        variant="outline"
-        className="border-primary/30 text-primary hover:bg-primary/10 gap-1"
-        title={`We denken dat hier ${suggestion.b_lu_name} geteeld werd in ${calendar}. Toevoegen als hoofdteelt?`}
-      >
-        <Sprout className="h-3 w-3" />
-        Voorstel: {suggestion.b_lu_name}
-      </Badge>
-    </NavLink>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <NavLink
+            to={buildAcceptSuggestionUrl(b_id_farm, calendar, b_id, suggestion)}
+            className="max-w-[10rem]"
+          >
+            <Badge
+              variant="secondary"
+              className="hover:bg-secondary/70 flex min-w-0 items-center gap-1"
+            >
+              <Sprout className="h-3 w-3 shrink-0" />
+              <span className="min-w-0 truncate">BRP: {suggestion.b_lu_name}</span>
+            </Badge>
+          </NavLink>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            BRP-schatting: {suggestion.b_lu_name} ({calendar}). Klik om toe te voegen als
+            hoofdteelt.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+type CultivationSuggestionStatusProps = {
+  b_id_farm: string
+  calendar: string
+  b_id: string
+  b_name?: string
+  result: CultivationSuggestionResult
+}
+
+/**
+ * Full-status variant for the highest-visibility surfaces (farm dashboard, field detail):
+ * distinguishes "here's a suggestion" from "we couldn't determine one" so a silent NMI failure
+ * never looks identical to "nothing to suggest". Renders nothing when the feature is fully
+ * disabled (`not_configured`) so self-hosted instances without an NMI subscription never see
+ * any trace of it.
+ */
+export function CultivationSuggestionStatusBanner({
+  b_id_farm,
+  calendar,
+  b_id,
+  b_name,
+  result,
+}: CultivationSuggestionStatusProps) {
+  if (result.status === "not_configured") {
+    return null
+  }
+
+  if (result.status === "suggested") {
+    return (
+      <CultivationSuggestionBanner
+        b_id_farm={b_id_farm}
+        calendar={calendar}
+        b_id={b_id}
+        b_name={b_name}
+        suggestion={result.suggestion}
+      />
+    )
+  }
+
+  const message =
+    result.status === "no_estimate"
+      ? "Geen BRP-schatting beschikbaar voor dit jaar."
+      : "De BRP-schatting kon niet worden opgehaald. Probeer het later opnieuw."
+
+  return (
+    <div className="text-muted-foreground flex items-start gap-2 rounded-lg border border-dashed p-3 text-sm">
+      <CircleHelp className="mt-0.5 h-4 w-4 shrink-0" />
+      <p>
+        {b_name && <span className="font-medium">{b_name}: </span>}
+        {message}
+      </p>
+    </div>
   )
 }

--- a/fdm-app/app/components/blocks/cultivation/suggestion.tsx
+++ b/fdm-app/app/components/blocks/cultivation/suggestion.tsx
@@ -1,0 +1,95 @@
+import { Sprout } from "lucide-react"
+import { NavLink } from "react-router"
+import { Badge } from "~/components/ui/badge"
+import { Button } from "~/components/ui/button"
+import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
+
+/**
+ * Builds the URL to the field's cultivation page with the suggestion pre-filled as query
+ * params, consumed by the "add cultivation" dialog to auto-open pre-filled.
+ */
+function buildAcceptSuggestionUrl(
+  b_id_farm: string,
+  calendar: string,
+  b_id: string,
+  suggestion: CultivationSuggestion,
+) {
+  const params = new URLSearchParams({
+    suggest_b_lu_catalogue: suggestion.b_lu_catalogue,
+    suggest_start: `${calendar}-01-01`,
+  })
+  return `/farm/${b_id_farm}/${calendar}/field/${b_id}/cultivation?${params.toString()}`
+}
+
+type CultivationSuggestionProps = {
+  b_id_farm: string
+  calendar: string
+  b_id: string
+  /** Field name, shown for contexts that list multiple fields (e.g. the dashboard banner). */
+  b_name?: string
+  suggestion: CultivationSuggestion | undefined
+}
+
+/**
+ * A non-dismissible inline suggestion for a field/year with no registered main cultivation,
+ * sourced from the NMI Estimates endpoint's BRP cultivation guess. Renders `null` when there
+ * is no suggestion (no NMI API key configured, no estimate for the year, or a lookup failure) —
+ * callers can always render this component unconditionally.
+ */
+export function CultivationSuggestionBanner({
+  b_id_farm,
+  calendar,
+  b_id,
+  b_name,
+  suggestion,
+}: CultivationSuggestionProps) {
+  if (!suggestion) {
+    return null
+  }
+
+  return (
+    <div className="border-primary/30 bg-primary/5 flex items-start gap-2 rounded-lg border p-3">
+      <Sprout className="text-primary mt-0.5 h-4 w-4 shrink-0" />
+      <div className="flex flex-1 flex-wrap items-center justify-between gap-2">
+        <p className="text-sm">
+          {b_name && <span className="font-medium">{b_name}: </span>}
+          We denken dat hier <span className="font-medium">{suggestion.b_lu_name}</span> geteeld
+          werd in {calendar}. Toevoegen als hoofdteelt?
+        </p>
+        <Button size="sm" variant="outline" asChild>
+          <NavLink to={buildAcceptSuggestionUrl(b_id_farm, calendar, b_id, suggestion)}>
+            Toevoegen als hoofdteelt
+          </NavLink>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Compact variant of {@link CultivationSuggestionBanner} for dense contexts (e.g. a table cell).
+ * Renders `null` when there is no suggestion.
+ */
+export function CultivationSuggestionBadge({
+  b_id_farm,
+  calendar,
+  b_id,
+  suggestion,
+}: CultivationSuggestionProps) {
+  if (!suggestion) {
+    return null
+  }
+
+  return (
+    <NavLink to={buildAcceptSuggestionUrl(b_id_farm, calendar, b_id, suggestion)}>
+      <Badge
+        variant="outline"
+        className="border-primary/30 text-primary hover:bg-primary/10 gap-1"
+        title={`We denken dat hier ${suggestion.b_lu_name} geteeld werd in ${calendar}. Toevoegen als hoofdteelt?`}
+      >
+        <Sprout className="h-3 w-3" />
+        Voorstel: {suggestion.b_lu_name}
+      </Badge>
+    </NavLink>
+  )
+}

--- a/fdm-app/app/components/blocks/cultivation/types.tsx
+++ b/fdm-app/app/components/blocks/cultivation/types.tsx
@@ -12,6 +12,14 @@ export interface CultivationOption {
   label: string
 }
 
+/** Pre-fill values sourced from an accepted `CultivationSuggestion` (see `~/lib/cultivation-suggestion.server`). */
+export interface CultivationDefaultValues {
+  b_lu_catalogue: string
+  b_lu_start: Date
+}
+
 export interface CultivationsFormProps {
   options: CultivationOption[]
+  /** When set, pre-fills the form and auto-opens the dialog (used for accepted suggestions). */
+  defaultValues?: CultivationDefaultValues
 }

--- a/fdm-app/app/components/blocks/cultivation/types.tsx
+++ b/fdm-app/app/components/blocks/cultivation/types.tsx
@@ -16,6 +16,7 @@ export interface CultivationOption {
 export interface CultivationDefaultValues {
   b_lu_catalogue: string
   b_lu_start: Date
+  b_lu_end?: Date
 }
 
 export interface CultivationsFormProps {

--- a/fdm-app/app/components/blocks/field-dashboard/dashboard-map.tsx
+++ b/fdm-app/app/components/blocks/field-dashboard/dashboard-map.tsx
@@ -11,13 +11,13 @@ import { useEffect, useMemo, useRef } from "react"
 import { Layer, Map as MapGL, type MapRef } from "react-map-gl/maplibre"
 import { useNavigate } from "react-router"
 import { MapTilerAttribution } from "~/components/blocks/atlas/atlas-attribution"
+import { FieldsPanelHover } from "~/components/blocks/atlas/atlas-panels"
 import {
   FieldSourceClickable,
   FieldsSourceNotClickable,
 } from "~/components/blocks/atlas/atlas-sources"
 import { getFieldsStyle } from "~/components/blocks/atlas/atlas-styles"
 import { getViewState } from "~/components/blocks/atlas/atlas-viewstate"
-import { FieldsPanelHover } from "~/components/blocks/atlas/atlas-panels"
 import type { FieldDashboardTileProps } from "./types"
 
 export default function FieldDashboardMap({

--- a/fdm-app/app/components/blocks/field-dashboard/tile.tsx
+++ b/fdm-app/app/components/blocks/field-dashboard/tile.tsx
@@ -1,5 +1,5 @@
-import { ArrowRight, CircleAlert, Plus } from "lucide-react"
 import type { ComponentType, ReactNode } from "react"
+import { ArrowRight, CircleAlert, Plus } from "lucide-react"
 import { Link } from "react-router"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "~/components/ui/card"

--- a/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
+++ b/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
@@ -12,12 +12,12 @@ import {
 } from "lucide-react"
 import { lazy, type ReactNode, Suspense } from "react"
 import { Await, Link } from "react-router"
+import { CultivationSuggestionStatusBanner } from "~/components/blocks/cultivation/suggestion"
 import { ScoreBadge } from "~/components/blocks/indicators/score-badge"
 import { NormProgressBar } from "~/components/blocks/norms/progress-bar"
 import { AdviceProgressBar } from "~/components/blocks/nutrient-advice/progress-bar"
 import { BCS_COLOR_CLASSES, BCS_SCORE_DOT } from "~/components/blocks/soil-visual/bcs-color-utils"
 import { BcsScoreCard } from "~/components/blocks/soil-visual/bcs-score-card"
-import { CultivationSuggestionBanner } from "~/components/blocks/cultivation/suggestion"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
@@ -128,7 +128,10 @@ export function FieldDashboardMapTile({ dashboard, tile }: FieldDashboardTilePro
           errorElement={<FieldDashboardMap dashboard={dashboard} fieldCroprotationById={{}} />}
         >
           {(fieldCroprotationById) => (
-            <FieldDashboardMap dashboard={dashboard} fieldCroprotationById={fieldCroprotationById} />
+            <FieldDashboardMap
+              dashboard={dashboard}
+              fieldCroprotationById={fieldCroprotationById}
+            />
           )}
         </Await>
       </Suspense>
@@ -191,7 +194,7 @@ export function FieldDashboardIdentityTile({ dashboard, tile }: FieldDashboardTi
 
 export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldDashboardTileProps) {
   const activeCultivation = dashboard.cultivation.active
-  const suggestion = dashboard.cultivation.suggestion
+  const suggestionResult = dashboard.cultivation.suggestionResult
 
   if (!activeCultivation) {
     return (
@@ -211,14 +214,12 @@ export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldD
               : undefined
           }
         />
-        {suggestion && (
-          <CultivationSuggestionBanner
-            b_id_farm={dashboard.b_id_farm}
-            calendar={dashboard.calendar}
-            b_id={dashboard.b_id}
-            suggestion={suggestion}
-          />
-        )}
+        <CultivationSuggestionStatusBanner
+          b_id_farm={dashboard.b_id_farm}
+          calendar={dashboard.calendar}
+          b_id={dashboard.b_id}
+          result={suggestionResult}
+        />
       </div>
     )
   }
@@ -231,14 +232,12 @@ export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldD
   return (
     <FieldDashboardTile title={tile.title} detailHref={tile.detailHref}>
       <div className="space-y-4">
-        {suggestion && (
-          <CultivationSuggestionBanner
-            b_id_farm={dashboard.b_id_farm}
-            calendar={dashboard.calendar}
-            b_id={dashboard.b_id}
-            suggestion={suggestion}
-          />
-        )}
+        <CultivationSuggestionStatusBanner
+          b_id_farm={dashboard.b_id_farm}
+          calendar={dashboard.calendar}
+          b_id={dashboard.b_id}
+          result={suggestionResult}
+        />
         <div>
           <p className="text-xl font-semibold break-words">{activeCultivation.name}</p>
           <p className="text-muted-foreground mt-1 text-sm">

--- a/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
+++ b/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
@@ -194,7 +194,24 @@ export function FieldDashboardIdentityTile({ dashboard, tile }: FieldDashboardTi
 
 export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldDashboardTileProps) {
   const activeCultivation = dashboard.cultivation.active
-  const suggestionResult = dashboard.cultivation.suggestionResult
+
+  // The suggestion lookup calls the NMI API and must never block the rest of this tile (which
+  // renders synchronously) — resolved separately via <Await>, same pattern as the other
+  // NMI-backed tiles (cultivation history, bln, etc.).
+  const suggestionBanner = (
+    <Suspense fallback={null}>
+      <Await resolve={dashboard.asyncInsights.cultivationSuggestion} errorElement={null}>
+        {(result) => (
+          <CultivationSuggestionStatusBanner
+            b_id_farm={dashboard.b_id_farm}
+            calendar={dashboard.calendar}
+            b_id={dashboard.b_id}
+            result={result}
+          />
+        )}
+      </Await>
+    </Suspense>
+  )
 
   if (!activeCultivation) {
     return (
@@ -214,12 +231,7 @@ export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldD
               : undefined
           }
         />
-        <CultivationSuggestionStatusBanner
-          b_id_farm={dashboard.b_id_farm}
-          calendar={dashboard.calendar}
-          b_id={dashboard.b_id}
-          result={suggestionResult}
-        />
+        {suggestionBanner}
       </div>
     )
   }
@@ -232,12 +244,7 @@ export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldD
   return (
     <FieldDashboardTile title={tile.title} detailHref={tile.detailHref}>
       <div className="space-y-4">
-        <CultivationSuggestionStatusBanner
-          b_id_farm={dashboard.b_id_farm}
-          calendar={dashboard.calendar}
-          b_id={dashboard.b_id}
-          result={suggestionResult}
-        />
+        {suggestionBanner}
         <div>
           <p className="text-xl font-semibold break-words">{activeCultivation.name}</p>
           <p className="text-muted-foreground mt-1 text-sm">

--- a/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
+++ b/fdm-app/app/components/blocks/field-dashboard/tiles.tsx
@@ -17,6 +17,7 @@ import { NormProgressBar } from "~/components/blocks/norms/progress-bar"
 import { AdviceProgressBar } from "~/components/blocks/nutrient-advice/progress-bar"
 import { BCS_COLOR_CLASSES, BCS_SCORE_DOT } from "~/components/blocks/soil-visual/bcs-color-utils"
 import { BcsScoreCard } from "~/components/blocks/soil-visual/bcs-score-card"
+import { CultivationSuggestionBanner } from "~/components/blocks/cultivation/suggestion"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
@@ -190,24 +191,35 @@ export function FieldDashboardIdentityTile({ dashboard, tile }: FieldDashboardTi
 
 export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldDashboardTileProps) {
   const activeCultivation = dashboard.cultivation.active
+  const suggestion = dashboard.cultivation.suggestion
 
   if (!activeCultivation) {
     return (
-      <FieldDashboardTileEmpty
-        title={tile.title}
-        detailHref={tile.detailHref}
-        icon={Sprout}
-        emptyTitle="Nog geen gewas voor dit jaar"
-        emptyDescription="Registreer een teelt om oogsten, bemesting en bodeminformatie in context te zien."
-        action={
-          dashboard.fieldWritePermission
-            ? {
-                href: tile.detailHref,
-                label: "Gewas toevoegen",
-              }
-            : undefined
-        }
-      />
+      <div className="space-y-3">
+        <FieldDashboardTileEmpty
+          title={tile.title}
+          detailHref={tile.detailHref}
+          icon={Sprout}
+          emptyTitle="Nog geen gewas voor dit jaar"
+          emptyDescription="Registreer een teelt om oogsten, bemesting en bodeminformatie in context te zien."
+          action={
+            dashboard.fieldWritePermission
+              ? {
+                  href: tile.detailHref,
+                  label: "Gewas toevoegen",
+                }
+              : undefined
+          }
+        />
+        {suggestion && (
+          <CultivationSuggestionBanner
+            b_id_farm={dashboard.b_id_farm}
+            calendar={dashboard.calendar}
+            b_id={dashboard.b_id}
+            suggestion={suggestion}
+          />
+        )}
+      </div>
     )
   }
 
@@ -219,6 +231,14 @@ export function FieldDashboardCurrentCultivationTile({ dashboard, tile }: FieldD
   return (
     <FieldDashboardTile title={tile.title} detailHref={tile.detailHref}>
       <div className="space-y-4">
+        {suggestion && (
+          <CultivationSuggestionBanner
+            b_id_farm={dashboard.b_id_farm}
+            calendar={dashboard.calendar}
+            b_id={dashboard.b_id}
+            suggestion={suggestion}
+          />
+        )}
         <div>
           <p className="text-xl font-semibold break-words">{activeCultivation.name}</p>
           <p className="text-muted-foreground mt-1 text-sm">

--- a/fdm-app/app/components/blocks/field-dashboard/types.ts
+++ b/fdm-app/app/components/blocks/field-dashboard/types.ts
@@ -3,9 +3,9 @@ import type { FeatureCollection, Geometry } from "geojson"
 import type { StyleSpecification } from "maplibre-gl"
 import type { ComponentType } from "react"
 import type { CultivationHistory } from "~/components/blocks/atlas-fields/cultivation-history"
-import type { BcsPreviewResult } from "~/lib/bcs"
-import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import type { BcsScores } from "~/components/blocks/soil-visual/bcs-color-utils"
+import type { BcsPreviewResult } from "~/lib/bcs"
+import type { CultivationSuggestionResult } from "~/lib/cultivation-suggestion.server"
 
 export type AsyncTileResult<T> =
   | { status: "ready"; data: T }
@@ -148,7 +148,7 @@ export interface FieldDashboardData {
   selectedFieldGeoJson: FeatureCollection<Geometry, FieldDashboardMapFeatureProperties>
   cultivation: {
     active: FieldDashboardCultivationSummary | null
-    suggestion: CultivationSuggestion | null
+    suggestionResult: CultivationSuggestionResult
   }
   fertilizer: {
     applicationCount: number

--- a/fdm-app/app/components/blocks/field-dashboard/types.ts
+++ b/fdm-app/app/components/blocks/field-dashboard/types.ts
@@ -148,7 +148,6 @@ export interface FieldDashboardData {
   selectedFieldGeoJson: FeatureCollection<Geometry, FieldDashboardMapFeatureProperties>
   cultivation: {
     active: FieldDashboardCultivationSummary | null
-    suggestionResult: CultivationSuggestionResult
   }
   fertilizer: {
     applicationCount: number
@@ -174,6 +173,7 @@ export interface FieldDashboardData {
     fertilizer: Promise<FieldDashboardFertilizerAsyncSummary>
     bln: Promise<AsyncTileResult<FieldDashboardBlnSummary>>
     cultivationHistory: Promise<AsyncTileResult<FieldDashboardCultivationHistoryEntry[]>>
+    cultivationSuggestion: Promise<CultivationSuggestionResult>
     fieldCultivationColors: Promise<Record<string, string | null>>
     nitrogenBalance: Promise<AsyncTileResult<FieldDashboardNitrogenBalanceSummary>>
     organicMatterBalance: Promise<AsyncTileResult<FieldDashboardOrganicMatterBalanceSummary>>

--- a/fdm-app/app/components/blocks/field-dashboard/types.ts
+++ b/fdm-app/app/components/blocks/field-dashboard/types.ts
@@ -4,6 +4,7 @@ import type { StyleSpecification } from "maplibre-gl"
 import type { ComponentType } from "react"
 import type { CultivationHistory } from "~/components/blocks/atlas-fields/cultivation-history"
 import type { BcsPreviewResult } from "~/lib/bcs"
+import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import type { BcsScores } from "~/components/blocks/soil-visual/bcs-color-utils"
 
 export type AsyncTileResult<T> =
@@ -147,6 +148,7 @@ export interface FieldDashboardData {
   selectedFieldGeoJson: FeatureCollection<Geometry, FieldDashboardMapFeatureProperties>
   cultivation: {
     active: FieldDashboardCultivationSummary | null
+    suggestion: CultivationSuggestion | null
   }
   fertilizer: {
     applicationCount: number

--- a/fdm-app/app/components/blocks/fields/columns.tsx
+++ b/fdm-app/app/components/blocks/fields/columns.tsx
@@ -8,7 +8,7 @@ import {
   Square,
   Triangle,
 } from "lucide-react"
-import { NavLink } from "react-router"
+import { NavLink, useParams } from "react-router"
 import type { BcsColor } from "~/components/blocks/soil-visual/bcs-color-utils"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
@@ -21,8 +21,10 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
+import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { BufferStripCheckbox } from "./buffer-strip-checkbox"
 import { DataTableColumnHeader } from "./column-header"
+import { CultivationSuggestionBadge } from "../cultivation/suggestion"
 
 const BCS_BADGE_CLASS: Record<BcsColor, string> = {
   red: "bg-red-100 text-red-700 hover:bg-red-200",
@@ -36,6 +38,7 @@ export type FieldExtended = {
   b_id: string
   b_name: string
   cultivations: Cultivation[]
+  cultivationSuggestion?: CultivationSuggestion
   fertilizers: Fertilizer[]
   a_som_loi: number | null
   b_soiltype_agr: string | null
@@ -102,6 +105,7 @@ export const columns: ColumnDef<FieldExtended>[] = [
     },
     cell: ({ row }) => {
       const field = row.original
+      const params = useParams()
 
       const cultivationsSorted = [...field.cultivations].sort((a, b) =>
         a.b_lu_name.localeCompare(b.b_lu_name),
@@ -121,6 +125,14 @@ export const columns: ColumnDef<FieldExtended>[] = [
               {cultivation.b_lu_name}
             </Badge>
           ))}
+          {field.cultivationSuggestion && params.b_id_farm && params.calendar && (
+            <CultivationSuggestionBadge
+              b_id_farm={params.b_id_farm}
+              calendar={params.calendar}
+              b_id={field.b_id}
+              suggestion={field.cultivationSuggestion}
+            />
+          )}
         </div>
       )
     },

--- a/fdm-app/app/components/blocks/fields/columns.tsx
+++ b/fdm-app/app/components/blocks/fields/columns.tsx
@@ -8,7 +8,7 @@ import {
   Square,
   Triangle,
 } from "lucide-react"
-import { NavLink, useParams } from "react-router"
+import { NavLink } from "react-router"
 import type { BcsColor } from "~/components/blocks/soil-visual/bcs-color-utils"
 import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
@@ -53,270 +53,275 @@ export type FieldExtended = {
   } | null
 }
 
-export const columns: ColumnDef<FieldExtended>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "b_name",
-    enableSorting: true,
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Naam" />
+export function buildColumns(b_id_farm: string, calendar: string): ColumnDef<FieldExtended>[] {
+  return [
+    {
+      id: "select",
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() && "indeterminate")
+          }
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+          aria-label="Select all"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+          aria-label="Select row"
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
     },
-    cell: ({ row }) => {
-      const field = row.original
+    {
+      accessorKey: "b_name",
+      enableSorting: true,
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Naam" />
+      },
+      cell: ({ row }) => {
+        const field = row.original
 
-      return (
-        <NavLink to={`./${field.b_id}`} className="group flex w-fit items-center hover:underline">
-          {field.b_name}
-          <ArrowUpRightFromSquare className="ml-2 h-4 w-4 text-gray-500 opacity-0 transition-opacity group-hover:opacity-100" />
-        </NavLink>
-      )
-    },
-  },
-  {
-    accessorKey: "cultivations",
-    enableSorting: true,
-    sortingFn: (rowA, rowB, _columnId) => {
-      const cultivationA = rowA.original.cultivations[0]?.b_lu_name || ""
-      const cultivationB = rowB.original.cultivations[0]?.b_lu_name || ""
-      return cultivationA.localeCompare(cultivationB)
-    },
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Gewassen" />
-    },
-    cell: ({ row }) => {
-      const field = row.original
-      const params = useParams()
-
-      const cultivationsSorted = [...field.cultivations].sort((a, b) =>
-        a.b_lu_name.localeCompare(b.b_lu_name),
-      )
-
-      return (
-        <div className="flex flex-col items-start space-y-2">
-          {cultivationsSorted.map((cultivation, idx) => (
-            <Badge
-              key={`${cultivation.b_lu_name}-${idx}`}
-              style={{
-                backgroundColor: getCultivationColor(cultivation.b_lu_croprotation ?? undefined),
-              }}
-              className="text-white"
-              variant="default"
-            >
-              {cultivation.b_lu_name}
-            </Badge>
-          ))}
-          {field.cultivationSuggestion && params.b_id_farm && params.calendar && (
-            <CultivationSuggestionBadge
-              b_id_farm={params.b_id_farm}
-              calendar={params.calendar}
-              b_id={field.b_id}
-              suggestion={field.cultivationSuggestion}
-            />
-          )}
-        </div>
-      )
-    },
-    enableHiding: true, // Enable hiding for mobile
-  },
-  {
-    accessorKey: "fertilizerApplications",
-    enableSorting: true,
-    sortingFn: (rowA, rowB, _columnId) => {
-      const fertilizerA = rowA.original.fertilizers[0]?.p_name_nl || ""
-      const fertilizerB = rowB.original.fertilizers[0]?.p_name_nl || ""
-      return fertilizerA.localeCompare(fertilizerB)
-    },
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Bemesting met:" />
-    },
-    cell: ({ row }) => {
-      const fertilizers = row.original.fertilizers
-
-      return (
-        <div className="flex flex-col items-start space-y-2">
-          {fertilizers.map((fertilizer) => (
-            <NavLink
-              key={fertilizer.p_id}
-              to={`./modify_fertilizer/${fertilizer.p_id}?fieldIds=${row.original.b_id}`}
-            >
-              <Badge variant="outline" className="text-muted-foreground gap-1">
-                <span>
-                  {fertilizer.p_type === "manure" ? (
-                    <Square className="size-3 fill-yellow-600 text-yellow-600" />
-                  ) : fertilizer.p_type === "mineral" ? (
-                    <Circle className="size-3 fill-sky-600 text-sky-600" />
-                  ) : fertilizer.p_type === "compost" ? (
-                    <Triangle className="size-3 fill-green-600 text-green-600" />
-                  ) : (
-                    <Diamond className="size-3 fill-gray-600 text-gray-600" />
-                  )}
-                </span>
-                {fertilizer.p_name_nl}
-              </Badge>
-            </NavLink>
-          ))}
-        </div>
-      )
-    },
-    enableHiding: true, // Enable hiding for mobile
-  },
-  {
-    accessorKey: "b_bufferstrip",
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Bufferstrook" />
-    },
-    cell: (props) => <BufferStripCheckbox {...props} />,
-    enableHiding: true, // Enable hiding for mobile
-  },
-  {
-    accessorKey: "a_som_loi",
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="OS" />
-    },
-    enableHiding: true, // Enable hiding for mobile
-    cell: ({ row }) => {
-      const field = row.original
-      return (
-        <p className="text-muted-foreground">
-          {field.a_som_loi !== null ? `${field.a_som_loi.toFixed(2)} %` : "-"}
-        </p>
-      )
-    },
-  },
-  {
-    id: "bcs",
-    accessorFn: (row) => row.bcs?.d_bcs ?? null,
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="BCS" />
-    },
-    enableHiding: true,
-    cell: ({ row }) => {
-      const field = row.original
-      if (!field.bcs) {
         return (
           <NavLink
-            to={`./${field.b_id}/bcs/new`}
-            className="text-muted-foreground hover:text-foreground transition-colors"
-            title="Nieuwe BCS aanmaken"
+            to={`./${field.b_id}`}
+            className="group flex w-fit items-center hover:underline"
           >
-            –
+            {field.b_name}
+            <ArrowUpRightFromSquare className="ml-2 h-4 w-4 text-gray-500 opacity-0 transition-opacity group-hover:opacity-100" />
           </NavLink>
         )
-      }
-      return (
-        <NavLink to={`./${field.b_id}/bcs/${field.bcs.a_id}`} className="inline-flex">
-          <Badge
-            className={`tabular-nums ${BCS_BADGE_CLASS[field.bcs.scoreColor]}`}
-            variant="secondary"
-          >
-            {Math.round(field.bcs.d_bcs)}
-          </Badge>
-        </NavLink>
-      )
+      },
     },
-  },
-  {
-    accessorKey: "b_soiltype_agr",
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Bodemtype" />
-    },
-    enableHiding: true, // Enable hiding for mobile
-    cell: ({ row }) => {
-      const field = row.original
-      return <p className="text-muted-foreground">{field.b_soiltype_agr}</p>
-    },
-  },
-  {
-    accessorKey: "b_area",
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    header: ({ column }) => {
-      return <DataTableColumnHeader column={column} title="Oppervlakte" />
-    },
-    enableHiding: true, // Enable hiding for mobile
-    cell: ({ row }) => {
-      const field = row.original
-      return (
-        <p className="text-muted-foreground">
-          {field.b_area < 0.1 ? "< 0.1 ha" : `${field.b_area.toFixed(1)} ha`}
-        </p>
-      )
-    },
-  },
-  {
-    id: "actions",
-    enableHiding: false,
-    cell: ({ row }) => {
-      const field = row.original
+    {
+      accessorKey: "cultivations",
+      enableSorting: true,
+      sortingFn: (rowA, rowB, _columnId) => {
+        const cultivationA = rowA.original.cultivations[0]?.b_lu_name || ""
+        const cultivationB = rowB.original.cultivations[0]?.b_lu_name || ""
+        return cultivationA.localeCompare(cultivationB)
+      },
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Gewassen" />
+      },
+      cell: ({ row }) => {
+        const field = row.original
 
-      return (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-8 w-8 p-0">
-              <span className="sr-only">Open menu</span>
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {/* <DropdownMenuLabel>Acties</DropdownMenuLabel>
-                        <DropdownMenuItem
-                            onClick={() =>
-                                navigator.clipboard.writeText(field.b_id)
-                            }
-                        >
-                            Kopieer perceel id
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator /> */}
-            <DropdownMenuLabel>Gegevens</DropdownMenuLabel>
-            <DropdownMenuItem>
-              <NavLink to={`./${field.b_id}`}>Overzicht</NavLink>
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <NavLink to={`./${field.b_id}/cultivation`}>Gewassen</NavLink>
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <NavLink to={`./${field.b_id}/fertilizer`}>Bemesting</NavLink>
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <NavLink to={`./${field.b_id}/soil`}>Bodem</NavLink>
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <NavLink to={`./${field.b_id}/atlas`}>Kaart</NavLink>
-            </DropdownMenuItem>
-            {field.has_write_permission && (
-              <DropdownMenuItem>
-                <NavLink to={`./${field.b_id}/delete`}>Verwijderen</NavLink>
-              </DropdownMenuItem>
+        const cultivationsSorted = [...field.cultivations].sort((a, b) =>
+          a.b_lu_name.localeCompare(b.b_lu_name),
+        )
+
+        return (
+          <div className="flex flex-col items-start space-y-2">
+            {cultivationsSorted.map((cultivation, idx) => (
+              <Badge
+                key={`${cultivation.b_lu_name}-${idx}`}
+                style={{
+                  backgroundColor: getCultivationColor(cultivation.b_lu_croprotation ?? undefined),
+                }}
+                className="text-white"
+                variant="default"
+              >
+                {cultivation.b_lu_name}
+              </Badge>
+            ))}
+            {field.cultivationSuggestion && (
+              <CultivationSuggestionBadge
+                b_id_farm={b_id_farm}
+                calendar={calendar}
+                b_id={field.b_id}
+                suggestion={field.cultivationSuggestion}
+              />
             )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )
+          </div>
+        )
+      },
+      enableHiding: true, // Enable hiding for mobile
     },
-  },
-]
+    {
+      accessorKey: "fertilizerApplications",
+      enableSorting: true,
+      sortingFn: (rowA, rowB, _columnId) => {
+        const fertilizerA = rowA.original.fertilizers[0]?.p_name_nl || ""
+        const fertilizerB = rowB.original.fertilizers[0]?.p_name_nl || ""
+        return fertilizerA.localeCompare(fertilizerB)
+      },
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Bemesting met:" />
+      },
+      cell: ({ row }) => {
+        const fertilizers = row.original.fertilizers
+
+        return (
+          <div className="flex flex-col items-start space-y-2">
+            {fertilizers.map((fertilizer) => (
+              <NavLink
+                key={fertilizer.p_id}
+                to={`./modify_fertilizer/${fertilizer.p_id}?fieldIds=${row.original.b_id}`}
+              >
+                <Badge variant="outline" className="text-muted-foreground gap-1">
+                  <span>
+                    {fertilizer.p_type === "manure" ? (
+                      <Square className="size-3 fill-yellow-600 text-yellow-600" />
+                    ) : fertilizer.p_type === "mineral" ? (
+                      <Circle className="size-3 fill-sky-600 text-sky-600" />
+                    ) : fertilizer.p_type === "compost" ? (
+                      <Triangle className="size-3 fill-green-600 text-green-600" />
+                    ) : (
+                      <Diamond className="size-3 fill-gray-600 text-gray-600" />
+                    )}
+                  </span>
+                  {fertilizer.p_name_nl}
+                </Badge>
+              </NavLink>
+            ))}
+          </div>
+        )
+      },
+      enableHiding: true, // Enable hiding for mobile
+    },
+    {
+      accessorKey: "b_bufferstrip",
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Bufferstrook" />
+      },
+      cell: (props) => <BufferStripCheckbox {...props} />,
+      enableHiding: true, // Enable hiding for mobile
+    },
+    {
+      accessorKey: "a_som_loi",
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="OS" />
+      },
+      enableHiding: true, // Enable hiding for mobile
+      cell: ({ row }) => {
+        const field = row.original
+        return (
+          <p className="text-muted-foreground">
+            {field.a_som_loi !== null ? `${field.a_som_loi.toFixed(2)} %` : "-"}
+          </p>
+        )
+      },
+    },
+    {
+      id: "bcs",
+      accessorFn: (row) => row.bcs?.d_bcs ?? null,
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="BCS" />
+      },
+      enableHiding: true,
+      cell: ({ row }) => {
+        const field = row.original
+        if (!field.bcs) {
+          return (
+            <NavLink
+              to={`./${field.b_id}/bcs/new`}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title="Nieuwe BCS aanmaken"
+            >
+              –
+            </NavLink>
+          )
+        }
+        return (
+          <NavLink to={`./${field.b_id}/bcs/${field.bcs.a_id}`} className="inline-flex">
+            <Badge
+              className={`tabular-nums ${BCS_BADGE_CLASS[field.bcs.scoreColor]}`}
+              variant="secondary"
+            >
+              {Math.round(field.bcs.d_bcs)}
+            </Badge>
+          </NavLink>
+        )
+      },
+    },
+    {
+      accessorKey: "b_soiltype_agr",
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Bodemtype" />
+      },
+      enableHiding: true, // Enable hiding for mobile
+      cell: ({ row }) => {
+        const field = row.original
+        return <p className="text-muted-foreground">{field.b_soiltype_agr}</p>
+      },
+    },
+    {
+      accessorKey: "b_area",
+      enableSorting: true,
+      sortingFn: "alphanumeric",
+      header: ({ column }) => {
+        return <DataTableColumnHeader column={column} title="Oppervlakte" />
+      },
+      enableHiding: true, // Enable hiding for mobile
+      cell: ({ row }) => {
+        const field = row.original
+        return (
+          <p className="text-muted-foreground">
+            {field.b_area < 0.1 ? "< 0.1 ha" : `${field.b_area.toFixed(1)} ha`}
+          </p>
+        )
+      },
+    },
+    {
+      id: "actions",
+      enableHiding: false,
+      cell: ({ row }) => {
+        const field = row.original
+
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0">
+                <span className="sr-only">Open menu</span>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {/* <DropdownMenuLabel>Acties</DropdownMenuLabel>
+                          <DropdownMenuItem
+                              onClick={() =>
+                                  navigator.clipboard.writeText(field.b_id)
+                              }
+                          >
+                              Kopieer perceel id
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator /> */}
+              <DropdownMenuLabel>Gegevens</DropdownMenuLabel>
+              <DropdownMenuItem>
+                <NavLink to={`./${field.b_id}`}>Overzicht</NavLink>
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <NavLink to={`./${field.b_id}/cultivation`}>Gewassen</NavLink>
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <NavLink to={`./${field.b_id}/fertilizer`}>Bemesting</NavLink>
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <NavLink to={`./${field.b_id}/soil`}>Bodem</NavLink>
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <NavLink to={`./${field.b_id}/atlas`}>Kaart</NavLink>
+              </DropdownMenuItem>
+              {field.has_write_permission && (
+                <DropdownMenuItem>
+                  <NavLink to={`./${field.b_id}/delete`}>Verwijderen</NavLink>
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )
+      },
+    },
+  ]
+}

--- a/fdm-app/app/components/blocks/fields/columns.tsx
+++ b/fdm-app/app/components/blocks/fields/columns.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import { NavLink, useParams } from "react-router"
 import type { BcsColor } from "~/components/blocks/soil-visual/bcs-color-utils"
+import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
@@ -21,10 +22,9 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
-import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
+import { CultivationSuggestionBadge } from "../cultivation/suggestion"
 import { BufferStripCheckbox } from "./buffer-strip-checkbox"
 import { DataTableColumnHeader } from "./column-header"
-import { CultivationSuggestionBadge } from "../cultivation/suggestion"
 
 const BCS_BADGE_CLASS: Record<BcsColor, string> = {
   red: "bg-red-100 text-red-700 hover:bg-red-200",

--- a/fdm-app/app/components/blocks/gerrit/plan-table.tsx
+++ b/fdm-app/app/components/blocks/gerrit/plan-table.tsx
@@ -8,11 +8,11 @@ import {
 import { CheckCircle2, ChevronDown, ChevronUp, Info } from "lucide-react"
 import { Fragment } from "react"
 import { Form } from "react-router"
+import { NormProgressBar } from "~/components/blocks/norms/progress-bar"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
-import { NormProgressBar } from "~/components/blocks/norms/progress-bar"
 import { Spinner } from "~/components/ui/spinner"
 import {
   Table,
@@ -328,7 +328,11 @@ export function PlanTable({ plan, isSaving, expandedRows, toggleRow }: PlanTable
                                             {Math.round(fill)} / {Math.round(norm)}
                                           </span>
                                         </div>
-                                        <NormProgressBar used={fill} limit={norm} className="h-1.5" />
+                                        <NormProgressBar
+                                          used={fill}
+                                          limit={norm}
+                                          className="h-1.5"
+                                        />
                                       </div>
                                     ))}
                                   </div>

--- a/fdm-app/app/components/blocks/header/balance.tsx
+++ b/fdm-app/app/components/blocks/header/balance.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown } from "lucide-react"
 import { NavLink, useLocation } from "react-router"
 import { useCalendarStore } from "@/app/store/calendar"
+import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import {
   DropdownMenu,
@@ -8,7 +9,6 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
-import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 
 export function HeaderBalance({
   b_id_farm,
@@ -64,7 +64,9 @@ export function HeaderBalance({
             <HeaderFieldPicker
               b_id={b_id}
               fieldOptions={fieldOptions}
-              buildHref={(optionId) => `/farm/${b_id_farm}/${calendar}/balance/${balanceKind}/${optionId}`}
+              buildHref={(optionId) =>
+                `/farm/${b_id_farm}/${calendar}/balance/${balanceKind}/${optionId}`
+              }
             />
           </BreadcrumbItem>
         </>

--- a/fdm-app/app/components/blocks/header/field.tsx
+++ b/fdm-app/app/components/blocks/header/field.tsx
@@ -1,8 +1,8 @@
 import { useLocation } from "react-router"
 import { cn } from "@/app/lib/utils"
 import { useCalendarStore } from "@/app/store/calendar"
-import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
+import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 
 export function HeaderField({
   b_id_farm,

--- a/fdm-app/app/components/blocks/header/indicators.tsx
+++ b/fdm-app/app/components/blocks/header/indicators.tsx
@@ -1,12 +1,12 @@
 import { useMatches, useParams } from "react-router"
 import { useCalendarStore } from "@/app/store/calendar"
+import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb"
-import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 
 export function HeaderIndicators({ b_id_farm }: { b_id_farm: string }) {
   const calendarFromStore = useCalendarStore((state) => state.calendar)

--- a/fdm-app/app/components/blocks/header/measures.tsx
+++ b/fdm-app/app/components/blocks/header/measures.tsx
@@ -1,12 +1,12 @@
 import { useMatches, useParams } from "react-router"
 import { useCalendarStore } from "@/app/store/calendar"
+import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb"
-import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
 
 export function HeaderMeasures({ b_id_farm }: { b_id_farm: string }) {
   const calendarFromStore = useCalendarStore((state) => state.calendar)

--- a/fdm-app/app/components/blocks/header/norms.tsx
+++ b/fdm-app/app/components/blocks/header/norms.tsx
@@ -1,6 +1,6 @@
 import { useCalendarStore } from "@/app/store/calendar"
-import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
+import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 
 export function HeaderNorms({
   b_id_farm,

--- a/fdm-app/app/components/blocks/header/nutrient-advice.tsx
+++ b/fdm-app/app/components/blocks/header/nutrient-advice.tsx
@@ -1,6 +1,6 @@
 import { useCalendarStore } from "@/app/store/calendar"
-import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import { HeaderFieldPicker } from "~/components/blocks/header/field-picker"
+import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 
 export function HeaderNutrientAdvice({
   b_id_farm,

--- a/fdm-app/app/components/blocks/mijnpercelen/loader-and-action.server.ts
+++ b/fdm-app/app/components/blocks/mijnpercelen/loader-and-action.server.ts
@@ -308,7 +308,11 @@ export async function genericAction(
       if (nmiApiKey) {
         for (const { b_id, geometry } of addedFields) {
           try {
-            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(
+              fdm,
+              geometry,
+              nmiApiKey,
+            )
             await addSoilAnalysis(
               fdm,
               session.principal_id,

--- a/fdm-app/app/components/blocks/mijnpercelen/loader-and-action.server.ts
+++ b/fdm-app/app/components/blocks/mijnpercelen/loader-and-action.server.ts
@@ -19,7 +19,7 @@ import { length } from "@turf/length"
 import fs from "node:fs/promises"
 import { data } from "react-router"
 import { redirectWithSuccess } from "remix-toast"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey, getSoilParameterEstimatesForGeometry } from "~/integrations/nmi.server"
 import { captureEvent } from "~/lib/analytics.server"
 import { getSession } from "~/lib/auth.server"
 import { getCalendar } from "~/lib/calendar"
@@ -308,7 +308,7 @@ export async function genericAction(
       if (nmiApiKey) {
         for (const { b_id, geometry } of addedFields) {
           try {
-            const soilEstimates = await getSoilParameterEstimates(geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
             await addSoilAnalysis(
               fdm,
               session.principal_id,

--- a/fdm-app/app/components/blocks/nutrient-advice/overview-columns.tsx
+++ b/fdm-app/app/components/blocks/nutrient-advice/overview-columns.tsx
@@ -1,6 +1,7 @@
 import type { Column, ColumnDef, RowData } from "@tanstack/react-table"
 import { ArrowDown, ArrowUp } from "lucide-react"
 import { NavLink } from "react-router"
+import { CultivationSuggestionBadge } from "~/components/blocks/cultivation/suggestion"
 import { getCultivationColor } from "~/components/custom/cultivation-colors"
 import { Badge } from "~/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip"
@@ -244,7 +245,7 @@ function FieldColumnHeader({ column }: { column: Column<FieldNutrientRow, unknow
   )
 }
 
-export function buildFieldColumn(): ColumnDef<FieldNutrientRow> {
+export function buildFieldColumn(b_id_farm: string, calendar: string): ColumnDef<FieldNutrientRow> {
   return {
     id: "field",
     accessorKey: "b_name",
@@ -255,36 +256,50 @@ export function buildFieldColumn(): ColumnDef<FieldNutrientRow> {
       const field = row.original
       const cultivation = field.mainCultivation
       return (
-        <NavLink
-          to={`./${field.b_id}${cultivation ? `?cultivation=${cultivation.b_lu}` : ""}`}
-          className="group block max-w-[16rem]"
-        >
-          <span
-            title={field.b_name}
-            className="group-hover:text-foreground/80 block truncate font-medium underline-offset-4 group-hover:underline"
+        <div>
+          <NavLink
+            to={`./${field.b_id}${cultivation ? `?cultivation=${cultivation.b_lu}` : ""}`}
+            className="group block max-w-[16rem]"
           >
-            {field.b_name}
-          </span>
-          <span className="mt-1 flex min-w-0 items-center gap-2">
-            <span className="text-muted-foreground shrink-0 text-xs">
-              {field.b_area < 0.1 ? "< 0.1 ha" : `${field.b_area.toFixed(1)} ha`}
+            <span
+              title={field.b_name}
+              className="group-hover:text-foreground/80 block truncate font-medium underline-offset-4 group-hover:underline"
+            >
+              {field.b_name}
             </span>
-            {cultivation ? (
-              <Badge
-                title={cultivation.b_lu_name}
-                style={{
-                  backgroundColor: getCultivationColor(cultivation.b_lu_croprotation ?? undefined),
-                }}
-                className="min-w-0 truncate text-white"
-                variant="default"
-              >
-                {cultivation.b_lu_name}
-              </Badge>
-            ) : (
-              <span className="text-muted-foreground truncate text-xs italic">Geen gewas</span>
-            )}
-          </span>
-        </NavLink>
+            <span className="mt-1 flex min-w-0 items-center gap-2">
+              <span className="text-muted-foreground shrink-0 text-xs">
+                {field.b_area < 0.1 ? "< 0.1 ha" : `${field.b_area.toFixed(1)} ha`}
+              </span>
+              {cultivation ? (
+                <Badge
+                  title={cultivation.b_lu_name}
+                  style={{
+                    backgroundColor: getCultivationColor(
+                      cultivation.b_lu_croprotation ?? undefined,
+                    ),
+                  }}
+                  className="min-w-0 truncate text-white"
+                  variant="default"
+                >
+                  {cultivation.b_lu_name}
+                </Badge>
+              ) : (
+                <span className="text-muted-foreground truncate text-xs italic">Geen gewas</span>
+              )}
+            </span>
+          </NavLink>
+          {field.cultivationSuggestion && (
+            <div className="mt-1" data-prevent-row-click="true">
+              <CultivationSuggestionBadge
+                b_id_farm={b_id_farm}
+                calendar={calendar}
+                b_id={field.b_id}
+                suggestion={field.cultivationSuggestion}
+              />
+            </div>
+          )}
+        </div>
       )
     },
     footer: () => <span className="font-medium">Bedrijfstotaal</span>,
@@ -300,6 +315,8 @@ export function buildFieldColumn(): ColumnDef<FieldNutrientRow> {
 export function buildOverviewColumns(
   nutrients: NutrientDescription[],
   unitMode: UnitMode,
+  b_id_farm: string,
+  calendar: string,
 ): ColumnDef<FieldNutrientRow>[] {
   const order: NutrientDescription["type"][] = ["primary", "secondary", "trace"]
   const orderedNutrients = order.flatMap((type) =>
@@ -313,5 +330,5 @@ export function buildOverviewColumns(
     return buildNutrientColumn(nutrient, unitMode, isGroupStart)
   })
 
-  return [buildFieldColumn(), ...nutrientColumns]
+  return [buildFieldColumn(b_id_farm, calendar), ...nutrientColumns]
 }

--- a/fdm-app/app/components/blocks/nutrient-advice/overview-table.tsx
+++ b/fdm-app/app/components/blocks/nutrient-advice/overview-table.tsx
@@ -44,9 +44,16 @@ const MAX_ERROR_FIELDS_LISTED = 4
 interface NutrientAdviceOverviewTableProps {
   data: FieldNutrientRow[]
   nutrients: NutrientDescription[]
+  b_id_farm: string
+  calendar: string
 }
 
-export function NutrientAdviceOverviewTable({ data, nutrients }: NutrientAdviceOverviewTableProps) {
+export function NutrientAdviceOverviewTable({
+  data,
+  nutrients,
+  b_id_farm,
+  calendar,
+}: NutrientAdviceOverviewTableProps) {
   const navigate = useNavigate()
   const isMobile = useIsMobile()
   const [search, setSearch] = useState("")
@@ -76,8 +83,8 @@ export function NutrientAdviceOverviewTable({ data, nutrients }: NutrientAdviceO
   }, [isMobile, nutrients, hasCustomColumnVisibility, applyDefaultColumnVisibility])
 
   const columns = useMemo<ColumnDef<FieldNutrientRow>[]>(
-    () => buildOverviewColumns(nutrients, unitMode),
-    [nutrients, unitMode],
+    () => buildOverviewColumns(nutrients, unitMode, b_id_farm, calendar),
+    [nutrients, unitMode, b_id_farm, calendar],
   )
 
   const filteredData = useMemo(() => {

--- a/fdm-app/app/components/blocks/nutrient-advice/overview-types.ts
+++ b/fdm-app/app/components/blocks/nutrient-advice/overview-types.ts
@@ -1,3 +1,5 @@
+import type { CultivationSuggestion } from "~/lib/cultivation-suggestion.server"
+
 export type UnitMode = "per_ha" | "total"
 
 export type FieldNutrientValue = {
@@ -16,6 +18,12 @@ export type FieldNutrientRow = {
     b_lu_name: string
     b_lu_croprotation: string | null
   } | null
+  /**
+   * Set when `mainCultivation` was resolved via the `cultivations[0]` fallback (no registered
+   * default/"hoofdteelt" cultivation for the active year) and an NMI-estimate-based suggestion
+   * is available for the actual missing cultivation.
+   */
+  cultivationSuggestion?: CultivationSuggestion
   /** Set when the advice could not be calculated for this field (e.g. missing cultivation or soil data). */
   errorMessage?: string
   /** Nutrient values keyed by nutrient symbol (e.g. "N", "P", "EOC"). */

--- a/fdm-app/app/components/blocks/sidebar/apps.tsx
+++ b/fdm-app/app/components/blocks/sidebar/apps.tsx
@@ -294,7 +294,8 @@ export function SidebarApps({
                         onClick={() =>
                           openFarmPicker(
                             "de balansen",
-                            (b_id_farm) => `/farm/${b_id_farm}/${selectedCalendar}/balance/nitrogen`,
+                            (b_id_farm) =>
+                              `/farm/${b_id_farm}/${selectedCalendar}/balance/nitrogen`,
                           )
                         }
                       >

--- a/fdm-app/app/components/blocks/sidebar/farm-picker-dialog.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm-picker-dialog.tsx
@@ -49,7 +49,10 @@ export function FarmPickerDialog({
         </DialogHeader>
         {farms.length > 0 ? (
           <Command>
-            <CommandInput placeholder="Zoek bedrijf..." className="border-none focus:ring-0 focus-visible:ring-0" />
+            <CommandInput
+              placeholder="Zoek bedrijf..."
+              className="border-none focus:ring-0 focus-visible:ring-0"
+            />
             <CommandList className="max-h-[300px] overflow-y-auto p-2">
               <CommandEmpty>Geen bedrijven gevonden.</CommandEmpty>
               <CommandGroup heading="Bedrijven">

--- a/fdm-app/app/components/blocks/sidebar/farm.tsx
+++ b/fdm-app/app/components/blocks/sidebar/farm.tsx
@@ -20,6 +20,8 @@ import { getCalendarSelection } from "@/app/lib/calendar"
 import { useCalendarStore } from "@/app/store/calendar"
 import { useFarmStore } from "@/app/store/farm"
 import { useSelectedFieldStore } from "@/app/store/selected-field"
+import { FarmPickerDialog } from "~/components/blocks/sidebar/farm-picker-dialog"
+import { FieldPickerDialog } from "~/components/blocks/sidebar/field-picker-dialog"
 import { Badge } from "~/components/ui/badge"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/components/ui/collapsible"
 import {
@@ -44,8 +46,6 @@ import {
 } from "~/components/ui/sidebar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "~/components/ui/tooltip"
 import { getFieldNavigationItems } from "~/lib/field-navigation"
-import { FarmPickerDialog } from "~/components/blocks/sidebar/farm-picker-dialog"
-import { FieldPickerDialog } from "~/components/blocks/sidebar/field-picker-dialog"
 
 export function SidebarFarm({
   farm,
@@ -443,7 +443,10 @@ export function SidebarFarm({
                     <SidebarMenuButton
                       className="text-muted-foreground"
                       onClick={() =>
-                        openFarmPicker("meststoffen", (b_id_farm) => `/farm/${b_id_farm}/fertilizers`)
+                        openFarmPicker(
+                          "meststoffen",
+                          (b_id_farm) => `/farm/${b_id_farm}/fertilizers`,
+                        )
                       }
                     >
                       <Shapes />
@@ -543,7 +546,8 @@ export function SidebarFarm({
                             asChild
                             isActive={
                               item.segment === ""
-                                ? location.pathname === item.to || location.pathname === `${item.to}/`
+                                ? location.pathname === item.to ||
+                                  location.pathname === `${item.to}/`
                                 : location.pathname.startsWith(item.to)
                             }
                           >

--- a/fdm-app/app/integrations/nmi.server.ts
+++ b/fdm-app/app/integrations/nmi.server.ts
@@ -1,8 +1,8 @@
+import type { SoilParameterEstimatesResponse } from "@nmi-agro/fdm-calculator"
 /* eslint-disable typescript/no-redundant-type-constituents -- 'any' is used intentionally inside custom return types to represent raw third-party JSON properties that cannot be typed ahead of time. */
 import type { FdmType, FieldGeometry } from "@nmi-agro/fdm-core"
-import type { SoilParameterEstimatesResponse } from "@nmi-agro/fdm-calculator"
-import { getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
 import type { Feature, Geometry } from "geojson"
+import { getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
 import centroid from "@turf/centroid"
 import { fileTypeFromBuffer } from "file-type"
 import proj4 from "proj4"

--- a/fdm-app/app/integrations/nmi.server.ts
+++ b/fdm-app/app/integrations/nmi.server.ts
@@ -1,10 +1,11 @@
 /* eslint-disable typescript/no-redundant-type-constituents -- 'any' is used intentionally inside custom return types to represent raw third-party JSON properties that cannot be typed ahead of time. */
-import type { FieldGeometry } from "@nmi-agro/fdm-core"
+import type { FdmType, FieldGeometry } from "@nmi-agro/fdm-core"
+import type { SoilParameterEstimatesResponse } from "@nmi-agro/fdm-calculator"
+import { getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
 import type { Feature, Geometry } from "geojson"
 import centroid from "@turf/centroid"
 import { fileTypeFromBuffer } from "file-type"
 import proj4 from "proj4"
-import { z } from "zod"
 import { serverConfig } from "~/lib/config.server"
 
 const MAX_PDF_SIZE = 5 * 1024 * 1024
@@ -37,67 +38,20 @@ async function validatePdfMagicBytes(file: File) {
   }
 }
 
-export async function getSoilParameterEstimates(
+/**
+ * Resolves the centroid of a not-yet-persisted field geometry (e.g. a drawn or
+ * imported polygon that doesn't have a `b_id` yet) and fetches the cached soil
+ * parameter + BRP cultivation-history estimates for it.
+ *
+ * For persisted fields (with a `b_id`), prefer resolving the centroid via
+ * `collectInputForSoilParameterEstimates` (from `@nmi-agro/fdm-calculator`),
+ * which reuses the field's DB-computed centroid instead of recomputing it here.
+ */
+export async function getSoilParameterEstimatesForGeometry(
+  fdm: FdmType,
   field: Feature | FieldGeometry,
   nmiApiKey: string | undefined,
-): Promise<{
-  a_al_ox: number
-  a_c_of: number
-  a_ca_co: number
-  a_ca_co_po: number
-  a_caco3_if: number
-  a_cec_co: number
-  a_clay_mi: number
-  a_cn_fr: number
-  a_com_fr: number
-  a_cu_cc: number
-  a_density_sa: number
-  a_fe_ox: number
-  a_k_cc: number
-  a_k_co: number
-  a_k_co_po: number
-  a_mg_cc: number
-  a_mg_co: number
-  a_mg_co_po: number
-  a_n_pmn: number
-  a_n_rt: number
-  a_p_al: number
-  a_p_cc: number
-  a_p_ox: number
-  a_p_rt: number
-  a_p_sg: number
-  a_p_wa: number
-  a_ph_cc: number
-  a_s_rt: number
-  a_sand_mi: number
-  a_silt_mi: number
-  a_som_loi: number
-  a_zn_cc: number
-  b_soiltype_agr: string
-  b_gwl_class: string
-  b_gwl_ghg: number
-  b_gwl_glg: number
-  b_c_st03: number
-  b_som_potential: number
-  b_c_st03_potential: number
-  b_c_delta: number
-  cultivations: { year: number; b_lu_brp: number }[]
-  cultivations_advanced: {
-    year: number
-    fields: {
-      b_lu_brp: number
-      b_area: number
-      b_area_overlap: number
-    }[]
-  }[]
-  a_source: string
-  a_depth_upper: number
-  a_depth_lower: number | undefined
-}> {
-  if (!nmiApiKey) {
-    throw new Error("Please provide a NMI API key")
-  }
-
+): Promise<SoilParameterEstimatesResponse> {
   let geometry: Geometry
   if ("geometry" in field) {
     geometry = field.geometry
@@ -108,96 +62,8 @@ export async function getSoilParameterEstimates(
   const a_lon = fieldCentroid.geometry.coordinates[0]
   const a_lat = fieldCentroid.geometry.coordinates[1]
 
-  const responseApi = await fetch(
-    `https://api.nmi-agro.nl/estimates?${new URLSearchParams({
-      a_lat: a_lat.toString(),
-      a_lon: a_lon.toString(),
-    })}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${nmiApiKey}`,
-      },
-    },
-  )
-
-  if (!responseApi.ok) {
-    throw new Error("Request to NMI API failed")
-  }
-
-  const result = await responseApi.json()
-  const response = result.data
-  response.a_source = "nl-other-nmi"
-  response.a_depth_upper = 0
-  response.a_depth_lower = undefined
-
-  // Validate the response using the Zod schema
-  const parsedResponse = soilParameterEstimatesSchema.safeParse(result.data)
-  if (!parsedResponse.success) {
-    console.error(
-      "NMI API response validation failed:",
-      JSON.stringify(z.treeifyError(parsedResponse.error), null, 2),
-    )
-    throw new Error(`Invalid response from NMI API: ${parsedResponse.error.message}`)
-  }
-
-  return response
+  return getSoilParameterEstimates(fdm, { a_lat, a_lon, nmiApiKey })
 }
-
-const soilParameterEstimatesSchema = z.object({
-  a_al_ox: z.number(),
-  a_ca_co: z.number(),
-  a_ca_co_po: z.number(),
-  a_caco3_if: z.number(),
-  a_cec_co: z.number(),
-  a_clay_mi: z.number(),
-  a_cn_fr: z.number(),
-  a_com_fr: z.number(),
-  a_cu_cc: z.number(),
-  a_fe_ox: z.number(),
-  a_k_cc: z.number(),
-  a_k_co: z.number(),
-  a_k_co_po: z.number(),
-  a_mg_cc: z.number(),
-  a_mg_co: z.number(),
-  a_mg_co_po: z.number(),
-  a_n_pmn: z.number(),
-  a_n_rt: z.number(),
-  a_p_al: z.number(),
-  a_p_cc: z.number(),
-  a_p_ox: z.number(),
-  a_p_rt: z.number(),
-  a_p_sg: z.number(),
-  a_p_wa: z.number(),
-  a_ph_cc: z.number(),
-  a_s_rt: z.number(),
-  a_sand_mi: z.number(),
-  a_silt_mi: z.number(),
-  a_som_loi: z.number(),
-  a_zn_cc: z.number(),
-  b_soiltype_agr: z.string(),
-  b_gwl_class: z.string(),
-  b_gwl_ghg: z.number(),
-  b_gwl_glg: z.number(),
-  b_c_st03: z.number(),
-  b_som_potential: z.number(),
-  b_c_st03_potential: z.number(),
-  b_c_delta: z.number(),
-  cultivations: z.array(z.object({ year: z.number(), b_lu_brp: z.number() })),
-  cultivations_advanced: z.array(
-    z.object({
-      year: z.number(),
-      fields: z.array(
-        z.object({
-          b_lu_brp: z.number(),
-          b_area: z.number(),
-          b_area_overlap: z.number(),
-        }),
-      ),
-    }),
-  ),
-  a_source: z.string(),
-})
 
 export async function extractSoilAnalysis(formData: FormData) {
   const nmiApiKey = getNmiApiKey()

--- a/fdm-app/app/lib/cultivation-suggestion.server.ts
+++ b/fdm-app/app/lib/cultivation-suggestion.server.ts
@@ -1,39 +1,60 @@
 import type { FdmType, PrincipalId } from "@nmi-agro/fdm-core"
-import { collectInputForSoilParameterEstimates, getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
+import {
+  collectInputForSoilParameterEstimates,
+  getSoilParameterEstimates,
+} from "@nmi-agro/fdm-calculator"
+import { getDefaultDatesOfCultivation } from "@nmi-agro/fdm-core"
 import { getCultivationCatalogue } from "@nmi-agro/fdm-data"
 
 export type CultivationSuggestion = {
   b_lu_catalogue: string
   b_lu_name: string
+  /** Default sowing date for this crop/year, sourced from the cultivation catalogue (same logic used for RVO/shapefile imports via `getDefaultDatesOfCultivation`). */
+  b_lu_start: Date
+  /** Default harvest/end date for this crop/year, or `undefined` for crops that aren't harvested once (e.g. grassland). */
+  b_lu_end: Date | undefined
 }
+
+/**
+ * Outcome of a cultivation-suggestion lookup, distinguishing *why* no suggestion is available
+ * so the higher-visibility surfaces (dashboard, field detail) can tell "nothing to suggest"
+ * apart from "we couldn't check" instead of rendering identical silence for both.
+ */
+export type CultivationSuggestionResult =
+  | { status: "suggested"; suggestion: CultivationSuggestion }
+  /** No NMI API key configured — the feature is fully disabled for this instance. */
+  | { status: "not_configured" }
+  /** NMI API key configured and the lookup succeeded, but no BRP entry exists for this year. */
+  | { status: "no_estimate" }
+  /** NMI API key configured, but the lookup itself failed (network/validation error). */
+  | { status: "unavailable" }
 
 /**
  * Suggests a main cultivation for a field/year based on the NMI Estimates endpoint's
  * BRP-derived cultivation guess (`cultivations: { year, b_lu_brp }[]`), for use when
  * `getDefaultCultivation` (the "May 15th" rule) finds no registered cultivation.
  *
- * Always resolves to `undefined` rather than throwing — the suggestion is a nice-to-have
- * enrichment and must never block or break a page:
- * - No NMI API key configured (self-hosted/OSS instances without a subscription).
- * - No entry for the requested year in `cultivations` (current year before BRP data is
- *   published, a future year, or no BRP registration match for this field/location).
- * - Any failure calling the NMI API or resolving the catalogue entry (logged, not thrown).
+ * Always resolves to a result rather than throwing — the suggestion is a nice-to-have
+ * enrichment and must never block or break a page. See {@link CultivationSuggestionResult}
+ * for the distinct "nothing to suggest" reasons this can resolve to.
  *
  * @param fdm - The FDM instance for database interaction.
  * @param principal_id - The principal making the request.
+ * @param b_id_farm - The farm ID, used to resolve the suggested crop's default sowing/harvest dates.
  * @param b_id - The field ID to suggest a cultivation for.
  * @param year - The calendar year (string) to look up an estimate for.
  * @param nmiApiKey - The NMI API key for authentication, or `undefined` if not configured.
  */
-export async function getCultivationSuggestion(
+export async function getCultivationSuggestionResult(
   fdm: FdmType,
   principal_id: PrincipalId,
+  b_id_farm: string,
   b_id: string,
   year: string,
   nmiApiKey: string | undefined,
-): Promise<CultivationSuggestion | undefined> {
+): Promise<CultivationSuggestionResult> {
   if (!nmiApiKey) {
-    return undefined
+    return { status: "not_configured" }
   }
 
   try {
@@ -50,7 +71,7 @@ export async function getCultivationSuggestion(
 
     const estimateForYear = estimates.cultivations.find((c) => c.year === Number(year))
     if (!estimateForYear) {
-      return undefined
+      return { status: "no_estimate" }
     }
 
     const b_lu_catalogue = `nl_${estimateForYear.b_lu_brp}`
@@ -58,18 +79,58 @@ export async function getCultivationSuggestion(
       (item) => item.b_lu_catalogue === b_lu_catalogue,
     )
     if (!catalogueItem) {
-      return undefined
+      return { status: "no_estimate" }
     }
 
-    return {
+    // Resolve default sowing/harvest dates for this crop the same way the RVO/shapefile field
+    // import flow does (see `farm.$b_id_farm.$calendar.field.new._index.tsx`), rather than a
+    // fixed `<year>-01-01` placeholder.
+    const { b_lu_start, b_lu_end } = await getDefaultDatesOfCultivation(
+      fdm,
+      principal_id,
+      b_id_farm,
       b_lu_catalogue,
-      b_lu_name: catalogueItem.b_lu_name,
+      Number(year),
+    )
+
+    return {
+      status: "suggested",
+      suggestion: {
+        b_lu_catalogue,
+        b_lu_name: catalogueItem.b_lu_name,
+        b_lu_start,
+        b_lu_end,
+      },
     }
   } catch (error) {
     console.error(
       `Failed to compute cultivation suggestion for field ${b_id}, year ${year}:`,
       error,
     )
-    return undefined
+    return { status: "unavailable" }
   }
+}
+
+/**
+ * Convenience wrapper around {@link getCultivationSuggestionResult} for call sites that only
+ * care about the suggestion itself (dense table cells) and don't need to distinguish *why*
+ * there is none.
+ */
+export async function getCultivationSuggestion(
+  fdm: FdmType,
+  principal_id: PrincipalId,
+  b_id_farm: string,
+  b_id: string,
+  year: string,
+  nmiApiKey: string | undefined,
+): Promise<CultivationSuggestion | undefined> {
+  const result = await getCultivationSuggestionResult(
+    fdm,
+    principal_id,
+    b_id_farm,
+    b_id,
+    year,
+    nmiApiKey,
+  )
+  return result.status === "suggested" ? result.suggestion : undefined
 }

--- a/fdm-app/app/lib/cultivation-suggestion.server.ts
+++ b/fdm-app/app/lib/cultivation-suggestion.server.ts
@@ -1,0 +1,75 @@
+import type { FdmType, PrincipalId } from "@nmi-agro/fdm-core"
+import { collectInputForSoilParameterEstimates, getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
+import { getCultivationCatalogue } from "@nmi-agro/fdm-data"
+
+export type CultivationSuggestion = {
+  b_lu_catalogue: string
+  b_lu_name: string
+}
+
+/**
+ * Suggests a main cultivation for a field/year based on the NMI Estimates endpoint's
+ * BRP-derived cultivation guess (`cultivations: { year, b_lu_brp }[]`), for use when
+ * `getDefaultCultivation` (the "May 15th" rule) finds no registered cultivation.
+ *
+ * Always resolves to `undefined` rather than throwing — the suggestion is a nice-to-have
+ * enrichment and must never block or break a page:
+ * - No NMI API key configured (self-hosted/OSS instances without a subscription).
+ * - No entry for the requested year in `cultivations` (current year before BRP data is
+ *   published, a future year, or no BRP registration match for this field/location).
+ * - Any failure calling the NMI API or resolving the catalogue entry (logged, not thrown).
+ *
+ * @param fdm - The FDM instance for database interaction.
+ * @param principal_id - The principal making the request.
+ * @param b_id - The field ID to suggest a cultivation for.
+ * @param year - The calendar year (string) to look up an estimate for.
+ * @param nmiApiKey - The NMI API key for authentication, or `undefined` if not configured.
+ */
+export async function getCultivationSuggestion(
+  fdm: FdmType,
+  principal_id: PrincipalId,
+  b_id: string,
+  year: string,
+  nmiApiKey: string | undefined,
+): Promise<CultivationSuggestion | undefined> {
+  if (!nmiApiKey) {
+    return undefined
+  }
+
+  try {
+    const estimatesInput = await collectInputForSoilParameterEstimates(
+      fdm,
+      principal_id,
+      b_id,
+      nmiApiKey,
+    )
+    const [estimates, cultivationCatalogue] = await Promise.all([
+      getSoilParameterEstimates(fdm, estimatesInput),
+      getCultivationCatalogue("brp"),
+    ])
+
+    const estimateForYear = estimates.cultivations.find((c) => c.year === Number(year))
+    if (!estimateForYear) {
+      return undefined
+    }
+
+    const b_lu_catalogue = `nl_${estimateForYear.b_lu_brp}`
+    const catalogueItem = cultivationCatalogue.find(
+      (item) => item.b_lu_catalogue === b_lu_catalogue,
+    )
+    if (!catalogueItem) {
+      return undefined
+    }
+
+    return {
+      b_lu_catalogue,
+      b_lu_name: catalogueItem.b_lu_name,
+    }
+  } catch (error) {
+    console.error(
+      `Failed to compute cultivation suggestion for field ${b_id}, year ${year}:`,
+      error,
+    )
+    return undefined
+  }
+}

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.$centroid.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.atlas.fields.$centroid.tsx
@@ -1,8 +1,8 @@
-import type { Feature, Point } from "geojson"
 import {
   calculateNlvSupplyBySom,
   calculateWaterSupplyBySom,
   getRegion,
+  getSoilParameterEstimates,
   isFieldInGWGBGebied,
   isFieldInNatura2000Gebied,
   isFieldInNVGebied,
@@ -30,10 +30,11 @@ import { SoilTextureCard } from "~/components/blocks/atlas-fields/soil-texture"
 import { ErrorBlock } from "~/components/custom/error"
 import { Button } from "~/components/ui/button"
 import { useAnalytics } from "~/hooks/use-analytics"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey } from "~/integrations/nmi.server"
 import { getCalendar } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
+import { fdm } from "~/lib/fdm.server"
 
 // Meta
 export const meta: MetaFunction = () => {
@@ -149,17 +150,13 @@ async function loadAsyncData(_calendar: string, latitude: number, longitude: num
   try {
     const latestStatusYear = "2026"
     const fieldPromise = getFieldByCentroid(longitude, latitude, latestStatusYear)
-    const field = {
-      type: "Feature",
-      properties: {},
-      geometry: {
-        type: "Point",
-        coordinates: [longitude, latitude],
-      },
-    } as Feature<Point>
     const nmiApiKey = getNmiApiKey()
 
-    const estimatesPromise = getSoilParameterEstimates(field, nmiApiKey)
+    const estimatesPromise = getSoilParameterEstimates(fdm, {
+      a_lat: latitude,
+      a_lon: longitude,
+      nmiApiKey,
+    })
     const cultivationCataloguePromise = getCultivationCatalogue("brp")
 
     const fieldDetailsPromise = Promise.all([

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field-options.ts
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field-options.ts
@@ -1,9 +1,9 @@
 import { getFields } from "@nmi-agro/fdm-core"
 import { data, type LoaderFunctionArgs } from "react-router"
+import { getSession } from "~/lib/auth.server"
 import { getTimeframe } from "~/lib/calendar"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
-import { getSession } from "~/lib/auth.server"
 
 /**
  * Resource route that returns a minimal list of fields for a farm.

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
@@ -6,7 +6,6 @@ import {
   calculateOrganicMatterBalance,
   collectInputForNitrogenBalance,
   collectInputForOrganicMatterBalance,
-  collectInputForSoilParameterEstimates,
   getNutrientAdvice,
   getSoilParameterEstimates,
 } from "@nmi-agro/fdm-calculator"
@@ -303,9 +302,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const hasDefaultCultivation = !!getDefaultCultivation(cultivations, calendar)
     // "not_configured" doubles as "nothing to show" here when a default cultivation already
     // exists — CultivationSuggestionStatusBanner renders null for that status either way.
-    const cultivationSuggestionResult: CultivationSuggestionResult = hasDefaultCultivation
-      ? { status: "not_configured" }
-      : await getCultivationSuggestionResult(
+    // Deferred (not awaited) so a slow/unavailable NMI lookup never blocks the rest of the
+    // field dashboard — consumed via `dashboard.asyncInsights.cultivationSuggestion` and an
+    // <Await> boundary, same as the other NMI-backed tiles (cultivation history, bln, etc.).
+    const cultivationSuggestionPromise: Promise<CultivationSuggestionResult> = hasDefaultCultivation
+      ? Promise.resolve({ status: "not_configured" })
+      : getCultivationSuggestionResult(
           fdm,
           session.principal_id,
           b_id_farm,
@@ -454,14 +456,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
 
       try {
-        const estimatesInput = await collectInputForSoilParameterEstimates(
-          fdm,
-          session.principal_id,
-          b_id,
-          nmiApiKey,
-        )
+        // `field.b_centroid` was already resolved by the `getField` call above — build the
+        // estimates input directly instead of re-fetching the field via
+        // `collectInputForSoilParameterEstimates` (which would call `getField` again).
+        const [a_lon, a_lat] = field.b_centroid
         const [estimates, cultivationCatalogue] = await Promise.all([
-          getSoilParameterEstimates(fdm, estimatesInput),
+          getSoilParameterEstimates(fdm, { a_lat, a_lon, nmiApiKey }),
           getCultivationCatalogue("brp"),
         ])
         const catalogueMap = new Map(
@@ -791,7 +791,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       selectedFieldGeoJson,
       cultivation: {
         active: cultivationSummary,
-        suggestionResult: cultivationSuggestionResult,
       },
       fertilizer: {
         applicationCount: fertilizerApplications.length,
@@ -844,6 +843,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         fertilizer: fertilizerAsyncPromise,
         bln: blnPromise,
         cultivationHistory: cultivationHistoryPromise,
+        cultivationSuggestion: cultivationSuggestionPromise,
         fieldCultivationColors: fieldCultivationColorsPromise,
         nitrogenBalance: nitrogenBalancePromise,
         organicMatterBalance: organicMatterBalancePromise,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
@@ -1,3 +1,4 @@
+import type { Geometry } from "geojson"
 import { NormNotApplicableError } from "@nmi-agro/fdm-calculator"
 import {
   calculateDose,
@@ -27,15 +28,9 @@ import {
 } from "@nmi-agro/fdm-core"
 import { getCultivationCatalogue } from "@nmi-agro/fdm-data"
 import { simplify } from "@turf/simplify"
-import type { Geometry } from "geojson"
 import { useEffect } from "react"
 import { data, type LoaderFunctionArgs, type MetaFunction, useLoaderData } from "react-router"
 import type { CultivationHistory } from "~/components/blocks/atlas-fields/cultivation-history"
-import {
-  buildFieldDashboardRegistry,
-  FIELD_DASHBOARD_SECTIONS,
-} from "~/components/blocks/field-dashboard/registry"
-import { FieldDashboardSectionHeading } from "~/components/blocks/field-dashboard/tile"
 import type {
   AsyncTileResult,
   FieldDashboardBlnSummary,
@@ -47,24 +42,34 @@ import type {
   FieldDashboardNutrientAdviceSummary,
   FieldDashboardOrganicMatterBalanceSummary,
 } from "~/components/blocks/field-dashboard/types"
+import type { CultivationSuggestionResult } from "~/lib/cultivation-suggestion.server"
+import {
+  buildFieldDashboardRegistry,
+  FIELD_DASHBOARD_SECTIONS,
+} from "~/components/blocks/field-dashboard/registry"
+import { FieldDashboardSectionHeading } from "~/components/blocks/field-dashboard/tile"
 import { getHarvestParameterLabel } from "~/components/blocks/harvest/parameters"
-import { getEffectiveHarvestable, getHarvestDateTerm, getHarvestTerm } from "~/components/blocks/harvest/utils"
+import {
+  getEffectiveHarvestable,
+  getHarvestDateTerm,
+  getHarvestTerm,
+} from "~/components/blocks/harvest/utils"
 import { constructSoilDataCards } from "~/components/blocks/soil/cards"
 import { useAnalytics } from "~/hooks/use-analytics"
-import { getSession } from "~/lib/auth.server"
-import { computeBcs } from "~/lib/bcs.server"
-import { isBcsAnalysis } from "~/lib/bcs"
-import { getTimeframe } from "~/lib/calendar"
-import { clientConfig } from "~/lib/config"
-import { getDefaultCultivation } from "~/lib/cultivation-helpers"
-import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
-import { handleLoaderError, reportError } from "~/lib/error"
-import { fdm } from "~/lib/fdm.server"
-import { getFieldAggregationScore } from "~/lib/aggregations"
 import { getIndicatorsForField } from "~/integrations/bln3.server"
 import { getNorms } from "~/integrations/calculator"
 import { getMapStyle } from "~/integrations/map"
 import { getNmiApiKey } from "~/integrations/nmi.server"
+import { getFieldAggregationScore } from "~/lib/aggregations"
+import { getSession } from "~/lib/auth.server"
+import { isBcsAnalysis } from "~/lib/bcs"
+import { computeBcs } from "~/lib/bcs.server"
+import { getTimeframe } from "~/lib/calendar"
+import { clientConfig } from "~/lib/config"
+import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import { getCultivationSuggestionResult } from "~/lib/cultivation-suggestion.server"
+import { handleLoaderError, reportError } from "~/lib/error"
+import { fdm } from "~/lib/fdm.server"
 import { getScoreTier, getScoreVerdict, scoreToDisplay } from "~/lib/indicators"
 import { cn } from "~/lib/utils"
 
@@ -121,7 +126,9 @@ async function computeFieldBalanceResult<TData>(options: {
   isBufferstrip: boolean
   bufferstripMessage: string
   collectInput: () => Promise<unknown>
-  calculate: (input: unknown) => Promise<{ fields: Array<{ b_id: string; errorMessage?: string; balance?: unknown }> }>
+  calculate: (
+    input: unknown,
+  ) => Promise<{ fields: Array<{ b_id: string; errorMessage?: string; balance?: unknown }> }>
   b_id: string
   missingParamsMessage: string
   genericErrorMessage: string
@@ -231,20 +238,20 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       soilAnalyses,
       measures,
     ] = await Promise.all([
-        getField(fdm, session.principal_id, b_id),
-        getFields(fdm, session.principal_id, b_id_farm, timeframe),
-        getCultivations(fdm, session.principal_id, b_id, timeframe),
-        // Fetched without a timeframe to cover the field's full multi-year cultivation history
-        getCultivations(fdm, session.principal_id, b_id),
-        getFertilizerApplications(fdm, session.principal_id, b_id, timeframe),
-        getFertilizers(fdm, session.principal_id, b_id_farm),
-        getCurrentSoilData(fdm, session.principal_id, b_id, timeframe),
-        getSoilAnalyses(fdm, session.principal_id, b_id, {
-          start: null,
-          end: timeframe.end,
-        }),
-        getMeasures(fdm, session.principal_id, b_id, timeframe),
-      ])
+      getField(fdm, session.principal_id, b_id),
+      getFields(fdm, session.principal_id, b_id_farm, timeframe),
+      getCultivations(fdm, session.principal_id, b_id, timeframe),
+      // Fetched without a timeframe to cover the field's full multi-year cultivation history
+      getCultivations(fdm, session.principal_id, b_id),
+      getFertilizerApplications(fdm, session.principal_id, b_id, timeframe),
+      getFertilizers(fdm, session.principal_id, b_id_farm),
+      getCurrentSoilData(fdm, session.principal_id, b_id, timeframe),
+      getSoilAnalyses(fdm, session.principal_id, b_id, {
+        start: null,
+        end: timeframe.end,
+      }),
+      getMeasures(fdm, session.principal_id, b_id, timeframe),
+    ])
 
     if (!field) {
       throw data("Unable to find field", { status: 404, statusText: "Unable to find field" })
@@ -291,17 +298,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     )
     const harvestsByCultivation = Object.fromEntries(harvestEntries)
 
-    const activeCultivation = getDefaultCultivation(cultivations, calendar) ?? cultivations[0] ?? null
+    const activeCultivation =
+      getDefaultCultivation(cultivations, calendar) ?? cultivations[0] ?? null
     const hasDefaultCultivation = !!getDefaultCultivation(cultivations, calendar)
-    const cultivationSuggestion = hasDefaultCultivation
-      ? null
-      : (await getCultivationSuggestion(
+    // "not_configured" doubles as "nothing to show" here when a default cultivation already
+    // exists — CultivationSuggestionStatusBanner renders null for that status either way.
+    const cultivationSuggestionResult: CultivationSuggestionResult = hasDefaultCultivation
+      ? { status: "not_configured" }
+      : await getCultivationSuggestionResult(
           fdm,
           session.principal_id,
+          b_id_farm,
           b_id,
           calendar,
           getNmiApiKey(),
-        )) ?? null
+        )
 
     const cultivationSummary = activeCultivation
       ? {
@@ -320,7 +331,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           harvests: (harvestsByCultivation[activeCultivation.b_lu] ?? [])
             .slice()
             .sort(
-              (a: (typeof harvestsByCultivation)[string][number], b: (typeof harvestsByCultivation)[string][number]) =>
+              (
+                a: (typeof harvestsByCultivation)[string][number],
+                b: (typeof harvestsByCultivation)[string][number],
+              ) =>
                 new Date(b.b_lu_harvest_date ?? 0).getTime() -
                 new Date(a.b_lu_harvest_date ?? 0).getTime(),
             )
@@ -401,9 +415,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       )[0]
 
     const measuredCount = filteredSoilAnalyses.filter(
-      (analysis) => analysis.a_source && analysis.a_source !== "nl-other-nmi" && analysis.a_source !== "other",
+      (analysis) =>
+        analysis.a_source && analysis.a_source !== "nl-other-nmi" && analysis.a_source !== "other",
     ).length
-    const estimatedCount = filteredSoilAnalyses.filter((analysis) => analysis.a_source === "nl-other-nmi").length
+    const estimatedCount = filteredSoilAnalyses.filter(
+      (analysis) => analysis.a_source === "nl-other-nmi",
+    ).length
     const unknownCount = filteredSoilAnalyses.length - measuredCount - estimatedCount
 
     const latestBcsAnalysis = soilAnalyses
@@ -427,9 +444,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       AsyncTileResult<FieldDashboardCultivationHistoryEntry[]>
     > => {
       const nmiApiKey = getNmiApiKey()
-      const fdmHistoryWithSource: FieldDashboardCultivationHistoryEntry[] = fdmCultivationHistory.map(
-        (entry) => ({ ...entry, source: "fdm" }),
-      )
+      const fdmHistoryWithSource: FieldDashboardCultivationHistoryEntry[] =
+        fdmCultivationHistory.map((entry) => ({ ...entry, source: "fdm" }))
 
       if (!nmiApiKey || !field.b_geometry) {
         return fdmHistoryWithSource.length > 0
@@ -511,20 +527,23 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
     })()
 
-
     const fertilizerAsyncPromise = (async (): Promise<FieldDashboardFertilizerAsyncSummary> => {
       const nmiApiKey = getNmiApiKey()
 
       if (!nmiApiKey) {
         return {
-          advice: buildUnavailableResult("Advies is nu niet beschikbaar omdat er geen NMI-koppeling is ingesteld."),
+          advice: buildUnavailableResult(
+            "Advies is nu niet beschikbaar omdat er geen NMI-koppeling is ingesteld.",
+          ),
           norms: buildUnavailableResult(
             "Gebruiksruimte is nu niet beschikbaar omdat de NMI-koppeling voor dit dashboard ontbreekt.",
           ),
         }
       }
 
-      const adviceResult = await (async (): Promise<AsyncTileResult<FieldDashboardNutrientAdviceSummary>> => {
+      const adviceResult = await (async (): Promise<
+        AsyncTileResult<FieldDashboardNutrientAdviceSummary>
+      > => {
         if (!activeCultivation) {
           return buildEmptyResult("Voeg eerst een gewas toe om bemestingsadvies te tonen.")
         }
@@ -616,7 +635,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const blnPromise = (async (): Promise<AsyncTileResult<FieldDashboardBlnSummary>> => {
       const nmiApiKey = getNmiApiKey()
       if (!nmiApiKey) {
-        return buildUnavailableResult("BLN is nu niet beschikbaar omdat de NMI-koppeling ontbreekt.")
+        return buildUnavailableResult(
+          "BLN is nu niet beschikbaar omdat de NMI-koppeling ontbreekt.",
+        )
       }
 
       try {
@@ -652,7 +673,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           { id: "S_CLIM_BLN", label: "Klimaat" },
           { id: "S_PROD_BLN", label: "Productie" },
         ].map(({ id, label }) => {
-          const score01 = getFieldAggregationScore(result.score, id as Parameters<typeof getFieldAggregationScore>[1])
+          const score01 = getFieldAggregationScore(
+            result.score,
+            id as Parameters<typeof getFieldAggregationScore>[1],
+          )
           return {
             id,
             label,
@@ -683,7 +707,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       bufferstripMessage: "Bufferstroken hebben geen stikstofbalans.",
       collectInput: () =>
         collectInputForNitrogenBalance(fdm, session.principal_id, b_id_farm, timeframe, b_id),
-      calculate: (input) => calculateNitrogenBalance(fdm, input as Parameters<typeof calculateNitrogenBalance>[1]),
+      calculate: (input) =>
+        calculateNitrogenBalance(fdm, input as Parameters<typeof calculateNitrogenBalance>[1]),
       b_id,
       missingParamsMessage:
         "Voor dit perceel ontbreken bodemparameters die nodig zijn voor de stikstofbalans.",
@@ -717,7 +742,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         isBufferstrip: !!field.b_bufferstrip,
         bufferstripMessage: "Bufferstroken hebben geen organische stofbalans.",
         collectInput: () =>
-          collectInputForOrganicMatterBalance(fdm, session.principal_id, b_id_farm, timeframe, b_id),
+          collectInputForOrganicMatterBalance(
+            fdm,
+            session.principal_id,
+            b_id_farm,
+            timeframe,
+            b_id,
+          ),
         calculate: (input) => {
           type InputType = Omit<
             Awaited<ReturnType<typeof collectInputForOrganicMatterBalance>>,
@@ -760,7 +791,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       selectedFieldGeoJson,
       cultivation: {
         active: cultivationSummary,
-        suggestion: cultivationSuggestion,
+        suggestionResult: cultivationSuggestionResult,
       },
       fertilizer: {
         applicationCount: fertilizerApplications.length,
@@ -777,7 +808,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             : null,
         applications: fertilizerApplications
           .slice()
-          .sort((a, b) => new Date(b.p_app_date ?? 0).getTime() - new Date(a.p_app_date ?? 0).getTime())
+          .sort(
+            (a, b) => new Date(b.p_app_date ?? 0).getTime() - new Date(a.p_app_date ?? 0).getTime(),
+          )
           .map((application) => ({
             p_app_id: application.p_app_id,
             p_name: application.p_name_nl ?? "Onbekende meststof",

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id._index.tsx
@@ -5,7 +5,9 @@ import {
   calculateOrganicMatterBalance,
   collectInputForNitrogenBalance,
   collectInputForOrganicMatterBalance,
+  collectInputForSoilParameterEstimates,
   getNutrientAdvice,
+  getSoilParameterEstimates,
 } from "@nmi-agro/fdm-calculator"
 import {
   checkPermission,
@@ -55,13 +57,14 @@ import { isBcsAnalysis } from "~/lib/bcs"
 import { getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { handleLoaderError, reportError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { getFieldAggregationScore } from "~/lib/aggregations"
 import { getIndicatorsForField } from "~/integrations/bln3.server"
 import { getNorms } from "~/integrations/calculator"
 import { getMapStyle } from "~/integrations/map"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey } from "~/integrations/nmi.server"
 import { getScoreTier, getScoreVerdict, scoreToDisplay } from "~/lib/indicators"
 import { cn } from "~/lib/utils"
 
@@ -289,6 +292,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const harvestsByCultivation = Object.fromEntries(harvestEntries)
 
     const activeCultivation = getDefaultCultivation(cultivations, calendar) ?? cultivations[0] ?? null
+    const hasDefaultCultivation = !!getDefaultCultivation(cultivations, calendar)
+    const cultivationSuggestion = hasDefaultCultivation
+      ? null
+      : (await getCultivationSuggestion(
+          fdm,
+          session.principal_id,
+          b_id,
+          calendar,
+          getNmiApiKey(),
+        )) ?? null
 
     const cultivationSummary = activeCultivation
       ? {
@@ -425,8 +438,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
 
       try {
+        const estimatesInput = await collectInputForSoilParameterEstimates(
+          fdm,
+          session.principal_id,
+          b_id,
+          nmiApiKey,
+        )
         const [estimates, cultivationCatalogue] = await Promise.all([
-          getSoilParameterEstimates(field.b_geometry, nmiApiKey),
+          getSoilParameterEstimates(fdm, estimatesInput),
           getCultivationCatalogue("brp"),
         ])
         const catalogueMap = new Map(
@@ -741,6 +760,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       selectedFieldGeoJson,
       cultivation: {
         active: cultivationSummary,
+        suggestion: cultivationSuggestion,
       },
       fertilizer: {
         applicationCount: fertilizerApplications.length,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
@@ -27,6 +27,13 @@ import { handleActionError, handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { extractFormValuesFromRequest } from "~/lib/form"
 
+/** Parses a date string, returning `undefined` for missing or unparsable input rather than an Invalid Date. */
+function parseValidDate(value: string | null): Date | undefined {
+  if (!value) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
 // Meta
 export const meta: MetaFunction = () => {
   return [
@@ -164,22 +171,24 @@ export default function FarmFieldsOverviewBlock() {
 
   // Pre-fill (and auto-open) the add-cultivation dialog when a suggestion was accepted
   // elsewhere in the app (dashboard, field list, field detail, nutrient advice overview).
+  // Query params are untrusted input: parse defensively and drop the whole suggestion rather
+  // than seed the form with an Invalid Date if either date fails to parse.
   const suggestedCatalogue = searchParams.get("suggest_b_lu_catalogue")
-  const suggestedStart = searchParams.get("suggest_start")
-  const suggestedEnd = searchParams.get("suggest_end")
+  const suggestedStart = parseValidDate(searchParams.get("suggest_start"))
+  const suggestedEnd = parseValidDate(searchParams.get("suggest_end"))
   const defaultValues =
     suggestedCatalogue && suggestedStart
       ? {
           b_lu_catalogue: suggestedCatalogue,
-          b_lu_start: new Date(suggestedStart),
-          b_lu_end: suggestedEnd ? new Date(suggestedEnd) : undefined,
+          b_lu_start: suggestedStart,
+          b_lu_end: suggestedEnd,
         }
       : undefined
 
   // Strip the suggestion query params once the dialog is closed (submitted or dismissed) so
   // navigating back, refreshing, or sharing this URL doesn't keep reopening it.
   const clearSuggestionParams = () => {
-    if (!suggestedCatalogue && !suggestedStart && !suggestedEnd) return
+    if (!searchParams.has("suggest_b_lu_catalogue") && !searchParams.has("suggest_start")) return
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev)

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
@@ -148,7 +148,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
  */
 export default function FarmFieldsOverviewBlock() {
   const loaderData = useLoaderData<typeof loader>()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   if ("warning" in loaderData) {
     return (
@@ -166,10 +166,31 @@ export default function FarmFieldsOverviewBlock() {
   // elsewhere in the app (dashboard, field list, field detail, nutrient advice overview).
   const suggestedCatalogue = searchParams.get("suggest_b_lu_catalogue")
   const suggestedStart = searchParams.get("suggest_start")
+  const suggestedEnd = searchParams.get("suggest_end")
   const defaultValues =
     suggestedCatalogue && suggestedStart
-      ? { b_lu_catalogue: suggestedCatalogue, b_lu_start: new Date(suggestedStart) }
+      ? {
+          b_lu_catalogue: suggestedCatalogue,
+          b_lu_start: new Date(suggestedStart),
+          b_lu_end: suggestedEnd ? new Date(suggestedEnd) : undefined,
+        }
       : undefined
+
+  // Strip the suggestion query params once the dialog is closed (submitted or dismissed) so
+  // navigating back, refreshing, or sharing this URL doesn't keep reopening it.
+  const clearSuggestionParams = () => {
+    if (!suggestedCatalogue && !suggestedStart && !suggestedEnd) return
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete("suggest_b_lu_catalogue")
+        next.delete("suggest_start")
+        next.delete("suggest_end")
+        return next
+      },
+      { replace: true },
+    )
+  }
 
   return (
     <div className="space-y-6">
@@ -180,6 +201,7 @@ export default function FarmFieldsOverviewBlock() {
           harvests={loaderData.harvests}
           editable={loaderData.fieldWritePermission}
           defaultValues={defaultValues}
+          onSuggestionDialogClose={clearSuggestionParams}
         />
         <Outlet />
       </div>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.cultivation.tsx
@@ -14,6 +14,7 @@ import {
   type MetaFunction,
   Outlet,
   useLoaderData,
+  useSearchParams,
 } from "react-router"
 import { dataWithSuccess } from "remix-toast"
 import { CultivationListCard } from "~/components/blocks/cultivation/card-list"
@@ -147,6 +148,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
  */
 export default function FarmFieldsOverviewBlock() {
   const loaderData = useLoaderData<typeof loader>()
+  const [searchParams] = useSearchParams()
 
   if ("warning" in loaderData) {
     return (
@@ -160,6 +162,15 @@ export default function FarmFieldsOverviewBlock() {
     )
   }
 
+  // Pre-fill (and auto-open) the add-cultivation dialog when a suggestion was accepted
+  // elsewhere in the app (dashboard, field list, field detail, nutrient advice overview).
+  const suggestedCatalogue = searchParams.get("suggest_b_lu_catalogue")
+  const suggestedStart = searchParams.get("suggest_start")
+  const defaultValues =
+    suggestedCatalogue && suggestedStart
+      ? { b_lu_catalogue: suggestedCatalogue, b_lu_start: new Date(suggestedStart) }
+      : undefined
+
   return (
     <div className="space-y-6">
       <div className="grid gap-4 2xl:grid-cols-2">
@@ -168,6 +179,7 @@ export default function FarmFieldsOverviewBlock() {
           cultivations={loaderData.cultivations}
           harvests={loaderData.harvests}
           editable={loaderData.fieldWritePermission}
+          defaultValues={defaultValues}
         />
         <Outlet />
       </div>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.$b_id.tsx
@@ -189,7 +189,9 @@ export default function FarmFieldIndex() {
         <FarmTitle
           title={loaderData.field?.b_name}
           description={
-            isDashboardRoute ? "Overzicht van dit perceel" : "Beheer hier de gegevens van dit perceel"
+            isDashboardRoute
+              ? "Overzicht van dit perceel"
+              : "Beheer hier de gegevens van dit perceel"
           }
         />
         <FarmContent>

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.new._index.tsx
@@ -47,7 +47,7 @@ import { Separator } from "~/components/ui/separator"
 import { SidebarInset } from "~/components/ui/sidebar"
 import { Skeleton } from "~/components/ui/skeleton"
 import { getMapStyle } from "~/integrations/map"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey, getSoilParameterEstimatesForGeometry } from "~/integrations/nmi.server"
 import { captureEvent } from "~/lib/analytics.server"
 import { getSession } from "~/lib/auth.server"
 import { getCalendar, getTimeframe } from "~/lib/calendar"
@@ -498,7 +498,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           )
 
           if (nmiApiKey) {
-            const estimates = await getSoilParameterEstimates(field, nmiApiKey)
+            const estimates = await getSoilParameterEstimatesForGeometry(fdm, field, nmiApiKey)
 
             await addSoilAnalysis(
               fdm,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
@@ -29,11 +29,14 @@ import { HeaderFarm } from "~/components/blocks/header/farm"
 import { BreadcrumbItem, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import { Button } from "~/components/ui/button"
 import { SidebarInset } from "~/components/ui/sidebar"
+import { getNmiApiKey } from "~/integrations/nmi.server"
 import { getSession } from "~/lib/auth.server"
 import { isBcsAnalysis } from "~/lib/bcs"
 import { computeBcs } from "~/lib/bcs.server"
 import { getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
+import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { handleActionError, handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { cn } from "~/lib/utils"
@@ -82,6 +85,7 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
         return {
           shouldShowLayout: false,
           b_id_farm: params.b_id_farm,
+          calendar: params.calendar,
           farmOptions: [],
           fieldOptions: [],
           fieldsExtended: [],
@@ -140,9 +144,22 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
 
     const fertilizers = await getFertilizers(fdm, session.principal_id, b_id_farm)
 
+    const calendar = params.calendar ?? new Date().getFullYear().toString()
+    const nmiApiKey = getNmiApiKey()
+
     const fieldsExtended = await Promise.all(
       fields.map(async (field) => {
         const cultivations = await getCultivations(fdm, session.principal_id, field.b_id, timeframe)
+
+        const cultivationSuggestion = getDefaultCultivation(cultivations, calendar)
+          ? undefined
+          : await getCultivationSuggestion(
+              fdm,
+              session.principal_id,
+              field.b_id,
+              calendar,
+              nmiApiKey,
+            )
 
         const fertilizerApplications = await getFertilizerApplications(
           fdm,
@@ -215,6 +232,7 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
           b_id: field.b_id,
           b_name: field.b_name,
           cultivations: cultivations,
+          cultivationSuggestion,
           fertilizers: fertilizersFiltered,
           a_som_loi: a_som_loi,
           b_soiltype_agr: b_soiltype_agr,
@@ -240,6 +258,7 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
     return {
       shouldShowLayout: true,
       b_id_farm: b_id_farm,
+      calendar,
       farmOptions: farmOptions,
       fieldOptions: fieldOptions,
       fieldsExtended: fieldsExtended,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
@@ -156,6 +156,7 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
           : await getCultivationSuggestion(
               fdm,
               session.principal_id,
+              b_id_farm,
               field.b_id,
               calendar,
               nmiApiKey,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.field.tsx
@@ -9,6 +9,7 @@ import {
   getSoilAnalyses,
   updateField,
 } from "@nmi-agro/fdm-core"
+import { useMemo } from "react"
 import {
   type ActionFunctionArgs,
   data,
@@ -22,7 +23,7 @@ import {
 import { dataWithSuccess } from "remix-toast"
 import { FarmContent } from "~/components/blocks/farm/farm-content"
 import { FarmTitle } from "~/components/blocks/farm/farm-title"
-import { columns, type FieldExtended } from "~/components/blocks/fields/columns"
+import { buildColumns, type FieldExtended } from "~/components/blocks/fields/columns"
 import { DataTable } from "~/components/blocks/fields/table"
 import { Header } from "~/components/blocks/header/base"
 import { HeaderFarm } from "~/components/blocks/header/farm"
@@ -41,6 +42,20 @@ import { handleActionError, handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { cn } from "~/lib/utils"
 import { useFieldFilterStore } from "~/store/field-filter"
+
+// Cap on simultaneous cultivation-suggestion lookups per farm, so farms with many fields
+// missing a main cultivation don't overload the external NMI API with unbounded parallel
+// requests (same concurrency-limiting approach as the nutrient advice overview loader).
+const CULTIVATION_SUGGESTION_CONCURRENCY = 4
+
+/** Splits an array into consecutive chunks of at most `size` items each. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
 
 export const meta: MetaFunction = () => {
   return [
@@ -151,17 +166,6 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
       fields.map(async (field) => {
         const cultivations = await getCultivations(fdm, session.principal_id, field.b_id, timeframe)
 
-        const cultivationSuggestion = getDefaultCultivation(cultivations, calendar)
-          ? undefined
-          : await getCultivationSuggestion(
-              fdm,
-              session.principal_id,
-              b_id_farm,
-              field.b_id,
-              calendar,
-              nmiApiKey,
-            )
-
         const fertilizerApplications = await getFertilizerApplications(
           fdm,
           session.principal_id,
@@ -233,7 +237,7 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
           b_id: field.b_id,
           b_name: field.b_name,
           cultivations: cultivations,
-          cultivationSuggestion,
+          cultivationSuggestion: undefined as Awaited<ReturnType<typeof getCultivationSuggestion>>,
           fertilizers: fertilizersFiltered,
           a_som_loi: a_som_loi,
           b_soiltype_agr: b_soiltype_agr,
@@ -244,6 +248,28 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
         }
       }),
     )
+
+    // Look up NMI-estimate-based cultivation suggestions for fields missing a default
+    // cultivation, in small concurrency-limited batches so a farm with many affected fields
+    // doesn't fire unbounded parallel requests at the external NMI API (same approach as the
+    // farm dashboard and nutrient advice overview loaders).
+    const fieldsMissingCultivation = fieldsExtended.filter(
+      (field) => !getDefaultCultivation(field.cultivations, calendar),
+    )
+    for (const fieldsChunk of chunk(fieldsMissingCultivation, CULTIVATION_SUGGESTION_CONCURRENCY)) {
+      await Promise.all(
+        fieldsChunk.map(async (field) => {
+          field.cultivationSuggestion = await getCultivationSuggestion(
+            fdm,
+            session.principal_id,
+            b_id_farm,
+            field.b_id,
+            calendar,
+            nmiApiKey,
+          )
+        }),
+      )
+    }
 
     const farmWritePermission = await checkPermission(
       fdm,
@@ -285,6 +311,11 @@ export async function loader({ request, params, url }: LoaderFunctionArgs) {
 export default function FarmFieldIndex() {
   const loaderData = useLoaderData<typeof loader>()
   const { showProductiveOnly } = useFieldFilterStore()
+
+  const columns = useMemo(
+    () => buildColumns(loaderData.b_id_farm, loaderData.calendar ?? ""),
+    [loaderData.b_id_farm, loaderData.calendar],
+  )
 
   const filteredFields = loaderData.fieldsExtended.filter((field) => {
     if (!showProductiveOnly) {

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.indicators.$b_id.tsx
@@ -196,32 +196,39 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     // Load in parallel: current field, all fields, BLN3 score + inputs, active measures, cultivations, BRP catalogue
     // Cultivations are fetched without timeframe to cover multi-year history (for display)
-    const [field, fields, bln3Result, fieldMeasures, cultivations, brpCatalogue, fieldWritePermission] =
-      await Promise.all([
-        getField(fdm, session.principal_id, b_id),
-        getFields(fdm, session.principal_id, b_id_farm, timeframe),
-        getIndicatorsForField({
-          principal_id: session.principal_id,
-          b_id,
-          timeframe,
-        }),
-        getFieldMeasuresForIndicators({
-          principal_id: session.principal_id,
-          b_id,
-          timeframe,
-        }),
-        getCultivations(fdm, session.principal_id, b_id),
-        getCultivationCatalogue("brp"),
-        checkPermission(
-          fdm,
-          "field",
-          "write",
-          b_id,
-          session.principal_id,
-          "routes/farm.$b_id_farm.$calendar.indicators.$b_id",
-          false,
-        ),
-      ])
+    const [
+      field,
+      fields,
+      bln3Result,
+      fieldMeasures,
+      cultivations,
+      brpCatalogue,
+      fieldWritePermission,
+    ] = await Promise.all([
+      getField(fdm, session.principal_id, b_id),
+      getFields(fdm, session.principal_id, b_id_farm, timeframe),
+      getIndicatorsForField({
+        principal_id: session.principal_id,
+        b_id,
+        timeframe,
+      }),
+      getFieldMeasuresForIndicators({
+        principal_id: session.principal_id,
+        b_id,
+        timeframe,
+      }),
+      getCultivations(fdm, session.principal_id, b_id),
+      getCultivationCatalogue("brp"),
+      checkPermission(
+        fdm,
+        "field",
+        "write",
+        b_id,
+        session.principal_id,
+        "routes/farm.$b_id_farm.$calendar.indicators.$b_id",
+        false,
+      ),
+    ])
     const fieldScore = bln3Result.score
     const bln3Inputs = bln3Result.inputs
 

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.nutrient_advice._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.nutrient_advice._index.tsx
@@ -29,6 +29,7 @@ import { getSession } from "~/lib/auth.server"
 import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
 import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { cn } from "~/lib/utils"
@@ -151,10 +152,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
               }
             }
 
+            const hasDefaultCultivation = !!getDefaultCultivation(cultivations, calendar)
             const activeCultivation =
               getDefaultCultivation(cultivations, calendar) ?? cultivations[0]
             const fertilizerApplications = fertilizerApplicationsByField.get(field.b_id) ?? []
             const currentSoilData = soilDataByField.get(field.b_id) ?? []
+
+            const cultivationSuggestion = hasDefaultCultivation
+              ? undefined
+              : await getCultivationSuggestion(
+                  fdm,
+                  session.principal_id,
+                  field.b_id,
+                  calendar,
+                  nmiApiKey,
+                )
 
             const mainCultivation = {
               b_lu: activeCultivation.b_lu,
@@ -187,6 +199,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 b_name: field.b_name,
                 b_area,
                 mainCultivation,
+                cultivationSuggestion,
                 values,
               }
             } catch (error) {
@@ -195,6 +208,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 b_name: field.b_name,
                 b_area,
                 mainCultivation,
+                cultivationSuggestion,
                 errorMessage: toFriendlyAdviceError(error),
                 values: {},
               }
@@ -299,5 +313,12 @@ function NutrientAdviceOverview({
   loaderData: Awaited<ReturnType<typeof loader>>
 }) {
   const { rows } = use(loaderData.asyncData)
-  return <NutrientAdviceOverviewTable data={rows} nutrients={loaderData.nutrientsDescription} />
+  return (
+    <NutrientAdviceOverviewTable
+      data={rows}
+      nutrients={loaderData.nutrientsDescription}
+      b_id_farm={loaderData.b_id_farm}
+      calendar={loaderData.calendar}
+    />
+  )
 }

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.nutrient_advice._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.nutrient_advice._index.tsx
@@ -163,6 +163,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
               : await getCultivationSuggestion(
                   fdm,
                   session.principal_id,
+                  b_id_farm,
                   field.b_id,
                   calendar,
                   nmiApiKey,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
@@ -541,7 +541,11 @@ export async function action({ request, params, url }: Route.ActionArgs) {
         const nmiApiKey = getNmiApiKey()
         if (nmiApiKey) {
           try {
-            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(
+              fdm,
+              geometry,
+              nmiApiKey,
+            )
             await addSoilAnalysis(
               tx,
               session.principal_id,

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.rvo.tsx
@@ -49,7 +49,7 @@ import {
   DialogTrigger,
 } from "~/components/ui/dialog"
 import { SidebarInset } from "~/components/ui/sidebar"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey, getSoilParameterEstimatesForGeometry } from "~/integrations/nmi.server"
 import {
   createConfiguredRvoClient,
   createRvoState,
@@ -541,7 +541,7 @@ export async function action({ request, params, url }: Route.ActionArgs) {
         const nmiApiKey = getNmiApiKey()
         if (nmiApiKey) {
           try {
-            const soilEstimates = await getSoilParameterEstimates(geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
             await addSoilAnalysis(
               tx,
               session.principal_id,

--- a/fdm-app/app/routes/farm.$b_id_farm._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm._index.tsx
@@ -38,11 +38,11 @@ import {
   useLoaderData,
 } from "react-router"
 import { toast } from "sonner"
+import { CultivationSuggestionStatusBanner } from "~/components/blocks/cultivation/suggestion"
 import { FarmContent } from "~/components/blocks/farm/farm-content"
 import { FarmTitle } from "~/components/blocks/farm/farm-title"
 import { Header } from "~/components/blocks/header/base"
 import { HeaderFarm } from "~/components/blocks/header/farm"
-import { CultivationSuggestionBanner } from "~/components/blocks/cultivation/suggestion"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
 import {
@@ -59,8 +59,8 @@ import { getRvoCredentials } from "~/integrations/rvo.server"
 import { getSession } from "~/lib/auth.server"
 import { getCalendarSelection } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
-import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { getDefaultCultivation } from "~/lib/cultivation-helpers"
+import { getCultivationSuggestionResult } from "~/lib/cultivation-suggestion.server"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
 import { cn } from "~/lib/utils"
@@ -132,13 +132,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const nmiApiKey = getNmiApiKey()
     const fieldsMissingCultivationDetails = await Promise.all(
       fields
-        .filter((field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear))
+        .filter(
+          (field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear),
+        )
         .map(async (field) => ({
           b_id: field.b_id,
           b_name: field.b_name,
-          suggestion: await getCultivationSuggestion(
+          result: await getCultivationSuggestionResult(
             fdm,
             session.principal_id,
+            b_id_farm,
             field.b_id,
             activeYear,
             nmiApiKey,
@@ -575,26 +578,25 @@ export default function FarmDashboardIndex() {
                         </button>
                         {showMissingCultivationDetails && (
                           <div className="space-y-2 border-t p-3">
-                            {loaderData.fieldsMissingCultivationDetails.map((field) =>
-                              field.suggestion ? (
-                                <CultivationSuggestionBanner
-                                  key={field.b_id}
+                            {loaderData.fieldsMissingCultivationDetails.map((field) => (
+                              <div key={field.b_id} className="space-y-1">
+                                <CultivationSuggestionStatusBanner
                                   b_id_farm={loaderData.b_id_farm}
                                   calendar={loaderData.cultivationYear}
                                   b_id={field.b_id}
                                   b_name={field.b_name}
-                                  suggestion={field.suggestion}
+                                  result={field.result}
                                 />
-                              ) : (
-                                <NavLink
-                                  key={field.b_id}
-                                  to={`${loaderData.cultivationYear}/field/${field.b_id}/cultivation`}
-                                  className="text-muted-foreground hover:text-foreground block text-sm underline"
-                                >
-                                  {field.b_name}: hoofdteelt toevoegen
-                                </NavLink>
-                              ),
-                            )}
+                                {field.result.status !== "suggested" && (
+                                  <NavLink
+                                    to={`${loaderData.cultivationYear}/field/${field.b_id}/cultivation`}
+                                    className="text-muted-foreground hover:text-foreground block text-sm underline"
+                                  >
+                                    {field.b_name}: hoofdteelt handmatig toevoegen
+                                  </NavLink>
+                                )}
+                              </div>
+                            ))}
                           </div>
                         )}
                       </div>

--- a/fdm-app/app/routes/farm.$b_id_farm._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm._index.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   ArrowRightLeft,
   BookOpenText,
+  ChevronDown,
   ChevronUp,
   CloudDownload,
   CloudUpload,
@@ -41,6 +42,7 @@ import { FarmContent } from "~/components/blocks/farm/farm-content"
 import { FarmTitle } from "~/components/blocks/farm/farm-title"
 import { Header } from "~/components/blocks/header/base"
 import { HeaderFarm } from "~/components/blocks/header/farm"
+import { CultivationSuggestionBanner } from "~/components/blocks/cultivation/suggestion"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card"
 import {
@@ -52,10 +54,12 @@ import {
 } from "~/components/ui/select"
 import { Separator } from "~/components/ui/separator"
 import { SidebarInset } from "~/components/ui/sidebar"
+import { getNmiApiKey } from "~/integrations/nmi.server"
 import { getRvoCredentials } from "~/integrations/rvo.server"
 import { getSession } from "~/lib/auth.server"
 import { getCalendarSelection } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
+import { getCultivationSuggestion } from "~/lib/cultivation-suggestion.server"
 import { getDefaultCultivation } from "~/lib/cultivation-helpers"
 import { handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
@@ -122,6 +126,26 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       (field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear),
     ).length
 
+    // For fields missing a main cultivation, look up an NMI-estimate-based suggestion (BRP guess)
+    // so the user can accept it instead of searching for the crop from scratch. Silently omitted
+    // (never blocks the dashboard) when no NMI API key is configured or no estimate is available.
+    const nmiApiKey = getNmiApiKey()
+    const fieldsMissingCultivationDetails = await Promise.all(
+      fields
+        .filter((field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear))
+        .map(async (field) => ({
+          b_id: field.b_id,
+          b_name: field.b_name,
+          suggestion: await getCultivationSuggestion(
+            fdm,
+            session.principal_id,
+            field.b_id,
+            activeYear,
+            nmiApiKey,
+          ),
+        })),
+    )
+
     // Get a list of possible farms of the user
     const farms = await getFarms(fdm, session.principal_id)
     const farmOptions = farms.map((farm) => {
@@ -154,6 +178,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       fieldsNumber: fields.length,
       farmArea: Math.round(farmArea),
       fieldsMissingCultivation,
+      fieldsMissingCultivationDetails,
       cultivationYear: activeYear,
       farmOptions: farmOptions,
       roles: roles,
@@ -219,6 +244,7 @@ export default function FarmDashboardIndex() {
   const setCalendar = useCalendarStore((state) => state.setCalendar)
   const years = getCalendarSelection()
   const [isGeneratingPdf, setIsGeneratingPdf] = useState(false)
+  const [showMissingCultivationDetails, setShowMissingCultivationDetails] = useState(false)
 
   const handleDownloadPdf = async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -517,21 +543,61 @@ export default function FarmDashboardIndex() {
                       </div>
                     </div>
                     {loaderData.fieldsMissingCultivation > 0 && (
-                      <NavLink
-                        to={`${loaderData.cultivationYear}/field`}
-                        className="border-destructive/30 bg-destructive/5 hover:bg-destructive/10 flex items-start gap-2 rounded-lg border p-3 transition-colors"
-                      >
-                        <AlertTriangle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
-                        <p className="text-sm">
-                          <span className="font-medium">
-                            {loaderData.fieldsMissingCultivation}{" "}
-                            {loaderData.fieldsMissingCultivation === 1
-                              ? "perceel mist"
-                              : "percelen missen"}
-                          </span>{" "}
-                          een hoofdteelt voor dit jaar. Bekijk de percelen om dit aan te vullen.
-                        </p>
-                      </NavLink>
+                      <div className="border-destructive/30 bg-destructive/5 rounded-lg border">
+                        <button
+                          type="button"
+                          onClick={() => setShowMissingCultivationDetails((prev) => !prev)}
+                          className="hover:bg-destructive/10 flex w-full items-start gap-2 rounded-lg p-3 text-left transition-colors"
+                        >
+                          <AlertTriangle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+                          <p className="flex-1 text-sm">
+                            <span className="font-medium">
+                              {loaderData.fieldsMissingCultivation}{" "}
+                              {loaderData.fieldsMissingCultivation === 1
+                                ? "perceel mist"
+                                : "percelen missen"}
+                            </span>{" "}
+                            een hoofdteelt voor dit jaar.{" "}
+                            <NavLink
+                              to={`${loaderData.cultivationYear}/field`}
+                              className="underline"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              Bekijk de percelen
+                            </NavLink>{" "}
+                            om dit aan te vullen.
+                          </p>
+                          {showMissingCultivationDetails ? (
+                            <ChevronUp className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+                          ) : (
+                            <ChevronDown className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+                          )}
+                        </button>
+                        {showMissingCultivationDetails && (
+                          <div className="space-y-2 border-t p-3">
+                            {loaderData.fieldsMissingCultivationDetails.map((field) =>
+                              field.suggestion ? (
+                                <CultivationSuggestionBanner
+                                  key={field.b_id}
+                                  b_id_farm={loaderData.b_id_farm}
+                                  calendar={loaderData.cultivationYear}
+                                  b_id={field.b_id}
+                                  b_name={field.b_name}
+                                  suggestion={field.suggestion}
+                                />
+                              ) : (
+                                <NavLink
+                                  key={field.b_id}
+                                  to={`${loaderData.cultivationYear}/field/${field.b_id}/cultivation`}
+                                  className="text-muted-foreground hover:text-foreground block text-sm underline"
+                                >
+                                  {field.b_name}: hoofdteelt toevoegen
+                                </NavLink>
+                              ),
+                            )}
+                          </div>
+                        )}
+                      </div>
                     )}
                     <Separator />
                     {/* Role + Year */}

--- a/fdm-app/app/routes/farm.$b_id_farm._index.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm._index.tsx
@@ -66,6 +66,20 @@ import { fdm } from "~/lib/fdm.server"
 import { cn } from "~/lib/utils"
 import { useCalendarStore } from "~/store/calendar"
 
+// Cap on simultaneous cultivation-suggestion lookups per farm, so farms with many fields
+// missing a main cultivation don't overload the external NMI API with unbounded parallel
+// requests (same concurrency-limiting approach as the nutrient advice overview loader).
+const CULTIVATION_SUGGESTION_CONCURRENCY = 4
+
+/** Splits an array into consecutive chunks of at most `size` items each. */
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
 // Meta
 export const meta: MetaFunction = () => {
   return [
@@ -124,18 +138,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     })
     const fieldsMissingCultivation = fields.filter(
       (field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear),
-    ).length
+    )
 
     // For fields missing a main cultivation, look up an NMI-estimate-based suggestion (BRP guess)
     // so the user can accept it instead of searching for the crop from scratch. Silently omitted
     // (never blocks the dashboard) when no NMI API key is configured or no estimate is available.
+    // Looked up in small concurrency-limited batches so a farm with many affected fields doesn't
+    // fire unbounded parallel requests at the external NMI API.
     const nmiApiKey = getNmiApiKey()
-    const fieldsMissingCultivationDetails = await Promise.all(
-      fields
-        .filter(
-          (field) => !getDefaultCultivation(cultivationsByField.get(field.b_id) ?? [], activeYear),
-        )
-        .map(async (field) => ({
+    const fieldsMissingCultivationDetails: {
+      b_id: string
+      b_name: string
+      result: Awaited<ReturnType<typeof getCultivationSuggestionResult>>
+    }[] = []
+    for (const fieldsChunk of chunk(fieldsMissingCultivation, CULTIVATION_SUGGESTION_CONCURRENCY)) {
+      const chunkResults = await Promise.all(
+        fieldsChunk.map(async (field) => ({
           b_id: field.b_id,
           b_name: field.b_name,
           result: await getCultivationSuggestionResult(
@@ -147,7 +165,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             nmiApiKey,
           ),
         })),
-    )
+      )
+      fieldsMissingCultivationDetails.push(...chunkResults)
+    }
 
     // Get a list of possible farms of the user
     const farms = await getFarms(fdm, session.principal_id)
@@ -180,7 +200,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       b_name_farm: farm.b_name_farm,
       fieldsNumber: fields.length,
       farmArea: Math.round(farmArea),
-      fieldsMissingCultivation,
+      fieldsMissingCultivation: fieldsMissingCultivation.length,
       fieldsMissingCultivationDetails,
       cultivationYear: activeYear,
       farmOptions: farmOptions,
@@ -550,7 +570,7 @@ export default function FarmDashboardIndex() {
                         <button
                           type="button"
                           onClick={() => setShowMissingCultivationDetails((prev) => !prev)}
-                          className="hover:bg-destructive/10 flex w-full items-start gap-2 rounded-lg p-3 text-left transition-colors"
+                          className="hover:bg-destructive/10 flex w-full items-start gap-2 rounded-t-lg p-3 text-left transition-colors"
                         >
                           <AlertTriangle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
                           <p className="flex-1 text-sm">
@@ -560,15 +580,7 @@ export default function FarmDashboardIndex() {
                                 ? "perceel mist"
                                 : "percelen missen"}
                             </span>{" "}
-                            een hoofdteelt voor dit jaar.{" "}
-                            <NavLink
-                              to={`${loaderData.cultivationYear}/field`}
-                              className="underline"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              Bekijk de percelen
-                            </NavLink>{" "}
-                            om dit aan te vullen.
+                            een hoofdteelt voor dit jaar.
                           </p>
                           {showMissingCultivationDetails ? (
                             <ChevronUp className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
@@ -576,6 +588,12 @@ export default function FarmDashboardIndex() {
                             <ChevronDown className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
                           )}
                         </button>
+                        <NavLink
+                          to={`${loaderData.cultivationYear}/field`}
+                          className="text-muted-foreground hover:text-foreground block px-3 pb-3 text-sm underline"
+                        >
+                          Bekijk de percelen om dit aan te vullen
+                        </NavLink>
                         {showMissingCultivationDetails && (
                           <div className="space-y-2 border-t p-3">
                             {loaderData.fieldsMissingCultivationDetails.map((field) => (

--- a/fdm-app/app/routes/farm._index.tsx
+++ b/fdm-app/app/routes/farm._index.tsx
@@ -4,16 +4,7 @@ import {
   getFarms,
   listPendingInvitationsForUser,
 } from "@nmi-agro/fdm-core"
-import {
-  ArrowRight,
-  Check,
-  House,
-  Layers,
-  LifeBuoy,
-  MapIcon,
-  Mountain,
-  Plus,
-} from "lucide-react"
+import { ArrowRight, Check, House, Layers, LifeBuoy, MapIcon, Mountain, Plus } from "lucide-react"
 import { useMemo } from "react"
 import {
   type ActionFunctionArgs,
@@ -338,21 +329,30 @@ export default function AppIndex() {
                     <CardContent className="text-muted-foreground grow text-left text-sm">
                       <ul className="space-y-3">
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Balansen:</b> Uw bodemgezondheid zichtbaar via stikstof- en
                             organische stofbalansen.
                           </span>
                         </li>
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Bemestingsadvies:</b> Adviezen afgestemd op uw bodemanalyse en
                             gewassen.
                           </span>
                         </li>
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Gebruiksruimte:</b> Stikstof, dierlijke mest en fosfaat altijd
                             inzichtelijk.
@@ -386,28 +386,37 @@ export default function AppIndex() {
                       </div>
                       <CardTitle className="text-left text-2xl">Atlas verkennen</CardTitle>
                       <CardDescription className="text-left text-base">
-                        Verken openbare kaartdata over percelen, bodem en hoogte in Nederland —
-                        geen bedrijf nodig.
+                        Verken openbare kaartdata over percelen, bodem en hoogte in Nederland — geen
+                        bedrijf nodig.
                       </CardDescription>
                     </CardHeader>
                     <CardContent className="text-muted-foreground grow text-left text-sm">
                       <ul className="space-y-3">
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Percelen:</b> Gewashistorie en ruimtelijke kenmerken van alle
                             percelen in Nederland.
                           </span>
                         </li>
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Hoogtekaart:</b> AHN4-data voor inzicht in het microreliëf van uw
                             percelen.
                           </span>
                         </li>
                         <li className="flex items-start gap-3">
-                          <Check className="text-primary mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+                          <Check
+                            className="text-primary mt-1 h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
                           <span>
                             <b>Bodemkaart:</b> Bodemtype en grondwatertrappen op perceel niveau.
                           </span>

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.atlas.tsx
@@ -44,7 +44,7 @@ import { Separator } from "~/components/ui/separator"
 import { SidebarInset } from "~/components/ui/sidebar"
 import { Skeleton } from "~/components/ui/skeleton"
 import { getMapStyle } from "~/integrations/map"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey, getSoilParameterEstimatesForGeometry } from "~/integrations/nmi.server"
 import { getSession } from "~/lib/auth.server"
 import { getCalendar, getTimeframe } from "~/lib/calendar"
 import { clientConfig } from "~/lib/config"
@@ -454,7 +454,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
           )
 
           if (nmiApiKey) {
-            const estimates = await getSoilParameterEstimates(field, nmiApiKey)
+            const estimates = await getSoilParameterEstimatesForGeometry(fdm, field, nmiApiKey)
 
             await addSoilAnalysis(
               fdm,

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
@@ -427,7 +427,11 @@ export async function action({ request, params, url }: ActionFunctionArgs) {
         const nmiApiKey = getNmiApiKey()
         if (nmiApiKey) {
           try {
-            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(
+              fdm,
+              geometry,
+              nmiApiKey,
+            )
             await addSoilAnalysis(
               tx,
               session.principal_id,

--- a/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
+++ b/fdm-app/app/routes/farm.create.$b_id_farm.$calendar.rvo.tsx
@@ -38,7 +38,7 @@ import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert"
 import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from "~/components/ui/breadcrumb"
 import { Button } from "~/components/ui/button"
 import { SidebarInset } from "~/components/ui/sidebar"
-import { getNmiApiKey, getSoilParameterEstimates } from "~/integrations/nmi.server"
+import { getNmiApiKey, getSoilParameterEstimatesForGeometry } from "~/integrations/nmi.server"
 import {
   createConfiguredRvoClient,
   createRvoState,
@@ -427,7 +427,7 @@ export async function action({ request, params, url }: ActionFunctionArgs) {
         const nmiApiKey = getNmiApiKey()
         if (nmiApiKey) {
           try {
-            const soilEstimates = await getSoilParameterEstimates(geometry, nmiApiKey)
+            const soilEstimates = await getSoilParameterEstimatesForGeometry(fdm, geometry, nmiApiKey)
             await addSoilAnalysis(
               tx,
               session.principal_id,

--- a/fdm-app/app/store/nutrient-advice-overview.ts
+++ b/fdm-app/app/store/nutrient-advice-overview.ts
@@ -38,8 +38,7 @@ export const useNutrientAdviceOverviewStore = create<NutrientAdviceOverviewState
       applyDefaultColumnVisibility: (columnVisibility) => set({ columnVisibility }),
       // "Select all" in the column visibility dropdown: an empty state means every column is
       // visible, so resetting simply clears any per-column overrides.
-      resetColumnVisibility: () =>
-        set({ columnVisibility: {}, hasCustomColumnVisibility: true }),
+      resetColumnVisibility: () => set({ columnVisibility: {}, hasCustomColumnVisibility: true }),
     }),
     {
       name: "nutrient-advice-overview-storage",

--- a/fdm-calculator/src/estimates/index.test.ts
+++ b/fdm-calculator/src/estimates/index.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import type { SoilParameterEstimatesInput, SoilParameterEstimatesResponse } from "./types"
+import { requestSoilParameterEstimates } from "./index"
+
+const mockEstimatesData: SoilParameterEstimatesResponse = {
+  a_al_ox: 1,
+  a_c_of: 1,
+  a_ca_co: 1,
+  a_ca_co_po: 1,
+  a_caco3_if: 1,
+  a_cec_co: 1,
+  a_clay_mi: 1,
+  a_cn_fr: 1,
+  a_com_fr: 1,
+  a_cu_cc: 1,
+  a_density_sa: 1,
+  a_fe_ox: 1,
+  a_k_cc: 1,
+  a_k_co: 1,
+  a_k_co_po: 1,
+  a_mg_cc: 1,
+  a_mg_co: 1,
+  a_mg_co_po: 1,
+  a_n_pmn: 1,
+  a_n_rt: 1,
+  a_p_al: 1,
+  a_p_cc: 1,
+  a_p_ox: 1,
+  a_p_rt: 1,
+  a_p_sg: 1,
+  a_p_wa: 1,
+  a_ph_cc: 1,
+  a_s_rt: 1,
+  a_sand_mi: 1,
+  a_silt_mi: 1,
+  a_som_loi: 1,
+  a_zn_cc: 1,
+  b_soiltype_agr: "dekzand",
+  b_gwl_class: "IIb",
+  b_gwl_ghg: 1,
+  b_gwl_glg: 1,
+  b_c_st03: 1,
+  b_som_potential: 1,
+  b_c_st03_potential: 1,
+  b_c_delta: 1,
+  cultivations: [{ year: 2024, b_lu_brp: 265 }],
+  cultivations_advanced: [],
+  a_source: "nl-other-nmi",
+  a_depth_upper: 0,
+  a_depth_lower: undefined,
+}
+
+describe("requestSoilParameterEstimates", () => {
+  beforeAll(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.mocked(fetch).mockClear()
+  })
+
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("should throw an error if nmiApiKey is not provided", async () => {
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: undefined,
+    }
+
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
+      "Please provide a NMI API key",
+    )
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("should successfully fetch soil parameter estimates from NMI API", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockEstimatesData }),
+    } as Response)
+
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: "mock-api-key",
+    }
+
+    const result = await requestSoilParameterEstimates(input)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("https://api.nmi-agro.nl/estimates?"),
+      expect.objectContaining({ method: "GET" }),
+    )
+    expect(result.cultivations).toEqual([{ year: 2024, b_lu_brp: 265 }])
+  })
+
+  it("should throw an error if the NMI API request fails", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+    } as Response)
+
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: "mock-api-key",
+    }
+
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
+      "Request to NMI API failed",
+    )
+  })
+
+  it("should throw an error if the NMI API response fails validation", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { invalid: true } }),
+    } as Response)
+
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: "mock-api-key",
+    }
+
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
+      "Invalid response from NMI API",
+    )
+  })
+
+  it("should return undefined for the requested year when it is absent from cultivations", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockEstimatesData }),
+    } as Response)
+
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: "mock-api-key",
+    }
+
+    const result = await requestSoilParameterEstimates(input)
+    const suggestionForFutureYear = result.cultivations.find((c) => c.year === 2099)
+
+    expect(suggestionForFutureYear).toBeUndefined()
+  })
+})

--- a/fdm-calculator/src/estimates/index.test.ts
+++ b/fdm-calculator/src/estimates/index.test.ts
@@ -129,10 +129,10 @@ describe("requestSoilParameterEstimates", () => {
     )
   })
 
-  it("should return undefined for the requested year when it is absent from cultivations", async () => {
+  it("should throw an error if the NMI API response has no data", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: mockEstimatesData }),
+      json: async () => ({ data: null }),
     } as Response)
 
     const input: SoilParameterEstimatesInput = {
@@ -141,9 +141,26 @@ describe("requestSoilParameterEstimates", () => {
       nmiApiKey: "mock-api-key",
     }
 
-    const result = await requestSoilParameterEstimates(input)
-    const suggestionForFutureYear = result.cultivations.find((c) => c.year === 2099)
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
+      "Invalid response from NMI API: missing data",
+    )
+  })
 
-    expect(suggestionForFutureYear).toBeUndefined()
+  it("should throw a timeout error if the request is aborted", async () => {
+    vi.mocked(fetch).mockImplementationOnce(() => {
+      const abortError = new Error("The operation was aborted")
+      abortError.name = "AbortError"
+      return Promise.reject(abortError)
+    })
+
+    const input: SoilParameterEstimatesInput = {
+      a_lat: 52.4,
+      a_lon: 4.3,
+      nmiApiKey: "mock-api-key",
+    }
+
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
+      "De aanvraag naar de NMI Estimates API is verlopen (timeout).",
+    )
   })
 })

--- a/fdm-calculator/src/estimates/index.test.ts
+++ b/fdm-calculator/src/estimates/index.test.ts
@@ -4,7 +4,6 @@ import { requestSoilParameterEstimates } from "./index"
 
 const mockEstimatesData: SoilParameterEstimatesResponse = {
   a_al_ox: 1,
-  a_c_of: 1,
   a_ca_co: 1,
   a_ca_co_po: 1,
   a_caco3_if: 1,
@@ -13,7 +12,6 @@ const mockEstimatesData: SoilParameterEstimatesResponse = {
   a_cn_fr: 1,
   a_com_fr: 1,
   a_cu_cc: 1,
-  a_density_sa: 1,
   a_fe_ox: 1,
   a_k_cc: 1,
   a_k_co: 1,

--- a/fdm-calculator/src/estimates/index.test.ts
+++ b/fdm-calculator/src/estimates/index.test.ts
@@ -109,9 +109,7 @@ describe("requestSoilParameterEstimates", () => {
       nmiApiKey: "mock-api-key",
     }
 
-    await expect(requestSoilParameterEstimates(input)).rejects.toThrow(
-      "Request to NMI API failed",
-    )
+    await expect(requestSoilParameterEstimates(input)).rejects.toThrow("Request to NMI API failed")
   })
 
   it("should throw an error if the NMI API response fails validation", async () => {

--- a/fdm-calculator/src/estimates/index.ts
+++ b/fdm-calculator/src/estimates/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @packageDocumentation
+ * @module estimates
+ *
+ * Soil parameter + BRP cultivation-history estimates via the NMI API.
+ *
+ * Provides two exports:
+ * - {@link requestSoilParameterEstimates} — the raw, uncached API call function
+ * - {@link getSoilParameterEstimates} — the DB-backed cached version (use this in production)
+ *
+ * Callers are responsible for resolving the field centroid coordinates before calling
+ * either function. For persisted fields, use {@link collectInputForSoilParameterEstimates}
+ * (see `./input`) to resolve the centroid via `getField`.
+ *
+ * @example
+ * ```typescript
+ * import { collectInputForSoilParameterEstimates, getSoilParameterEstimates } from "@nmi-agro/fdm-calculator"
+ *
+ * const input = await collectInputForSoilParameterEstimates(fdm, principal_id, b_id, nmiApiKey)
+ * const estimates = await getSoilParameterEstimates(fdm, input)
+ * ```
+ */
+
+import { withCalculationCache } from "@nmi-agro/fdm-core"
+import { z } from "zod"
+import type { SoilParameterEstimatesInput, SoilParameterEstimatesResponse } from "./types"
+import pkg from "../package"
+import { soilParameterEstimatesSchema } from "./schemas"
+
+/**
+ * Calls `GET /estimates` with the given centroid coordinates and returns the
+ * parsed soil parameter + cultivation-history estimates.
+ *
+ * This is the **uncached** version. In most cases you should use {@link getSoilParameterEstimates}
+ * which adds DB-backed caching via `withCalculationCache`.
+ *
+ * @param input - Centroid coordinates (`a_lat`/`a_lon`) and the NMI API key.
+ * @throws {Error} If `nmiApiKey` is not provided, the NMI API request fails, or the response fails validation.
+ */
+export async function requestSoilParameterEstimates({
+  a_lat,
+  a_lon,
+  nmiApiKey,
+}: SoilParameterEstimatesInput): Promise<SoilParameterEstimatesResponse> {
+  if (!nmiApiKey) {
+    throw new Error("Please provide a NMI API key")
+  }
+
+  const responseApi = await fetch(
+    `https://api.nmi-agro.nl/estimates?${new URLSearchParams({
+      a_lat: a_lat.toString(),
+      a_lon: a_lon.toString(),
+    })}`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${nmiApiKey}`,
+      },
+    },
+  )
+
+  if (!responseApi.ok) {
+    throw new Error("Request to NMI API failed")
+  }
+
+  const result = await responseApi.json()
+  const response = result.data
+  response.a_source = "nl-other-nmi"
+  response.a_depth_upper = 0
+  response.a_depth_lower = undefined
+
+  // Validate the response using the Zod schema
+  const parsedResponse = soilParameterEstimatesSchema.safeParse(result.data)
+  if (!parsedResponse.success) {
+    console.error(
+      "NMI API response validation failed:",
+      JSON.stringify(z.treeifyError(parsedResponse.error), null, 2),
+    )
+    throw new Error(`Invalid response from NMI API: ${parsedResponse.error.message}`)
+  }
+
+  return response
+}
+
+/**
+ * Cached version of `requestSoilParameterEstimates`.
+ * This function uses `withCalculationCache` to store and retrieve results,
+ * improving performance for repeated calls with the same inputs.
+ * The cache key is based on the inputs and the calculator version.
+ */
+export const getSoilParameterEstimates = withCalculationCache(
+  requestSoilParameterEstimates,
+  "requestSoilParameterEstimates",
+  pkg.calculatorVersion,
+  ["nmiApiKey"],
+)

--- a/fdm-calculator/src/estimates/index.ts
+++ b/fdm-calculator/src/estimates/index.ts
@@ -35,7 +35,7 @@ import { soilParameterEstimatesSchema } from "./schemas"
  * which adds DB-backed caching via `withCalculationCache`.
  *
  * @param input - Centroid coordinates (`a_lat`/`a_lon`) and the NMI API key.
- * @throws {Error} If `nmiApiKey` is not provided, the NMI API request fails, or the response fails validation.
+ * @throws {Error} If `nmiApiKey` is not provided, the NMI API request fails or times out, or the response fails validation.
  */
 export async function requestSoilParameterEstimates({
   a_lat,
@@ -46,25 +46,44 @@ export async function requestSoilParameterEstimates({
     throw new Error("Please provide a NMI API key")
   }
 
-  const responseApi = await fetch(
-    `https://api.nmi-agro.nl/estimates?${new URLSearchParams({
-      a_lat: a_lat.toString(),
-      a_lon: a_lon.toString(),
-    })}`,
-    {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${nmiApiKey}`,
-      },
-    },
-  )
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 30000) // 30s timeout
 
-  if (!responseApi.ok) {
-    throw new Error("Request to NMI API failed")
+  let result: { data?: unknown }
+  try {
+    const responseApi = await fetch(
+      `https://api.nmi-agro.nl/estimates?${new URLSearchParams({
+        a_lat: a_lat.toString(),
+        a_lon: a_lon.toString(),
+      })}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${nmiApiKey}`,
+        },
+        signal: controller.signal,
+      },
+    )
+
+    if (!responseApi.ok) {
+      throw new Error("Request to NMI API failed")
+    }
+
+    result = await responseApi.json()
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("De aanvraag naar de NMI Estimates API is verlopen (timeout).")
+    }
+    throw err
+  } finally {
+    clearTimeout(timeout)
   }
 
-  const result = await responseApi.json()
-  const response = result.data
+  if (!result.data || typeof result.data !== "object") {
+    throw new Error("Invalid response from NMI API: missing data")
+  }
+
+  const response = result.data as Record<string, unknown>
   response.a_source = "nl-other-nmi"
   response.a_depth_upper = 0
   response.a_depth_lower = undefined
@@ -79,7 +98,7 @@ export async function requestSoilParameterEstimates({
     throw new Error(`Invalid response from NMI API: ${parsedResponse.error.message}`)
   }
 
-  return response
+  return response as unknown as SoilParameterEstimatesResponse
 }
 
 /**

--- a/fdm-calculator/src/estimates/input.test.ts
+++ b/fdm-calculator/src/estimates/input.test.ts
@@ -1,0 +1,77 @@
+import type { Field, FdmType, PrincipalId } from "@nmi-agro/fdm-core"
+import { getField } from "@nmi-agro/fdm-core"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { collectInputForSoilParameterEstimates } from "./input"
+
+vi.mock("@nmi-agro/fdm-core", async () => {
+  const actual = await vi.importActual("@nmi-agro/fdm-core")
+  return {
+    ...actual,
+    getField: vi.fn(),
+  }
+})
+
+const mockedGetField = vi.mocked(getField)
+
+// Minimal FdmType mock — collect functions don't use transactions
+const mockFdm = {} as FdmType
+const principal_id: PrincipalId = "test-principal"
+const b_id = "field-1"
+
+// Base field: centroid [lon, lat] = [5.2, 51.6]
+const mockField: Field = {
+  b_id,
+  b_name: "Test field",
+  b_id_farm: "farm-1",
+  b_id_source: null,
+  b_geometry: null,
+  b_centroid: [5.2, 51.6],
+  b_area: 10,
+  b_perimeter: 400,
+  b_start: new Date("2020-01-01"),
+  b_end: null,
+  b_acquiring_method: "unknown",
+  b_bufferstrip: false,
+}
+
+describe("collectInputForSoilParameterEstimates", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("should return a_lat/a_lon from the field centroid", async () => {
+    mockedGetField.mockResolvedValue(mockField)
+
+    const result = await collectInputForSoilParameterEstimates(
+      mockFdm,
+      principal_id,
+      b_id,
+      "mock-api-key",
+    )
+
+    // b_centroid = [lon, lat]
+    expect(result.a_lon).toBe(5.2)
+    expect(result.a_lat).toBe(51.6)
+  })
+
+  it("should pass through the nmiApiKey", async () => {
+    mockedGetField.mockResolvedValue(mockField)
+
+    const result = await collectInputForSoilParameterEstimates(
+      mockFdm,
+      principal_id,
+      b_id,
+      "mock-api-key",
+    )
+
+    expect(result.nmiApiKey).toBe("mock-api-key")
+  })
+
+  it("should call getField with the correct arguments", async () => {
+    mockedGetField.mockResolvedValue(mockField)
+
+    await collectInputForSoilParameterEstimates(mockFdm, principal_id, b_id, "mock-api-key")
+
+    expect(mockedGetField).toHaveBeenCalledWith(mockFdm, principal_id, b_id)
+  })
+})

--- a/fdm-calculator/src/estimates/input.ts
+++ b/fdm-calculator/src/estimates/input.ts
@@ -1,0 +1,35 @@
+import type { FdmType, fdmSchema, PrincipalId } from "@nmi-agro/fdm-core"
+import { getField } from "@nmi-agro/fdm-core"
+import type { SoilParameterEstimatesInput } from "./types"
+
+/**
+ * Resolves the centroid coordinates for a persisted field and builds the input
+ * bundle expected by `getSoilParameterEstimates`/`requestSoilParameterEstimates`.
+ *
+ * The centroid is computed in Postgres (`ST_Centroid`/`ST_X`/`ST_Y`, see `getField`
+ * in `fdm-core/src/field.ts`) rather than recomputed client-side.
+ *
+ * @param fdm - The FDM instance for database interaction.
+ * @param principal_id - The principal making the request.
+ * @param b_id - The field ID to resolve the centroid for.
+ * @param nmiApiKey - The NMI API key for authentication.
+ * @returns A promise resolving to the collected soil parameter estimates input.
+ * @throws {Error} If the field cannot be found or access is denied.
+ */
+export async function collectInputForSoilParameterEstimates(
+  fdm: FdmType,
+  principal_id: PrincipalId,
+  b_id: fdmSchema.fieldsTypeSelect["b_id"],
+  nmiApiKey: string | undefined,
+): Promise<SoilParameterEstimatesInput> {
+  const field = await getField(fdm, principal_id, b_id)
+
+  // b_centroid = [lon, lat] (ST_X = longitude, ST_Y = latitude)
+  const [a_lon, a_lat] = field.b_centroid
+
+  return {
+    a_lat,
+    a_lon,
+    nmiApiKey,
+  }
+}

--- a/fdm-calculator/src/estimates/schemas.ts
+++ b/fdm-calculator/src/estimates/schemas.ts
@@ -6,7 +6,6 @@ import { z } from "zod"
  */
 export const soilParameterEstimatesSchema = z.object({
   a_al_ox: z.number(),
-  a_c_of: z.number(),
   a_ca_co: z.number(),
   a_ca_co_po: z.number(),
   a_caco3_if: z.number(),
@@ -15,7 +14,6 @@ export const soilParameterEstimatesSchema = z.object({
   a_cn_fr: z.number(),
   a_com_fr: z.number(),
   a_cu_cc: z.number(),
-  a_density_sa: z.number(),
   a_fe_ox: z.number(),
   a_k_cc: z.number(),
   a_k_co: z.number(),

--- a/fdm-calculator/src/estimates/schemas.ts
+++ b/fdm-calculator/src/estimates/schemas.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
  */
 export const soilParameterEstimatesSchema = z.object({
   a_al_ox: z.number(),
+  a_c_of: z.number(),
   a_ca_co: z.number(),
   a_ca_co_po: z.number(),
   a_caco3_if: z.number(),
@@ -14,6 +15,7 @@ export const soilParameterEstimatesSchema = z.object({
   a_cn_fr: z.number(),
   a_com_fr: z.number(),
   a_cu_cc: z.number(),
+  a_density_sa: z.number(),
   a_fe_ox: z.number(),
   a_k_cc: z.number(),
   a_k_co: z.number(),

--- a/fdm-calculator/src/estimates/schemas.ts
+++ b/fdm-calculator/src/estimates/schemas.ts
@@ -1,0 +1,60 @@
+import { z } from "zod"
+
+/**
+ * Zod schema validating the raw JSON payload returned by `GET /estimates`,
+ * moved verbatim from the original `fdm-app`-local implementation.
+ */
+export const soilParameterEstimatesSchema = z.object({
+  a_al_ox: z.number(),
+  a_ca_co: z.number(),
+  a_ca_co_po: z.number(),
+  a_caco3_if: z.number(),
+  a_cec_co: z.number(),
+  a_clay_mi: z.number(),
+  a_cn_fr: z.number(),
+  a_com_fr: z.number(),
+  a_cu_cc: z.number(),
+  a_fe_ox: z.number(),
+  a_k_cc: z.number(),
+  a_k_co: z.number(),
+  a_k_co_po: z.number(),
+  a_mg_cc: z.number(),
+  a_mg_co: z.number(),
+  a_mg_co_po: z.number(),
+  a_n_pmn: z.number(),
+  a_n_rt: z.number(),
+  a_p_al: z.number(),
+  a_p_cc: z.number(),
+  a_p_ox: z.number(),
+  a_p_rt: z.number(),
+  a_p_sg: z.number(),
+  a_p_wa: z.number(),
+  a_ph_cc: z.number(),
+  a_s_rt: z.number(),
+  a_sand_mi: z.number(),
+  a_silt_mi: z.number(),
+  a_som_loi: z.number(),
+  a_zn_cc: z.number(),
+  b_soiltype_agr: z.string(),
+  b_gwl_class: z.string(),
+  b_gwl_ghg: z.number(),
+  b_gwl_glg: z.number(),
+  b_c_st03: z.number(),
+  b_som_potential: z.number(),
+  b_c_st03_potential: z.number(),
+  b_c_delta: z.number(),
+  cultivations: z.array(z.object({ year: z.number(), b_lu_brp: z.number() })),
+  cultivations_advanced: z.array(
+    z.object({
+      year: z.number(),
+      fields: z.array(
+        z.object({
+          b_lu_brp: z.number(),
+          b_area: z.number(),
+          b_area_overlap: z.number(),
+        }),
+      ),
+    }),
+  ),
+  a_source: z.string(),
+})

--- a/fdm-calculator/src/estimates/types.d.ts
+++ b/fdm-calculator/src/estimates/types.d.ts
@@ -1,0 +1,73 @@
+/**
+ * Input parameters for `requestSoilParameterEstimates`/`getSoilParameterEstimates`.
+ * The centroid coordinates are the caller's responsibility to resolve — see
+ * `collectInputForSoilParameterEstimates` (persisted fields, resolves via `getField`)
+ * for the common case.
+ */
+export type SoilParameterEstimatesInput = {
+  /** Latitude of the field centroid (WGS84) */
+  a_lat: number
+  /** Longitude of the field centroid (WGS84) */
+  a_lon: number
+  /** NMI API key for authentication */
+  nmiApiKey: string | undefined
+}
+
+/**
+ * The full response structure from the NMI Estimates API (`GET /estimates`),
+ * unchanged from the original `fdm-app`-local implementation.
+ */
+export type SoilParameterEstimatesResponse = {
+  a_al_ox: number
+  a_c_of: number
+  a_ca_co: number
+  a_ca_co_po: number
+  a_caco3_if: number
+  a_cec_co: number
+  a_clay_mi: number
+  a_cn_fr: number
+  a_com_fr: number
+  a_cu_cc: number
+  a_density_sa: number
+  a_fe_ox: number
+  a_k_cc: number
+  a_k_co: number
+  a_k_co_po: number
+  a_mg_cc: number
+  a_mg_co: number
+  a_mg_co_po: number
+  a_n_pmn: number
+  a_n_rt: number
+  a_p_al: number
+  a_p_cc: number
+  a_p_ox: number
+  a_p_rt: number
+  a_p_sg: number
+  a_p_wa: number
+  a_ph_cc: number
+  a_s_rt: number
+  a_sand_mi: number
+  a_silt_mi: number
+  a_som_loi: number
+  a_zn_cc: number
+  b_soiltype_agr: string
+  b_gwl_class: string
+  b_gwl_ghg: number
+  b_gwl_glg: number
+  b_c_st03: number
+  b_som_potential: number
+  b_c_st03_potential: number
+  b_c_delta: number
+  cultivations: { year: number; b_lu_brp: number }[]
+  cultivations_advanced: {
+    year: number
+    fields: {
+      b_lu_brp: number
+      b_area: number
+      b_area_overlap: number
+    }[]
+  }[]
+  a_source: string
+  a_depth_upper: number
+  a_depth_lower: number | undefined
+}

--- a/fdm-calculator/src/estimates/types.d.ts
+++ b/fdm-calculator/src/estimates/types.d.ts
@@ -19,7 +19,6 @@ export type SoilParameterEstimatesInput = {
  */
 export type SoilParameterEstimatesResponse = {
   a_al_ox: number
-  a_c_of: number
   a_ca_co: number
   a_ca_co_po: number
   a_caco3_if: number
@@ -28,7 +27,6 @@ export type SoilParameterEstimatesResponse = {
   a_cn_fr: number
   a_com_fr: number
   a_cu_cc: number
-  a_density_sa: number
   a_fe_ox: number
   a_k_cc: number
   a_k_co: number

--- a/fdm-calculator/src/index.ts
+++ b/fdm-calculator/src/index.ts
@@ -136,6 +136,17 @@ export type {
   NutrientAdviceInputs,
   NutrientAdviceResponse,
 } from "./nutrient-advice/types"
+export {
+  collectInputForSoilParameterEstimates,
+} from "./estimates/input"
+export {
+  getSoilParameterEstimates,
+  requestSoilParameterEstimates,
+} from "./estimates/index"
+export type {
+  SoilParameterEstimatesInput,
+  SoilParameterEstimatesResponse,
+} from "./estimates/types"
 export type { NlvSupplyBySomParams } from "./other/nlv-supply-by-som"
 export { calculateNlvSupplyBySom } from "./other/nlv-supply-by-som"
 export type { WaterSupplyBySomParams } from "./other/water-supply-by-som"

--- a/fdm-calculator/src/index.ts
+++ b/fdm-calculator/src/index.ts
@@ -136,17 +136,9 @@ export type {
   NutrientAdviceInputs,
   NutrientAdviceResponse,
 } from "./nutrient-advice/types"
-export {
-  collectInputForSoilParameterEstimates,
-} from "./estimates/input"
-export {
-  getSoilParameterEstimates,
-  requestSoilParameterEstimates,
-} from "./estimates/index"
-export type {
-  SoilParameterEstimatesInput,
-  SoilParameterEstimatesResponse,
-} from "./estimates/types"
+export { collectInputForSoilParameterEstimates } from "./estimates/input"
+export { getSoilParameterEstimates, requestSoilParameterEstimates } from "./estimates/index"
+export type { SoilParameterEstimatesInput, SoilParameterEstimatesResponse } from "./estimates/types"
 export type { NlvSupplyBySomParams } from "./other/nlv-supply-by-som"
 export { calculateNlvSupplyBySom } from "./other/nlv-supply-by-som"
 export type { WaterSupplyBySomParams } from "./other/water-supply-by-som"


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Added NMI/BRP-based crop cultivation suggestions for fields missing a “hoofdteelt”, shown across the dashboard, field list/details, and nutrient advice (banner/badge/status).
  * Users can add the suggested cultivation via a pre-filled “add cultivation” dialog, using URL-driven auto-open with suggestion parameters cleared on close.
  * Missing-cultivation warnings are now expandable to reveal per-field guidance and fallbacks.
* **Bug Fixes**
  * Suggestions never block rendering and are omitted when NMI is not configured, no estimate exists, or lookup fails.
* **Chores**
  * Improved internal soil-estimation integration consistency and caching.

Closes nmi-agro/fdm#684