### PR TITLE
Use Six Digit Numeric OTPs for Magic Link Authentication

### DIFF
--- a/.changeset/gentle-otters-jump.md
+++ b/.changeset/gentle-otters-jump.md
@@ -9,3 +9,4 @@ Improved the sign-in verification flow (`signin/check-your-email`, `signin/verif
 - Auto-submit after a completed code no longer fires if the user edits the code during the reveal delay, and a manual submit click cancels the pending auto-submit.
 - Refactored `welcome.tsx` to reuse the shared `AuthLayout`/`AuthCard` components instead of duplicating the auth shell, and replaced its deprecated `Form`/`FormField` usage with the `Field` component pattern already used elsewhere (e.g. `Controller` + `Field`/`FieldLabel`/`FieldError`).
 - Gave the welcome screen a more concrete "what's next" description instead of a generic profile-completion message.
+- Include the sign-in code in the `previewText` of the magic-link email.

--- a/.changeset/gentle-otters-jump.md
+++ b/.changeset/gentle-otters-jump.md
@@ -9,4 +9,3 @@ Improved the sign-in verification flow (`signin/check-your-email`, `signin/verif
 - Auto-submit after a completed code no longer fires if the user edits the code during the reveal delay, and a manual submit click cancels the pending auto-submit.
 - Refactored `welcome.tsx` to reuse the shared `AuthLayout`/`AuthCard` components instead of duplicating the auth shell, and replaced its deprecated `Form`/`FormField` usage with the `Field` component pattern already used elsewhere (e.g. `Controller` + `Field`/`FieldLabel`/`FieldError`).
 - Gave the welcome screen a more concrete "what's next" description instead of a generic profile-completion message.
-- Include the sign-in code in the `previewText` of the magic-link email.

--- a/.changeset/gentle-otters-jump.md
+++ b/.changeset/gentle-otters-jump.md
@@ -1,0 +1,11 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+Improved the sign-in verification flow (`signin/check-your-email`, `signin/verify`, `welcome`):
+
+- Added a resend-code action with masked destination email and a cooldown, so the "request a new code" error copy has an actual button behind it.
+- Fixed the OTP field's accessibility: `aria-invalid` now reaches the rendered input, the error region no longer renders when empty, and focus moves back to the code field on a failed verification.
+- Auto-submit after a completed code no longer fires if the user edits the code during the reveal delay, and a manual submit click cancels the pending auto-submit.
+- Refactored `welcome.tsx` to reuse the shared `AuthLayout`/`AuthCard` components instead of duplicating the auth shell, and replaced its deprecated `Form`/`FormField` usage with the `Field` component pattern already used elsewhere (e.g. `Controller` + `Field`/`FieldLabel`/`FieldError`).
+- Gave the welcome screen a more concrete "what's next" description instead of a generic profile-completion message.

--- a/.changeset/shy-cobras-dance.md
+++ b/.changeset/shy-cobras-dance.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-core": patch
+"@nmi-agro/fdm-app": patch
+---
+
+Switch the magic-link sign-in code to a 6-digit numeric code (previously an 8-character alphanumeric code). This ensures mobile devices consistently show a numeric keypad for entry and makes the code faster to type, while remaining safe from brute-forcing thanks to the existing 5-attempts-per-15-minutes rate limit on code verification.

--- a/fdm-app/app/components/blocks/auth/auth-card.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-card.tsx
@@ -19,6 +19,11 @@ interface AuthCardProps {
   backLabel?: string
   showLogo?: boolean
   contentClassName?: string
+  /**
+   * Overrides the default "back to sign in" footer. Pass `null` to omit the
+   * footer entirely, or a node to render custom footer content instead.
+   */
+  footer?: React.ReactNode | null
 }
 
 export function AuthCard({
@@ -29,6 +34,7 @@ export function AuthCard({
   backLabel = "Terug naar aanmelden",
   showLogo = true,
   contentClassName,
+  footer,
 }: AuthCardProps) {
   return (
     <Card className="shadow-xl">
@@ -49,11 +55,17 @@ export function AuthCard({
         <CardDescription>{description}</CardDescription>
       </CardHeader>
       <CardContent className={cn("space-y-4", contentClassName)}>{children}</CardContent>
-      <CardFooter className="flex justify-center">
-        <Button asChild variant="ghost" className="text-muted-foreground w-full">
-          <NavLink to={backLink}>{backLabel}</NavLink>
-        </Button>
-      </CardFooter>
+      {footer !== null && (
+        <CardFooter className="flex justify-center">
+          {footer !== undefined ? (
+            footer
+          ) : (
+            <Button asChild variant="ghost" className="text-muted-foreground w-full">
+              <NavLink to={backLink}>{backLabel}</NavLink>
+            </Button>
+          )}
+        </CardFooter>
+      )}
     </Card>
   )
 }

--- a/fdm-app/app/components/blocks/auth/auth-code-field.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-code-field.tsx
@@ -21,17 +21,20 @@ export function AuthCodeField({
     <Controller
       control={control}
       name={name}
-      render={({ field, fieldState }) => (
-        <Field>
-          <FieldLabel className="sr-only">Code</FieldLabel>
-          <FieldContent>
-            <AuthCodeInput field={field} onComplete={onComplete} />
-            <FieldError
-              errors={[fieldState.error, serverError ? { message: serverError } : undefined]}
-            />
-          </FieldContent>
-        </Field>
-      )}
+      render={({ field, fieldState }) => {
+        const isInvalid = fieldState.invalid || !!serverError
+        return (
+          <Field data-invalid={isInvalid}>
+            <FieldLabel className="sr-only">Code</FieldLabel>
+            <FieldContent>
+              <AuthCodeInput field={field} onComplete={onComplete} aria-invalid={isInvalid} />
+              <FieldError
+                errors={[fieldState.error, serverError ? { message: serverError } : undefined]}
+              />
+            </FieldContent>
+          </Field>
+        )
+      }}
     />
   )
 }

--- a/fdm-app/app/components/blocks/auth/auth-code-input.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-code-input.tsx
@@ -1,3 +1,4 @@
+import { REGEXP_ONLY_DIGITS } from "input-otp"
 import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from "~/components/ui/input-otp"
 
 interface AuthCodeInputProps {
@@ -16,21 +17,19 @@ export function AuthCodeInput({ field, onComplete }: AuthCodeInputProps) {
   return (
     <div className="flex justify-center">
       <InputOTP
-        maxLength={8}
+        maxLength={6}
         {...field}
-        pattern="^[a-zA-Z0-9]+$"
+        inputMode="numeric"
+        pattern={REGEXP_ONLY_DIGITS}
         onComplete={onComplete}
         onChange={(value) => {
-          field.onChange(value.toUpperCase())
+          field.onChange(value)
         }}
         onPaste={(e) => {
           e.preventDefault()
           const text = e.clipboardData.getData("text")
-          // Strip non-alphanumeric (dashes, spaces) and limit to 8 chars
-          const clean = text
-            .replace(/[^a-zA-Z0-9]/g, "")
-            .toUpperCase()
-            .slice(0, 8)
+          // Strip non-digits (dashes, spaces) and limit to 6 chars
+          const clean = text.replace(/[^0-9]/g, "").slice(0, 6)
           field.onChange(clean)
         }}
       >
@@ -38,14 +37,12 @@ export function AuthCodeInput({ field, onComplete }: AuthCodeInputProps) {
           <InputOTPSlot index={0} />
           <InputOTPSlot index={1} />
           <InputOTPSlot index={2} />
-          <InputOTPSlot index={3} />
         </InputOTPGroup>
         <InputOTPSeparator />
         <InputOTPGroup>
+          <InputOTPSlot index={3} />
           <InputOTPSlot index={4} />
           <InputOTPSlot index={5} />
-          <InputOTPSlot index={6} />
-          <InputOTPSlot index={7} />
         </InputOTPGroup>
       </InputOTP>
     </div>

--- a/fdm-app/app/components/blocks/auth/auth-code-input.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-code-input.tsx
@@ -11,14 +11,16 @@ interface AuthCodeInputProps {
     disabled?: boolean
   }
   onComplete?: (value: string) => void
+  "aria-invalid"?: boolean
 }
 
-export function AuthCodeInput({ field, onComplete }: AuthCodeInputProps) {
+export function AuthCodeInput({ field, onComplete, "aria-invalid": ariaInvalid }: AuthCodeInputProps) {
   return (
     <div className="flex justify-center">
       <InputOTP
         maxLength={6}
         {...field}
+        aria-invalid={ariaInvalid}
         inputMode="numeric"
         pattern={REGEXP_ONLY_DIGITS}
         onComplete={onComplete}

--- a/fdm-app/app/components/blocks/auth/auth-formschema.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-formschema.tsx
@@ -7,13 +7,13 @@ export const FormSchema = z.object({
     })
     .trim()
     .min(6, {
-      message: "De code moet uit 6 cijfers bestaan",
+      error: "De code moet uit 6 cijfers bestaan",
     })
     .max(6, {
-      message: "De code moet uit 6 cijfers bestaan",
+      error: "De code moet uit 6 cijfers bestaan",
     })
     .regex(/^\d+$/, {
-      message: "De code mag alleen cijfers bevatten",
+      error: "De code mag alleen cijfers bevatten",
     }),
   redirectTo: z.string().optional(),
 })

--- a/fdm-app/app/components/blocks/auth/auth-formschema.tsx
+++ b/fdm-app/app/components/blocks/auth/auth-formschema.tsx
@@ -6,11 +6,14 @@ export const FormSchema = z.object({
       error: "Vul de verificatiecode in",
     })
     .trim()
-    .min(8, {
-      message: "De code moet uit 8 tekens bestaan",
+    .min(6, {
+      message: "De code moet uit 6 cijfers bestaan",
     })
-    .max(8, {
-      message: "De code moet uit 8 tekens bestaan",
+    .max(6, {
+      message: "De code moet uit 6 cijfers bestaan",
+    })
+    .regex(/^\d+$/, {
+      message: "De code mag alleen cijfers bevatten",
     }),
   redirectTo: z.string().optional(),
 })

--- a/fdm-app/app/components/blocks/email/magic-link.tsx
+++ b/fdm-app/app/components/blocks/email/magic-link.tsx
@@ -42,7 +42,7 @@ export const MagicLinkEmail = ({
           Uw inlogcode
         </Text>
         <Text className="m-0 py-2 text-3xl font-bold tracking-[0.2em] text-black">
-          {code.length === 8 ? `${code.slice(0, 4)}-${code.slice(4)}` : code}
+          {code.length === 6 ? `${code.slice(0, 3)}-${code.slice(3)}` : code}
         </Text>
       </Section>
       <Text className="text-[14px] leading-6 text-black">

--- a/fdm-app/app/components/blocks/email/magic-link.tsx
+++ b/fdm-app/app/components/blocks/email/magic-link.tsx
@@ -18,7 +18,8 @@ export const MagicLinkEmail = ({
   senderName,
   emailTimestamp,
 }: MagicLinkEmailProps) => {
-  const previewText = "Gebruik de code of link om in te loggen."
+  const formattedCode = code.length === 6 ? `${code.slice(0, 3)}-${code.slice(3)}` : code
+  const previewText = `Gebruik ${formattedCode} om aan te melden bij ${appName}.`
   const absoluteUrl = url.startsWith("http") ? url : `https://${url}`
 
   return (
@@ -42,7 +43,7 @@ export const MagicLinkEmail = ({
           Uw inlogcode
         </Text>
         <Text className="m-0 py-2 text-3xl font-bold tracking-[0.2em] text-black">
-          {code.length === 6 ? `${code.slice(0, 3)}-${code.slice(3)}` : code}
+          {formattedCode}
         </Text>
       </Section>
       <Text className="text-[14px] leading-6 text-black">

--- a/fdm-app/app/components/blocks/email/magic-link.tsx
+++ b/fdm-app/app/components/blocks/email/magic-link.tsx
@@ -19,7 +19,7 @@ export const MagicLinkEmail = ({
   emailTimestamp,
 }: MagicLinkEmailProps) => {
   const formattedCode = code.length === 6 ? `${code.slice(0, 3)}-${code.slice(3)}` : code
-  const previewText = `Gebruik ${formattedCode} om aan te melden bij ${appName}.`
+  const previewText = `Gebruik de code of link in deze e-mail om aan te melden bij ${appName}.`
   const absoluteUrl = url.startsWith("http") ? url : `https://${url}`
 
   return (

--- a/fdm-app/app/components/ui/field.tsx
+++ b/fdm-app/app/components/ui/field.tsx
@@ -184,17 +184,21 @@ function FieldError({
       return children
     }
 
-    if (!errors) {
+    const messages = errors?.filter((error) => error?.message) ?? []
+
+    if (messages.length === 0) {
       return null
     }
 
-    if (errors?.length === 1 && errors[0]?.message) {
-      return errors[0].message
+    if (messages.length === 1) {
+      return messages[0]?.message
     }
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
-        {errors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+        {messages.map((error, index) => (
+          <li key={index}>{error?.message}</li>
+        ))}
       </ul>
     )
   }, [children, errors])

--- a/fdm-app/app/components/ui/input-otp.tsx
+++ b/fdm-app/app/components/ui/input-otp.tsx
@@ -1,45 +1,60 @@
+"use client"
+
 import { OTPInput, OTPInputContext } from "input-otp"
-import { Minus } from "lucide-react"
+import { MinusIcon } from "lucide-react"
 import * as React from "react"
 import { cn } from "~/lib/utils"
 
-const InputOTP = React.forwardRef<
-  React.ElementRef<typeof OTPInput>,
-  React.ComponentPropsWithoutRef<typeof OTPInput>
->(({ className, containerClassName, ...props }, ref) => (
-  <OTPInput
-    ref={ref}
-    containerClassName={cn(
-      "flex items-center gap-2 has-[:disabled]:opacity-50",
-      containerClassName,
-    )}
-    className={cn("disabled:cursor-not-allowed", className)}
-    {...props}
-  />
-))
-InputOTP.displayName = "InputOTP"
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "cn-input-otp flex items-center has-disabled:opacity-50",
+        containerClassName,
+      )}
+      spellCheck={false}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  )
+}
 
-const InputOTPGroup = React.forwardRef<
-  React.ElementRef<"div">,
-  React.ComponentPropsWithoutRef<"div">
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex items-center", className)} {...props} />
-))
-InputOTPGroup.displayName = "InputOTPGroup"
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn(
+        "has-aria-invalid:border-destructive has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 flex items-center rounded-lg has-aria-invalid:ring-3",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
-const InputOTPSlot = React.forwardRef<
-  React.ElementRef<"div">,
-  React.ComponentPropsWithoutRef<"div"> & { index: number }
->(({ index, className, ...props }, ref) => {
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
   const inputOTPContext = React.useContext(OTPInputContext)
-  const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index]
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
 
   return (
     <div
-      ref={ref}
+      data-slot="input-otp-slot"
+      data-active={isActive}
       className={cn(
-        "border-input relative flex h-9 w-9 items-center justify-center border-y border-r text-sm shadow-sm transition-all first:rounded-l-md first:border-l last:rounded-r-md",
-        isActive && "ring-ring z-10 ring-1",
+        "border-input aria-invalid:border-destructive data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40 relative flex size-8 items-center justify-center border-y border-r text-sm transition-all outline-none first:rounded-l-lg first:border-l last:rounded-r-lg data-[active=true]:z-10 data-[active=true]:ring-3",
         className,
       )}
       {...props}
@@ -52,17 +67,19 @@ const InputOTPSlot = React.forwardRef<
       )}
     </div>
   )
-})
-InputOTPSlot.displayName = "InputOTPSlot"
+}
 
-const InputOTPSeparator = React.forwardRef<
-  React.ElementRef<"div">,
-  React.ComponentPropsWithoutRef<"div">
->(({ ...props }, ref) => (
-  <div ref={ref} role="separator" {...props}>
-    <Minus />
-  </div>
-))
-InputOTPSeparator.displayName = "InputOTPSeparator"
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-separator"
+      className="flex items-center [&_svg:not([class*='size-'])]:size-4"
+      role="separator"
+      {...props}
+    >
+      <MinusIcon />
+    </div>
+  )
+}
 
-export { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot }
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator }

--- a/fdm-app/app/lib/magic-link-cookie.server.ts
+++ b/fdm-app/app/lib/magic-link-cookie.server.ts
@@ -1,0 +1,24 @@
+import { createCookie } from "react-router"
+import { serverConfig } from "~/lib/config.server"
+
+const sessionSecret = serverConfig.auth.fdm_session_secret
+if (!sessionSecret?.trim() || sessionSecret === "undefined") {
+  throw new Error("FDM_SESSION_SECRET is missing or invalid. Cannot initialize magic-link cookie.")
+}
+
+/**
+ * Short-lived cookie that carries the plaintext email address between the
+ * sign-in, check-your-email, and verify steps of the magic-link flow.
+ *
+ * The email is deliberately kept out of the URL (query params end up in
+ * server access logs, browser history, and the `Referer` header) while still
+ * letting the UI show a masked version and support resending the code.
+ */
+export const magicLinkCookie = createCookie("magic_link_email", {
+  path: "/",
+  httpOnly: true,
+  sameSite: "lax",
+  secure: process.env.NODE_ENV === "production",
+  maxAge: 900, // 15 minutes — matches the magic-link/code validity window
+  secrets: [sessionSecret],
+})

--- a/fdm-app/app/lib/url-utils.ts
+++ b/fdm-app/app/lib/url-utils.ts
@@ -115,13 +115,23 @@ export function isOfOrigin(href: string, origin: string) {
 
 /**
  * Normalises the given address to be a safe, root-relative redirect target,
- * or `/farm` by default. Rejects protocol-relative (`//`) and absolute URLs
- * to prevent open-redirect vulnerabilities when the value is used as a
- * post-auth destination (e.g. a magic-link `callbackURL`).
+ * or `/farm` by default. Resolves the candidate against a fixed same-origin
+ * base and only accepts it if the resolved origin is unchanged, which closes
+ * host-confusion bypasses that a simple `startsWith("/")` check misses (e.g.
+ * a backslash-based address like `/\evil.com` is normalized by browsers/URL
+ * parsers to the protocol-relative `//evil.com`, silently changing the host).
  *
  * @param address address to check for safety, null/undefined if not specified
  * @returns the normalized, safe redirect address
  */
 export function getSafeRedirect(address: string | null | undefined): string {
-  return address?.startsWith("/") && !address.startsWith("//") ? address : "/farm"
+  if (!address) return "/farm"
+  try {
+    const base = new URL("http://localhost")
+    const resolved = new URL(address, base)
+    if (resolved.origin !== base.origin) return "/farm"
+    return `${resolved.pathname}${resolved.search}${resolved.hash}` || "/farm"
+  } catch {
+    return "/farm"
+  }
 }

--- a/fdm-app/app/lib/url-utils.ts
+++ b/fdm-app/app/lib/url-utils.ts
@@ -112,3 +112,16 @@ export function isOfOrigin(href: string, origin: string) {
     return false
   }
 }
+
+/**
+ * Normalises the given address to be a safe, root-relative redirect target,
+ * or `/farm` by default. Rejects protocol-relative (`//`) and absolute URLs
+ * to prevent open-redirect vulnerabilities when the value is used as a
+ * post-auth destination (e.g. a magic-link `callbackURL`).
+ *
+ * @param address address to check for safety, null/undefined if not specified
+ * @returns the normalized, safe redirect address
+ */
+export function getSafeRedirect(address: string | null | undefined): string {
+  return address?.startsWith("/") && !address.startsWith("//") ? address : "/farm"
+}

--- a/fdm-app/app/lib/utils.ts
+++ b/fdm-app/app/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Masks an email address for display, keeping the first character of the
+ * local part and the full domain (e.g. `jan@example.com` -> `j***@example.com`).
+ * Returns an empty string for invalid/empty input.
+ */
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split("@")
+  if (!local || !domain) return ""
+  return `${local[0]}***@${domain}`
+}

--- a/fdm-app/app/routes/signin._index.tsx
+++ b/fdm-app/app/routes/signin._index.tsx
@@ -66,7 +66,7 @@ import { clientConfig } from "~/lib/config"
 import { isInactiveRecipientError } from "~/lib/email.server"
 import { handleActionError, handleLoaderError } from "~/lib/error"
 import { magicLinkCookie } from "~/lib/magic-link-cookie.server"
-import { modifySearchParams } from "~/lib/url-utils"
+import { modifySearchParams, getSafeRedirect } from "~/lib/url-utils"
 import { cn } from "~/lib/utils"
 import { extractFormValuesFromRequest } from "../lib/form"
 
@@ -160,15 +160,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
   } catch (error) {
     throw handleLoaderError(error)
   }
-}
-
-/**Normalizes the given address to be a safe redirect, or `/farm` by default.
- *
- * @param address address to check for safety, null if not specified
- * @returns the normalized, safe redirect address
- */
-function getSafeRedirect(address: string | null) {
-  return address?.startsWith("/") && !address.startsWith("//") ? address : "/farm"
 }
 
 function scrollToTop() {

--- a/fdm-app/app/routes/signin._index.tsx
+++ b/fdm-app/app/routes/signin._index.tsx
@@ -1513,9 +1513,11 @@ export async function action({ request }: ActionFunctionArgs) {
       headers: request.headers,
     })
 
-    // Construct redirect URL preserving redirectTo/callbackURL
+    // Construct redirect URL preserving redirectTo/callbackURL and the
+    // email address, so check-your-email can show it and offer a resend
     const nextUrl = new URL("/signin/check-your-email", "http://localhost")
     nextUrl.searchParams.set("redirectTo", safeRedirectTo)
+    nextUrl.searchParams.set("email", email)
     const redirectUrl = `${nextUrl.pathname}${nextUrl.search}`
 
     return redirectWithSuccess(redirectUrl, `Een aanmeldcode is verstuurd naar ${email}.`)

--- a/fdm-app/app/routes/signin._index.tsx
+++ b/fdm-app/app/routes/signin._index.tsx
@@ -65,6 +65,7 @@ import { auth } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { isInactiveRecipientError } from "~/lib/email.server"
 import { handleActionError, handleLoaderError } from "~/lib/error"
+import { magicLinkCookie } from "~/lib/magic-link-cookie.server"
 import { modifySearchParams } from "~/lib/url-utils"
 import { cn } from "~/lib/utils"
 import { extractFormValuesFromRequest } from "../lib/form"
@@ -1513,14 +1514,19 @@ export async function action({ request }: ActionFunctionArgs) {
       headers: request.headers,
     })
 
-    // Construct redirect URL preserving redirectTo/callbackURL and the
-    // email address, so check-your-email can show it and offer a resend
+    // Preserve redirectTo/callbackURL in the URL, but keep the plaintext
+    // email out of it (query params leak into server logs, browser history,
+    // and the Referer header). It travels instead via a short-lived,
+    // httpOnly cookie that check-your-email/verify read server-side.
     const nextUrl = new URL("/signin/check-your-email", "http://localhost")
     nextUrl.searchParams.set("redirectTo", safeRedirectTo)
-    nextUrl.searchParams.set("email", email)
     const redirectUrl = `${nextUrl.pathname}${nextUrl.search}`
 
-    return redirectWithSuccess(redirectUrl, `Een aanmeldcode is verstuurd naar ${email}.`)
+    return redirectWithSuccess(redirectUrl, `Een aanmeldcode is verstuurd naar ${email}.`, {
+      headers: {
+        "Set-Cookie": await magicLinkCookie.serialize(email),
+      },
+    })
   } catch (error) {
     if (isInactiveRecipientError(error)) {
       console.error(`Attempted to send magic link to inactive email: ${email}`)

--- a/fdm-app/app/routes/signin.check-your-email.tsx
+++ b/fdm-app/app/routes/signin.check-your-email.tsx
@@ -23,7 +23,7 @@ import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { magicLinkCookie } from "~/lib/magic-link-cookie.server"
 import { maskEmail } from "~/lib/utils"
-import { modifySearchParams } from "~/lib/url-utils"
+import { modifySearchParams, getSafeRedirect } from "~/lib/url-utils"
 import { FormSchema } from "~/components/blocks/auth/auth-formschema"
 
 export const meta: MetaFunction = () => {
@@ -237,7 +237,8 @@ export default function SignIn() {
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData()
-  const redirectTo = String(formData.get("redirectTo") || "/farm")
+  // Validate redirectTo to prevent open redirect, matching signin._index.tsx
+  const safeRedirectTo = getSafeRedirect(String(formData.get("redirectTo") || ""))
 
   // Re-read the email from the cookie rather than trusting a client-supplied
   // field, keeping it the single source of truth for this flow.
@@ -249,7 +250,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   try {
     await auth.api.signInMagicLink({
-      body: { email, callbackURL: redirectTo },
+      body: { email, callbackURL: safeRedirectTo },
       headers: request.headers,
     })
     // Refresh the cookie's expiry so repeated resends keep working within

--- a/fdm-app/app/routes/signin.check-your-email.tsx
+++ b/fdm-app/app/routes/signin.check-your-email.tsx
@@ -2,13 +2,22 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react
 import type { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useRef, useState } from "react"
-import { Form, redirect, useFetcher, useLoaderData, useNavigation, useSearchParams } from "react-router"
+import {
+  Form,
+  NavLink,
+  redirect,
+  useFetcher,
+  useLoaderData,
+  useNavigation,
+  useSearchParams,
+} from "react-router"
 import { useRemixForm } from "remix-hook-form"
 import { AuthCard } from "~/components/blocks/auth/auth-card"
 import { AuthCodeField } from "~/components/blocks/auth/auth-code-field"
 import { AuthLayout } from "~/components/blocks/auth/auth-layout"
 import { Button } from "~/components/ui/button"
 import { Spinner } from "~/components/ui/spinner"
+import { useAnalytics } from "~/hooks/use-analytics"
 import { auth } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
@@ -59,6 +68,7 @@ export default function SignIn() {
   const [cooldown, setCooldown] = useState(0)
   const loaderData = useLoaderData<typeof loader>()
   const email = loaderData.email
+  const { capture } = useAnalytics()
 
   const verifyActionUrl = modifySearchParams("/signin/verify", (params) => {
     params.set("redirectTo", redirectTo)
@@ -85,8 +95,12 @@ export default function SignIn() {
   useEffect(() => {
     if (resendFetcher.state === "idle" && resendFetcher.data && "success" in resendFetcher.data) {
       setCooldown(RESEND_COOLDOWN_SECONDS)
+      capture("signin_code_resend_succeeded")
     }
-  }, [resendFetcher.state, resendFetcher.data])
+    if (resendFetcher.state === "idle" && resendFetcher.data && "error" in resendFetcher.data) {
+      capture("signin_code_resend_failed")
+    }
+  }, [resendFetcher.state, resendFetcher.data, capture])
 
   const isSubmitting =
     (navigation.state !== "idle" && navigation.formAction?.startsWith("/signin/verify")) ||
@@ -110,6 +124,7 @@ export default function SignIn() {
             : "Een aanmeldcode en link zijn naar je e-mailadres gestuurd."
         }
         contentClassName="space-y-6"
+        footer={null}
       >
         <p className="text-muted-foreground text-center text-sm">
           De code en link zijn 15 minuten geldig en kunnen maar één keer worden gebruikt.
@@ -135,6 +150,7 @@ export default function SignIn() {
             onComplete={(value) => {
               pendingCodeRef.current = value
               setIsAutoSubmitting(true)
+              capture("signin_code_autosubmit_scheduled")
               // Trigger programmatic submit which fires onSubmit handler
               // 1.5s delay so the user can see and confirm the completed code
               timeoutRef.current = setTimeout(() => {
@@ -143,6 +159,7 @@ export default function SignIn() {
                   formRef.current?.requestSubmit()
                 } else {
                   setIsAutoSubmitting(false)
+                  capture("signin_code_autosubmit_cancelled")
                 }
               }, 1500)
             }}
@@ -167,34 +184,52 @@ export default function SignIn() {
           </Button>
         </Form>
 
-        {email && (
-          <resendFetcher.Form method="POST" className="flex flex-col items-center gap-1 text-center">
-            <input type="hidden" name="redirectTo" value={redirectTo} />
-            <Button
-              type="submit"
-              variant="link"
-              size="sm"
-              className="text-muted-foreground h-auto p-0 text-xs"
-              disabled={resendFetcher.state !== "idle" || cooldown > 0}
+        {/* Resend and "different email" sit together as matching small text
+            links, rather than pairing a small link with a full-width button. */}
+        <div className="flex flex-col items-center gap-2 text-center">
+          {email && (
+            <resendFetcher.Form
+              method="POST"
+              className="flex flex-col items-center gap-1"
+              onSubmit={() => capture("signin_code_resend_clicked")}
             >
-              {cooldown > 0
-                ? `Nieuwe code opnieuw versturen (${cooldown}s)`
-                : resendFetcher.state !== "idle"
-                  ? "Code versturen..."
-                  : "Geen code ontvangen? Opnieuw versturen"}
-            </Button>
-            {resendFetcher.data && "error" in resendFetcher.data && (
-              <p className="text-destructive text-xs" role="alert">
-                {resendFetcher.data.error}
-              </p>
-            )}
-            {resendFetcher.data && "success" in resendFetcher.data && (
-              <p className="text-xs" role="status">
-                Nieuwe code verstuurd.
-              </p>
-            )}
-          </resendFetcher.Form>
-        )}
+              <input type="hidden" name="redirectTo" value={redirectTo} />
+              <Button
+                type="submit"
+                variant="link"
+                size="sm"
+                className="text-muted-foreground h-auto p-0 text-xs"
+                disabled={resendFetcher.state !== "idle" || cooldown > 0}
+              >
+                {cooldown > 0
+                  ? `Nieuwe code opnieuw versturen (${cooldown}s)`
+                  : resendFetcher.state !== "idle"
+                    ? "Code versturen..."
+                    : "Geen code ontvangen? Opnieuw versturen"}
+              </Button>
+              {resendFetcher.data && "error" in resendFetcher.data && (
+                <p className="text-destructive text-xs" role="alert">
+                  {resendFetcher.data.error}
+                </p>
+              )}
+              {resendFetcher.data && "success" in resendFetcher.data && (
+                <p className="text-xs" role="status">
+                  Nieuwe code verstuurd.
+                </p>
+              )}
+            </resendFetcher.Form>
+          )}
+          <Button
+            asChild
+            variant="link"
+            size="sm"
+            className="text-muted-foreground h-auto p-0 text-xs"
+          >
+            <NavLink to="/signin" onClick={() => capture("signin_different_email_clicked")}>
+              Ander e-mailadres gebruiken
+            </NavLink>
+          </Button>
+        </div>
       </AuthCard>
     </AuthLayout>
   )

--- a/fdm-app/app/routes/signin.check-your-email.tsx
+++ b/fdm-app/app/routes/signin.check-your-email.tsx
@@ -1,8 +1,8 @@
-import type { LoaderFunctionArgs, MetaFunction } from "react-router"
+import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router"
 import type { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useRef, useState } from "react"
-import { Form, redirect, useNavigation, useSearchParams } from "react-router"
+import { Form, redirect, useFetcher, useNavigation, useSearchParams } from "react-router"
 import { useRemixForm } from "remix-hook-form"
 import { AuthCard } from "~/components/blocks/auth/auth-card"
 import { AuthCodeField } from "~/components/blocks/auth/auth-code-field"
@@ -12,6 +12,7 @@ import { Spinner } from "~/components/ui/spinner"
 import { auth } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
+import { maskEmail } from "~/lib/utils"
 import { modifySearchParams } from "~/lib/url-utils"
 import { FormSchema } from "~/components/blocks/auth/auth-formschema"
 
@@ -35,23 +36,35 @@ export async function loader({ request }: LoaderFunctionArgs) {
       return redirect("/farm")
     }
 
-    return {}
+    const url = new URL(request.url)
+    const email = url.searchParams.get("email") || ""
+
+    return { email }
   } catch (error) {
     throw handleLoaderError(error)
   }
 }
 
+const RESEND_COOLDOWN_SECONDS = 30
+
 export default function SignIn() {
   const [searchParams] = useSearchParams()
+  const email = searchParams.get("email") || ""
   const redirectTo = searchParams.get("redirectTo") || "/farm"
   const navigation = useNavigation()
   const formRef = useRef<HTMLFormElement>(null)
   const [isAutoSubmitting, setIsAutoSubmitting] = useState(false)
+  const resendFetcher = useFetcher<typeof action>()
+  const [cooldown, setCooldown] = useState(0)
 
   const verifyActionUrl = modifySearchParams("/signin/verify", (params) => {
     params.set("redirectTo", redirectTo)
+    if (email) params.set("email", email)
   })
 
+  // Cancel a pending auto-submit if the user edits the code afterwards,
+  // so the auto-submit never overrides an intentional change.
+  const pendingCodeRef = useRef<string | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => {
     return () => {
@@ -60,6 +73,18 @@ export default function SignIn() {
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (cooldown <= 0) return
+    const interval = setInterval(() => setCooldown((c) => Math.max(0, c - 1)), 1000)
+    return () => clearInterval(interval)
+  }, [cooldown])
+
+  useEffect(() => {
+    if (resendFetcher.state === "idle" && resendFetcher.data && "success" in resendFetcher.data) {
+      setCooldown(RESEND_COOLDOWN_SECONDS)
+    }
+  }, [resendFetcher.state, resendFetcher.data])
 
   const isSubmitting =
     (navigation.state !== "idle" && navigation.formAction?.startsWith("/signin/verify")) ||
@@ -77,7 +102,11 @@ export default function SignIn() {
     <AuthLayout showCookieSettings={true}>
       <AuthCard
         title="Controleer je e-mail inbox"
-        description="Een aanmeldcode en link zijn naar je e-mailadres gestuurd."
+        description={
+          email
+            ? `Een aanmeldcode en link zijn naar ${maskEmail(email)} gestuurd.`
+            : "Een aanmeldcode en link zijn naar je e-mailadres gestuurd."
+        }
         contentClassName="space-y-6"
       >
         <p className="text-muted-foreground text-center text-sm">
@@ -101,16 +130,30 @@ export default function SignIn() {
         >
           <AuthCodeField
             control={form.control}
-            onComplete={() => {
+            onComplete={(value) => {
+              pendingCodeRef.current = value
               setIsAutoSubmitting(true)
               // Trigger programmatic submit which fires onSubmit handler
-              // 1.5s delay so user sees the completed code
+              // 1.5s delay so the user can see and confirm the completed code
               timeoutRef.current = setTimeout(() => {
-                formRef.current?.requestSubmit()
+                // Only submit if the code hasn't been edited since completion
+                if (form.getValues("code") === pendingCodeRef.current) {
+                  formRef.current?.requestSubmit()
+                } else {
+                  setIsAutoSubmitting(false)
+                }
               }, 1500)
             }}
           />
-          <Button type="submit" className="w-full" disabled={isSubmitting}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isSubmitting}
+            onClick={() => {
+              // Let a deliberate click interrupt any pending auto-submit
+              if (timeoutRef.current) clearTimeout(timeoutRef.current)
+            }}
+          >
             {isSubmitting ? (
               <div className="flex items-center space-x-2">
                 <Spinner />
@@ -121,7 +164,58 @@ export default function SignIn() {
             )}
           </Button>
         </Form>
+
+        {email && (
+          <resendFetcher.Form method="POST" className="flex flex-col items-center gap-1 text-center">
+            <input type="hidden" name="email" value={email} />
+            <input type="hidden" name="redirectTo" value={redirectTo} />
+            <Button
+              type="submit"
+              variant="link"
+              size="sm"
+              className="text-muted-foreground h-auto p-0 text-xs"
+              disabled={resendFetcher.state !== "idle" || cooldown > 0}
+            >
+              {cooldown > 0
+                ? `Nieuwe code opnieuw versturen (${cooldown}s)`
+                : resendFetcher.state !== "idle"
+                  ? "Code versturen..."
+                  : "Geen code ontvangen? Opnieuw versturen"}
+            </Button>
+            {resendFetcher.data && "error" in resendFetcher.data && (
+              <p className="text-destructive text-xs" role="alert">
+                {resendFetcher.data.error}
+              </p>
+            )}
+            {resendFetcher.data && "success" in resendFetcher.data && (
+              <p className="text-xs" role="status">
+                Nieuwe code verstuurd.
+              </p>
+            )}
+          </resendFetcher.Form>
+        )}
       </AuthCard>
     </AuthLayout>
   )
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData()
+  const email = String(formData.get("email") || "")
+  const redirectTo = String(formData.get("redirectTo") || "/farm")
+
+  if (!email) {
+    return { error: "E-mailadres ontbreekt. Ga terug naar aanmelden." }
+  }
+
+  try {
+    await auth.api.signInMagicLink({
+      body: { email, callbackURL: redirectTo },
+      headers: request.headers,
+    })
+    return { success: true }
+  } catch (error) {
+    console.error("Error resending magic link:", error)
+    return { error: "Het opnieuw versturen is niet gelukt. Probeer het straks opnieuw." }
+  }
 }

--- a/fdm-app/app/routes/signin.check-your-email.tsx
+++ b/fdm-app/app/routes/signin.check-your-email.tsx
@@ -13,7 +13,7 @@ import { auth } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
 import { modifySearchParams } from "~/lib/url-utils"
-import { FormSchema } from "../components/blocks/auth/auth-formschema"
+import { FormSchema } from "~/components/blocks/auth/auth-formschema"
 
 export const meta: MetaFunction = () => {
   return [

--- a/fdm-app/app/routes/signin.check-your-email.tsx
+++ b/fdm-app/app/routes/signin.check-your-email.tsx
@@ -2,7 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react
 import type { z } from "zod"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useEffect, useRef, useState } from "react"
-import { Form, redirect, useFetcher, useNavigation, useSearchParams } from "react-router"
+import { Form, redirect, useFetcher, useLoaderData, useNavigation, useSearchParams } from "react-router"
 import { useRemixForm } from "remix-hook-form"
 import { AuthCard } from "~/components/blocks/auth/auth-card"
 import { AuthCodeField } from "~/components/blocks/auth/auth-code-field"
@@ -12,6 +12,7 @@ import { Spinner } from "~/components/ui/spinner"
 import { auth } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleLoaderError } from "~/lib/error"
+import { magicLinkCookie } from "~/lib/magic-link-cookie.server"
 import { maskEmail } from "~/lib/utils"
 import { modifySearchParams } from "~/lib/url-utils"
 import { FormSchema } from "~/components/blocks/auth/auth-formschema"
@@ -36,8 +37,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
       return redirect("/farm")
     }
 
-    const url = new URL(request.url)
-    const email = url.searchParams.get("email") || ""
+    // The email travels via a short-lived httpOnly cookie rather than the
+    // URL, so it never ends up in server logs, browser history, or Referer.
+    const email = (await magicLinkCookie.parse(request.headers.get("Cookie"))) || ""
 
     return { email }
   } catch (error) {
@@ -49,17 +51,17 @@ const RESEND_COOLDOWN_SECONDS = 30
 
 export default function SignIn() {
   const [searchParams] = useSearchParams()
-  const email = searchParams.get("email") || ""
   const redirectTo = searchParams.get("redirectTo") || "/farm"
   const navigation = useNavigation()
   const formRef = useRef<HTMLFormElement>(null)
   const [isAutoSubmitting, setIsAutoSubmitting] = useState(false)
   const resendFetcher = useFetcher<typeof action>()
   const [cooldown, setCooldown] = useState(0)
+  const loaderData = useLoaderData<typeof loader>()
+  const email = loaderData.email
 
   const verifyActionUrl = modifySearchParams("/signin/verify", (params) => {
     params.set("redirectTo", redirectTo)
-    if (email) params.set("email", email)
   })
 
   // Cancel a pending auto-submit if the user edits the code afterwards,
@@ -167,7 +169,6 @@ export default function SignIn() {
 
         {email && (
           <resendFetcher.Form method="POST" className="flex flex-col items-center gap-1 text-center">
-            <input type="hidden" name="email" value={email} />
             <input type="hidden" name="redirectTo" value={redirectTo} />
             <Button
               type="submit"
@@ -201,8 +202,11 @@ export default function SignIn() {
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData()
-  const email = String(formData.get("email") || "")
   const redirectTo = String(formData.get("redirectTo") || "/farm")
+
+  // Re-read the email from the cookie rather than trusting a client-supplied
+  // field, keeping it the single source of truth for this flow.
+  const email = (await magicLinkCookie.parse(request.headers.get("Cookie"))) || ""
 
   if (!email) {
     return { error: "E-mailadres ontbreekt. Ga terug naar aanmelden." }
@@ -213,7 +217,12 @@ export async function action({ request }: ActionFunctionArgs) {
       body: { email, callbackURL: redirectTo },
       headers: request.headers,
     })
-    return { success: true }
+    // Refresh the cookie's expiry so repeated resends keep working within
+    // the flow, without extending the window indefinitely on its own.
+    return Response.json(
+      { success: true },
+      { headers: { "Set-Cookie": await magicLinkCookie.serialize(email) } },
+    )
   } catch (error) {
     console.error("Error resending magic link:", error)
     return { error: "Het opnieuw versturen is niet gelukt. Probeer het straks opnieuw." }

--- a/fdm-app/app/routes/signin.verify.tsx
+++ b/fdm-app/app/routes/signin.verify.tsx
@@ -24,6 +24,7 @@ import { serverConfig } from "~/lib/config.server"
 import { handleLoaderError } from "~/lib/error"
 import { FormSchema } from "../components/blocks/auth/auth-formschema"
 import { extractFormValuesFromRequest } from "../lib/form"
+import { modifySearchParams } from "../lib/url-utils"
 
 export const meta: MetaFunction = () => {
   return [
@@ -40,6 +41,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url)
     const code = url.searchParams.get("code") || ""
     const redirectTo = url.searchParams.get("redirectTo") || "/farm"
+    const email = url.searchParams.get("email") || ""
 
     // Check if user is already logged in
     const session = await auth.api.getSession({
@@ -49,14 +51,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       return redirect("/farm")
     }
 
-    return { code, redirectTo }
+    return { code, redirectTo, email }
   } catch (error) {
     throw handleLoaderError(error)
   }
 }
 
 export default function Verify() {
-  const { code, redirectTo } = useLoaderData<typeof loader>()
+  const { code, redirectTo, email } = useLoaderData<typeof loader>()
   const actionData = useActionData<typeof action>()
   const navigation = useNavigation()
   const isSubmitting = navigation.state !== "idle"
@@ -73,18 +75,31 @@ export default function Verify() {
 
   const hasAnimated = useRef(false)
 
-  // Capture code failure when actionData signals an error
+  // Capture code failure when actionData signals an error, and move focus
+  // back to the code field so the failure and its recovery link are announced.
   useEffect(() => {
     if (actionData?.errors?.code) {
       const reason = actionData.errors.code.includes("Te veel") ? "rate_limited" : "invalid_code"
       capture("signin_code_failed", { reason })
+      form.setFocus("code")
     }
-  }, [actionData])
+  }, [actionData, capture, form])
 
-  // Typing animation effect
+  // Reveal the emailed code character by character so the user sees it was
+  // received and is about to be verified, rather than jumping straight to a
+  // spinner. Fills instantly when the user prefers reduced motion.
   useEffect(() => {
     if (code && code.length === 6 && !hasAnimated.current) {
       hasAnimated.current = true
+      const prefersReducedMotion = window.matchMedia?.(
+        "(prefers-reduced-motion: reduce)",
+      )?.matches
+
+      if (prefersReducedMotion) {
+        form.setValue("code", code)
+        return
+      }
+
       const chars = code.split("")
       let current = ""
       chars.forEach((char, index) => {
@@ -95,6 +110,11 @@ export default function Verify() {
       })
     }
   }, [code, form])
+
+  const requestNewCodeUrl = modifySearchParams("/signin/check-your-email", (params) => {
+    params.set("redirectTo", redirectTo || "/farm")
+    if (email) params.set("email", email)
+  })
 
   return (
     <AuthLayout>
@@ -124,6 +144,12 @@ export default function Verify() {
               "Verifiëren en aanmelden"
             )}
           </Button>
+
+          {actionData?.errors?.code && (
+            <Button asChild variant="link" className="w-full">
+              <a href={requestNewCodeUrl}>Nieuwe code aanvragen</a>
+            </Button>
+          )}
         </Form>
       </AuthCard>
     </AuthLayout>
@@ -131,7 +157,9 @@ export default function Verify() {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  // Artificial delay to ensure the loading state is visible to the user
+  // Deliberate delay: makes the verification step feel checked/deliberate
+  // rather than instantaneous, and adds friction against brute-force/bot
+  // code-guessing attempts.
   await new Promise((resolve) => setTimeout(resolve, 700))
 
   const formValues = await extractFormValuesFromRequest(request, FormSchema)

--- a/fdm-app/app/routes/signin.verify.tsx
+++ b/fdm-app/app/routes/signin.verify.tsx
@@ -41,7 +41,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url)
     const code = url.searchParams.get("code") || ""
     const redirectTo = url.searchParams.get("redirectTo") || "/farm"
-    const email = url.searchParams.get("email") || ""
 
     // Check if user is already logged in
     const session = await auth.api.getSession({
@@ -51,14 +50,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       return redirect("/farm")
     }
 
-    return { code, redirectTo, email }
+    return { code, redirectTo }
   } catch (error) {
     throw handleLoaderError(error)
   }
 }
 
 export default function Verify() {
-  const { code, redirectTo, email } = useLoaderData<typeof loader>()
+  const { code, redirectTo } = useLoaderData<typeof loader>()
   const actionData = useActionData<typeof action>()
   const navigation = useNavigation()
   const isSubmitting = navigation.state !== "idle"
@@ -113,7 +112,6 @@ export default function Verify() {
 
   const requestNewCodeUrl = modifySearchParams("/signin/check-your-email", (params) => {
     params.set("redirectTo", redirectTo || "/farm")
-    if (email) params.set("email", email)
   })
 
   return (

--- a/fdm-app/app/routes/signin.verify.tsx
+++ b/fdm-app/app/routes/signin.verify.tsx
@@ -145,7 +145,12 @@ export default function Verify() {
 
           {actionData?.errors?.code && (
             <Button asChild variant="link" className="w-full">
-              <a href={requestNewCodeUrl}>Nieuwe code aanvragen</a>
+              <a
+                href={requestNewCodeUrl}
+                onClick={() => capture("signin_request_new_code_clicked")}
+              >
+                Nieuwe code aanvragen
+              </a>
             </Button>
           )}
         </Form>

--- a/fdm-app/app/routes/signin.verify.tsx
+++ b/fdm-app/app/routes/signin.verify.tsx
@@ -83,9 +83,9 @@ export default function Verify() {
 
   // Typing animation effect
   useEffect(() => {
-    if (code && code.length === 8 && !hasAnimated.current) {
+    if (code && code.length === 6 && !hasAnimated.current) {
       hasAnimated.current = true
-      const chars = code.toUpperCase().split("")
+      const chars = code.split("")
       let current = ""
       chars.forEach((char, index) => {
         setTimeout(() => {
@@ -100,7 +100,7 @@ export default function Verify() {
     <AuthLayout>
       <AuthCard
         title="Verifieer je code"
-        description="Vul de 8-cijferige code in die je per e-mail hebt ontvangen."
+        description="Vul de 6-cijferige code in die je per e-mail hebt ontvangen."
       >
         <Form
           onSubmit={(e) => {

--- a/fdm-app/app/routes/signin.verify.tsx
+++ b/fdm-app/app/routes/signin.verify.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react"
 import {
   type ActionFunctionArgs,
   Form,
+  Link,
   type LoaderFunctionArgs,
   type MetaFunction,
   redirect,
@@ -88,25 +89,32 @@ export default function Verify() {
   // received and is about to be verified, rather than jumping straight to a
   // spinner. Fills instantly when the user prefers reduced motion.
   useEffect(() => {
-    if (code && code.length === 6 && !hasAnimated.current) {
-      hasAnimated.current = true
-      const prefersReducedMotion = window.matchMedia?.(
-        "(prefers-reduced-motion: reduce)",
-      )?.matches
+    if (!(code && code.length === 6 && !hasAnimated.current)) {
+      return
+    }
+    hasAnimated.current = true
+    const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches
 
-      if (prefersReducedMotion) {
-        form.setValue("code", code)
-        return
+    if (prefersReducedMotion) {
+      form.setValue("code", code)
+      return
+    }
+
+    const chars = code.split("")
+    let current = ""
+    // Track every scheduled timeout so we can clear them all on cleanup,
+    // preventing form.setValue from firing after the component unmounts.
+    const timeoutIds = chars.map((char, index) =>
+      setTimeout(() => {
+        current += char
+        form.setValue("code", current)
+      }, index * 75),
+    ) // 75ms delay between keystrokes
+
+    return () => {
+      for (const id of timeoutIds) {
+        clearTimeout(id)
       }
-
-      const chars = code.split("")
-      let current = ""
-      chars.forEach((char, index) => {
-        setTimeout(() => {
-          current += char
-          form.setValue("code", current)
-        }, index * 75) // 75ms delay between keystrokes
-      })
     }
   }, [code, form])
 
@@ -145,12 +153,12 @@ export default function Verify() {
 
           {actionData?.errors?.code && (
             <Button asChild variant="link" className="w-full">
-              <a
-                href={requestNewCodeUrl}
+              <Link
+                to={requestNewCodeUrl}
                 onClick={() => capture("signin_request_new_code_clicked")}
               >
                 Nieuwe code aanvragen
-              </a>
+              </Link>
             </Button>
           )}
         </Form>

--- a/fdm-app/app/routes/welcome.tsx
+++ b/fdm-app/app/routes/welcome.tsx
@@ -2,36 +2,23 @@ import type { Resolver } from "react-hook-form"
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { updateUserProfile } from "@nmi-agro/fdm-core"
-import { Cookie } from "lucide-react"
+import { Controller } from "react-hook-form"
 import { Form, redirect, useLoaderData } from "react-router"
-import { RemixFormProvider, useRemixForm } from "remix-hook-form"
+import { useRemixForm } from "remix-hook-form"
 import { redirectWithSuccess } from "remix-toast"
 import { z } from "zod"
+import { AuthCard } from "~/components/blocks/auth/auth-card"
+import { AuthLayout } from "~/components/blocks/auth/auth-layout"
 import { Avatar, AvatarImage } from "~/components/ui/avatar"
 import { Button } from "~/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "~/components/ui/card"
-import {
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "~/components/ui/form"
+import { Field, FieldError, FieldLabel } from "~/components/ui/field"
 import { Input } from "~/components/ui/input"
 import { Spinner } from "~/components/ui/spinner"
 import { auth, getSession } from "~/lib/auth.server"
 import { clientConfig } from "~/lib/config"
 import { handleActionError, handleLoaderError } from "~/lib/error"
 import { fdm } from "~/lib/fdm.server"
-import { extractFormValuesFromRequest } from "../lib/form"
+import { extractFormValuesFromRequest } from "~/lib/form"
 
 export const meta: MetaFunction = () => {
   return [
@@ -102,14 +89,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
  */
 export default function Welcome() {
   const loaderData = useLoaderData<typeof loader>()
-  const openCookieSettings = () => {
-    if (window?.openCookieSettings) {
-      window.openCookieSettings()
-    }
-  }
-  const onOpenCookieSettings = () => {
-    openCookieSettings()
-  }
 
   const form = useRemixForm<z.infer<typeof FormSchema>>({
     mode: "onTouched",
@@ -121,119 +100,63 @@ export default function Welcome() {
   })
 
   return (
-    <div className="h-screen w-full overflow-hidden lg:grid lg:grid-cols-2">
-      <div className="flex h-full items-start justify-center overflow-y-auto py-6">
-        <div className="mx-auto grid w-[350px] gap-6">
-          <Card className="shadow-xl">
-            <CardHeader className="text-center">
-              <div className="mb-2 flex justify-center">
-                <div className="flex aspect-square size-16 items-center justify-center rounded-lg bg-[#122023]">
-                  <img className="size-12" src={clientConfig.logomark} alt={clientConfig.name} />
+    <AuthLayout showCookieSettings={true}>
+      <AuthCard
+        title="Profiel voltooien"
+        description={`Welkom bij ${clientConfig.name}. Vul je naam aan om direct te starten met je percelen, bemesting en bodemdata.`}
+        footer={
+          <p className="text-muted-foreground text-center text-xs">
+            Je kunt dit later altijd aanpassen via je profielinstellingen.
+          </p>
+        }
+      >
+        <Form id="formWelcome" onSubmit={form.handleSubmit} method="post">
+          <fieldset disabled={form.formState.isSubmitting}>
+            <div className="grid w-full items-center gap-4">
+              {loaderData.image ? (
+                <div className="flex flex-col justify-self-center">
+                  <Avatar className="h-12 w-12 rounded-lg">
+                    <AvatarImage src={loaderData.image} />
+                  </Avatar>
                 </div>
-              </div>
-              <h2 className="text-muted-foreground mb-2 text-lg font-semibold tracking-tight">
-                {clientConfig.name}
-              </h2>
-              <CardTitle className="text-xl">Profiel voltooien</CardTitle>
-              <CardDescription>
-                {`Welkom bij ${clientConfig.name}. Om verder te gaan maken we eerst je profiel compleet.`}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <RemixFormProvider {...form}>
-                <Form id="formWelcome" onSubmit={form.handleSubmit} method="post">
-                  <fieldset disabled={form.formState.isSubmitting}>
-                    <div className="grid w-full items-center gap-4">
-                      {loaderData.image ? (
-                        <div className="flex flex-col justify-self-center">
-                          <Avatar className="h-12 w-12 rounded-lg">
-                            <AvatarImage src={loaderData.image} />
-                          </Avatar>
-                        </div>
-                      ) : null}
-                      <div className="flex flex-col space-y-1.5">
-                        <FormField
-                          control={form.control}
-                          name="firstname"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Voornaam</FormLabel>
-                              <FormControl>
-                                <Input
-                                  placeholder="bv. Jan"
-                                  aria-required="true"
-                                  required
-                                  {...field}
-                                />
-                              </FormControl>
-                              <FormDescription />
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-                      <div className="flex flex-col space-y-1.5">
-                        <FormField
-                          control={form.control}
-                          name="surname"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Achternaam</FormLabel>
-                              <FormControl>
-                                <Input
-                                  placeholder="bv. de Vries"
-                                  aria-required="true"
-                                  required
-                                  {...field}
-                                />
-                              </FormControl>
-                              <FormDescription />
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </div>
-                      <Button type="submit" className="w-full">
-                        {form.formState.isSubmitting ? (
-                          <div className="flex items-center space-x-2">
-                            <Spinner />
-                            <span>Opslaan...</span>
-                          </div>
-                        ) : (
-                          "Doorgaan"
-                        )}
-                      </Button>
-                    </div>
-                  </fieldset>
-                </Form>
-              </RemixFormProvider>
-            </CardContent>
-            <CardFooter className="flex justify-center" />
-          </Card>
-        </div>
-      </div>
-      <div className="bg-muted hidden lg:block">
-        <img
-          src="https://images.unsplash.com/photo-1625565570971-e6b404974366?q=80&w=1930&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-          alt="Herd of cows on green grass field during daytime by Rickie-Tom Schünemann on Unsplash"
-          width="1920"
-          height="1080"
-          loading="lazy"
-          className="h-full w-full object-cover dark:brightness-[0.2] dark:grayscale"
-        />
-      </div>
-      <div className="fixed bottom-3 left-3 z-50">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="bg-card/80 hover:bg-card border-border flex items-center gap-1 border text-xs opacity-70 hover:opacity-100"
-          onClick={onOpenCookieSettings}
-        >
-          <Cookie className="h-3 w-3" />
-          <span>Cookie instellingen</span>
-        </Button>
-      </div>
-    </div>
+              ) : null}
+              <Controller
+                control={form.control}
+                name="firstname"
+                render={({ field, fieldState }) => (
+                  <Field data-invalid={fieldState.invalid}>
+                    <FieldLabel>Voornaam</FieldLabel>
+                    <Input placeholder="bv. Jan" aria-required="true" required {...field} />
+                    {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+                  </Field>
+                )}
+              />
+              <Controller
+                control={form.control}
+                name="surname"
+                render={({ field, fieldState }) => (
+                  <Field data-invalid={fieldState.invalid}>
+                    <FieldLabel>Achternaam</FieldLabel>
+                    <Input placeholder="bv. de Vries" aria-required="true" required {...field} />
+                    {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+                  </Field>
+                )}
+              />
+              <Button type="submit" className="w-full">
+                {form.formState.isSubmitting ? (
+                  <div className="flex items-center space-x-2">
+                    <Spinner />
+                    <span>Opslaan...</span>
+                  </div>
+                ) : (
+                  "Doorgaan"
+                )}
+              </Button>
+            </div>
+          </fieldset>
+        </Form>
+      </AuthCard>
+    </AuthLayout>
   )
 }
 

--- a/fdm-core/src/authentication.test.ts
+++ b/fdm-core/src/authentication.test.ts
@@ -45,6 +45,18 @@ describe("createFdmAuth", () => {
     fdm = createFdmServer(host, port, user, password, database)
   })
 
+  it("should generate a 6-digit numeric magic-link OTP", () => {
+    fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth)
+
+    const magicLinkPlugin = fdmAuth.options.plugins?.find(
+      (p: any) => p.id === "magic-link",
+    ) as any
+    expect(magicLinkPlugin).toBeDefined()
+
+    const token = magicLinkPlugin?.options?.generateToken?.()
+    expect(token).toMatch(/^\d{6}$/)
+  })
+
   it("should create an auth instance with the correct database adapter", () => {
     // Create the auth server using the mock FdmServer instance
     fdmAuth = createFdmAuth(fdm, googleAuth, microsoftAuth)

--- a/fdm-core/src/authentication.ts
+++ b/fdm-core/src/authentication.ts
@@ -411,16 +411,16 @@ export function createDisplayUsername(
   return name
 }
 
-const ALPHABET = "23456789ABCDFGHJKLMNPQRSTVWXYZ"
-const generateCodeWithNanoId = customAlphabet(ALPHABET, 8)
+const ALPHABET = "0123456789"
+const generateCodeWithNanoId = customAlphabet(ALPHABET, 6)
 /**
- * Generates a read-safe OTP (One-Time Password).
+ * Generates a numeric OTP (One-Time Password).
  *
- * This function uses a character set that avoids ambiguous characters
- * (e.g., I, O, 1, 0) to ensure the code is easy to read and type.
- * It produces an 8-character string.
+ * This function uses a digits-only character set so that mobile
+ * devices consistently show a numeric keypad for entry. It produces
+ * a 6-character string.
  *
- * @returns {string} An 8-character read-safe OTP.
+ * @returns {string} A 6-digit numeric OTP.
  */
 function generateReadSafeOTP(): string {
   return generateCodeWithNanoId()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-in verification now uses a six-digit numeric code for faster, keypad-friendly entry.
  * Added “resend code” with a 30-second cooldown, masked destination email, and “use a different email” option.
  * Magic-link emails now display the verification code more clearly with improved formatting.
* **Bug Fixes**
  * Improved code-entry validation, error rendering, and accessibility state handling.
  * Prevented unintended auto-submission after code completion if the user edits the code; returns focus to the code field on failure.
* **Refactor**
  * Updated the welcome screen to use the shared authentication layout/card components and modern form field patterns.
* **Tests**
  * Added coverage to confirm the generated OTP is 6 digits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #689 