### PR TITLE
Add End Date Validation when Adding Cultivation

### DIFF
--- a/.changeset/gentle-ghosts-visit.md
+++ b/.changeset/gentle-ghosts-visit.md
@@ -1,5 +1,0 @@
----
-"@nmi-agro/fdm-app": patch
----
-
-Now users see an error message inline in the form also when trying to create a cultivation, whose end date is before the start date. This used to only work for updating a cultivation.

--- a/.changeset/gentle-ghosts-visit.md
+++ b/.changeset/gentle-ghosts-visit.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": minor
+---
+
+Now users see an error message inline in the form also when trying to create a cultivation, whose end date is before the start date. This used to only work for updating a cultivation.

--- a/.changeset/gentle-ghosts-visit.md
+++ b/.changeset/gentle-ghosts-visit.md
@@ -1,5 +1,5 @@
 ---
-"@nmi-agro/fdm-app": minor
+"@nmi-agro/fdm-app": patch
 ---
 
 Now users see an error message inline in the form also when trying to create a cultivation, whose end date is before the start date. This used to only work for updating a cultivation.

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-app
 
+## 0.33.2
+
+### Patch Changes
+
+- [#701](https://github.com/nmi-agro/fdm/pull/701) [`be15738`](https://github.com/nmi-agro/fdm/commit/be1573826986a3fb735ac735f64765783cd33253) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - Now users see an error message inline in the form also when trying to create a cultivation, whose end date is before the start date. This used to only work for updating a cultivation.
+
 ## 0.33.1
 
 ### Patch Changes

--- a/fdm-app/app/components/blocks/cultivation/schema.ts
+++ b/fdm-app/app/components/blocks/cultivation/schema.ts
@@ -69,6 +69,18 @@ export const CultivationAddFormSchema = z.object({
         return value
     }, z.coerce.date().optional().nullable()),
 })
+    .refine(
+        (data) => {
+            if (data.b_lu_start && data.b_lu_end) {
+                return data.b_lu_end > data.b_lu_start
+            }
+            return true
+        },
+        {
+            path: ["b_lu_end"],
+            error: "Einddatum moet na de zaaidatum liggen.",
+        },
+    )
 
 export type CultivationAddFormSchemaType = z.infer<
     typeof CultivationAddFormSchema

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmi-agro/fdm-app",
-    "version": "0.33.1",
+    "version": "0.33.2",
     "private": true,
     "sideEffects": false,
     "type": "module",


### PR DESCRIPTION
**Enhancements**
- The users now get a better error message when they try to submit a cultivation end date that is before the start date, when adding a new cultivation. This already happened when modifying a cultivation.

We are not making Add and Details forms use a shared schema because they are different enough. However, both of their schemas should contain all the necessary validations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter form validation to ensure the cultivation end date is later than the sowing date when creating a cultivation.
  * Shows an inline error message on the end date field (“Einddatum moet na de zaaidatum liggen.”) if the dates are entered in the wrong order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->