### PR TITLE
Show Pending Organization Invitations to Readonly Members

### DIFF
--- a/.changeset/silly-views-learn.md
+++ b/.changeset/silly-views-learn.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-core": minor
+"@nmi-agro/fdm-app": minor
+---
+
+Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept of decline the invitation themselves.

--- a/.changeset/silly-views-learn.md
+++ b/.changeset/silly-views-learn.md
@@ -1,6 +1,0 @@
----
-"@nmi-agro/fdm-core": minor
-"@nmi-agro/fdm-app": minor
----
-
-Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept or decline the invitation themselves.

--- a/.changeset/silly-views-learn.md
+++ b/.changeset/silly-views-learn.md
@@ -3,4 +3,4 @@
 "@nmi-agro/fdm-app": minor
 ---
 
-Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept of decline the invitation themselves.
+Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept or decline the invitation themselves.

--- a/fdm-agents/CHANGELOG.md
+++ b/fdm-agents/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @nmi-agro/fdm-agents
 
+## 0.4.2
+
+### Patch Changes
+
+- Updated dependencies [[`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3)]:
+  - @nmi-agro/fdm-core@0.35.0
+  - @nmi-agro/fdm-calculator@0.17.1
+
 ## 0.4.1
 
 ### Patch Changes

--- a/fdm-agents/package.json
+++ b/fdm-agents/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-agents",
     "private": false,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "AI Agent for Fertilizer Planning",
     "license": "MIT",
     "type": "module",

--- a/fdm-api/CHANGELOG.md
+++ b/fdm-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @nmi-agro/fdm-api
 
+## 0.2.3
+
+### Patch Changes
+
+- Updated dependencies [[`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3)]:
+  - @nmi-agro/fdm-core@0.35.0
+  - @nmi-agro/fdm-calculator@0.17.1
+
 ## 0.2.2
 
 ### Patch Changes

--- a/fdm-api/package.json
+++ b/fdm-api/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-api",
     "private": true,
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Hono-based REST API for the Farm Data Model",
     "type": "module",
     "main": "./dist/index.js",

--- a/fdm-app/CHANGELOG.md
+++ b/fdm-app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog fdm-app
 
+## 0.34.0
+
+### Minor Changes
+
+- [#711](https://github.com/nmi-agro/fdm/pull/711) [`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept or decline the invitation themselves.
+
+### Patch Changes
+
+- Updated dependencies [[`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3)]:
+  - @nmi-agro/fdm-core@0.35.0
+  - @nmi-agro/fdm-agents@0.4.2
+  - @nmi-agro/fdm-calculator@0.17.1
+  - @nmi-agro/fdm-rvo@0.3.1
+
 ## 0.33.2
 
 ### Patch Changes

--- a/fdm-app/app/components/blocks/farm/pending-invitation.tsx
+++ b/fdm-app/app/components/blocks/farm/pending-invitation.tsx
@@ -24,6 +24,7 @@ type PendingInvitation = {
 type Props = {
     invitation: PendingInvitation
     principalType?: "user" | "organization"
+    canAccept?: boolean
 }
 
 function getRoleLabel(role: string): string {
@@ -36,6 +37,7 @@ function getRoleLabel(role: string): string {
 export function PendingInvitationCard({
     invitation,
     principalType = "user",
+    canAccept = true,
 }: Props) {
     const farmLabel = invitation.farm_name ?? invitation.resource_id
     const expiresText = formatDistanceToNow(new Date(invitation.expires), {
@@ -70,13 +72,13 @@ export function PendingInvitationCard({
                         {invitation.org_name}
                     </span>
                 )}{" "}
-                Je kunt deze uitnodiging accepteren of weigeren.
+                {canAccept ? "Je kunt deze uitnodiging accepteren of weigeren." : "Een beheerder van de organisatie kan deze uitnodiging accepteren of weigeren."}
                 <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground/80">
                     <Clock className="h-3 w-3" />
                     <span>Verloopt {expiresText}</span>
                 </div>
             </CardContent>
-            <CardFooter className="flex gap-2 pt-2">
+            {canAccept && <CardFooter className="flex gap-2 pt-2">
                 <Form method="post" className="flex-1">
                     <input
                         type="hidden"
@@ -114,7 +116,7 @@ export function PendingInvitationCard({
                         Weigeren
                     </Button>
                 </Form>
-            </CardFooter>
+            </CardFooter>}
         </Card>
     )
 }

--- a/fdm-app/app/components/blocks/farm/pending-invitation.tsx
+++ b/fdm-app/app/components/blocks/farm/pending-invitation.tsx
@@ -72,51 +72,61 @@ export function PendingInvitationCard({
                         {invitation.org_name}
                     </span>
                 )}{" "}
-                {canAccept ? "Je kunt deze uitnodiging accepteren of weigeren." : "Een beheerder van de organisatie kan deze uitnodiging accepteren of weigeren."}
+                {canAccept &&
+                    "Je kunt deze uitnodiging accepteren of weigeren."}
                 <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground/80">
                     <Clock className="h-3 w-3" />
                     <span>Verloopt {expiresText}</span>
                 </div>
             </CardContent>
-            {canAccept && <CardFooter className="flex gap-2 pt-2">
-                <Form method="post" className="flex-1">
-                    <input
-                        type="hidden"
-                        name="intent"
-                        value="accept_farm_invitation"
-                    />
-                    <input
-                        type="hidden"
-                        name="invitation_id"
-                        value={invitation.invitation_id}
-                    />
-                    <Button type="submit" size="sm" className="w-full">
-                        <Check className="mr-1 h-3 w-3" />
-                        Accepteren
-                    </Button>
-                </Form>
-                <Form method="post" className="flex-1">
-                    <input
-                        type="hidden"
-                        name="intent"
-                        value="decline_farm_invitation"
-                    />
-                    <input
-                        type="hidden"
-                        name="invitation_id"
-                        value={invitation.invitation_id}
-                    />
-                    <Button
-                        type="submit"
-                        size="sm"
-                        variant="outline"
-                        className="w-full"
-                    >
-                        <X className="mr-1 h-3 w-3" />
-                        Weigeren
-                    </Button>
-                </Form>
-            </CardFooter>}
+            <CardFooter className="flex gap-2 pt-2">
+                {canAccept ? (
+                    <>
+                        <Form method="post" className="flex-1">
+                            <input
+                                type="hidden"
+                                name="intent"
+                                value="accept_farm_invitation"
+                            />
+                            <input
+                                type="hidden"
+                                name="invitation_id"
+                                value={invitation.invitation_id}
+                            />
+                            <Button type="submit" size="sm" className="w-full">
+                                <Check className="mr-1 h-3 w-3" />
+                                Accepteren
+                            </Button>
+                        </Form>
+                        <Form method="post" className="flex-1">
+                            <input
+                                type="hidden"
+                                name="intent"
+                                value="decline_farm_invitation"
+                            />
+                            <input
+                                type="hidden"
+                                name="invitation_id"
+                                value={invitation.invitation_id}
+                            />
+                            <Button
+                                type="submit"
+                                size="sm"
+                                variant="outline"
+                                className="w-full"
+                            >
+                                <X className="mr-1 h-3 w-3" />
+                                Weigeren
+                            </Button>
+                        </Form>
+                    </>
+                ) : (
+                    <div className="text-xs text-muted-foreground">
+                        Een beheerder van de organisatie kan deze uitnodiging
+                        accepteren of weigeren.
+                    </div>
+                )}
+            </CardFooter>
         </Card>
     )
 }

--- a/fdm-app/app/components/blocks/farm/pending-invitation.tsx
+++ b/fdm-app/app/components/blocks/farm/pending-invitation.tsx
@@ -122,7 +122,7 @@ export function PendingInvitationCard({
                     </>
                 ) : (
                     <div className="text-xs text-muted-foreground">
-                        Een beheerder van de organisatie kan deze uitnodiging
+                        Een beheerder van de organisatie <strong>{invitation.org_name}</strong> kan deze uitnodiging
                         accepteren of weigeren.
                     </div>
                 )}

--- a/fdm-app/app/routes/farm._index.tsx
+++ b/fdm-app/app/routes/farm._index.tsx
@@ -95,10 +95,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
         })
 
         // Get pending farm invitations for this user
-        const pendingInvitations = await listPendingInvitationsForUser(
+        const pendingInvitationsRaw = await listPendingInvitationsForUser(
             fdm,
             session.user.id,
+            true,
         )
+        const pendingInvitations = [
+            ...pendingInvitationsRaw.filter(
+                (invitation) => invitation.can_accept,
+            ),
+            ...pendingInvitationsRaw.filter(
+                (invitation) => !invitation.can_accept,
+            ),
+        ]
 
         const rawOrganizations = await auth.api.listOrganizations({
             headers: request.headers,
@@ -476,6 +485,9 @@ export default function AppIndex() {
                                                         invitation.invitation_id
                                                     }
                                                     invitation={invitation}
+                                                    canAccept={
+                                                        invitation.can_accept
+                                                    }
                                                 />
                                             ),
                                         )}
@@ -535,6 +547,9 @@ export default function AppIndex() {
                                             <PendingInvitationCard
                                                 key={invitation.invitation_id}
                                                 invitation={invitation}
+                                                canAccept={
+                                                    invitation.can_accept
+                                                }
                                             />
                                         ),
                                     )}

--- a/fdm-app/app/routes/organization.$slug._index.tsx
+++ b/fdm-app/app/routes/organization.$slug._index.tsx
@@ -105,6 +105,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
         const allPendingInvitations = await listPendingInvitationsForUser(
             fdm,
             session.principal_id,
+            true,
         )
         const pendingInvitations = allPendingInvitations.filter(
             (invitation) => invitation.target_principal_id === organization.id,
@@ -272,6 +273,9 @@ export default function AppIndex() {
                                                     }
                                                     principalType="organization"
                                                     invitation={invitation}
+                                                    canAccept={
+                                                        invitation.can_accept
+                                                    }
                                                 />
                                             ),
                                         )}

--- a/fdm-app/package.json
+++ b/fdm-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmi-agro/fdm-app",
-    "version": "0.33.2",
+    "version": "0.34.0",
     "private": true,
     "sideEffects": false,
     "type": "module",

--- a/fdm-calculator/CHANGELOG.md
+++ b/fdm-calculator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # fdm-calculator
 
+## 0.17.1
+
+### Patch Changes
+
+- Updated dependencies [[`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3)]:
+  - @nmi-agro/fdm-core@0.35.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/fdm-calculator/package.json
+++ b/fdm-calculator/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-calculator",
     "private": false,
-    "version": "0.17.0",
+    "version": "0.17.1",
     "description": "Calculate various insights based on the Farm Data Model",
     "license": "MIT",
     "homepage": "https://github.com/nmi-agro/fdm",

--- a/fdm-core/CHANGELOG.md
+++ b/fdm-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog fdm-core
 
+## 0.35.0
+
+### Minor Changes
+
+- [#711](https://github.com/nmi-agro/fdm/pull/711) [`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3) Thanks [@BoraIneviNMI](https://github.com/BoraIneviNMI)! - Now users are able to see farm invitations for their organization even if they are just a member. This is handled through the new `include_readonly` flag that can be passed to the fdm-core `listPendingInvitationsForUser` and `listPendingInvitationsForPrincipal` methods. In fdm-app the users see no accept and decline buttons, and a message that says their admin can accept or decline the invitation, if they can't accept or decline the invitation themselves.
+
 ## 0.34.1
 
 ### Patch Changes

--- a/fdm-core/package.json
+++ b/fdm-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-core",
     "private": false,
-    "version": "0.34.1",
+    "version": "0.35.0",
     "description": "Interface for the Farm Data Model",
     "license": "MIT",
     "homepage": "https://svenvw.github.io/fdm/",

--- a/fdm-core/src/farm.ts
+++ b/fdm-core/src/farm.ts
@@ -790,14 +790,17 @@ export async function listPendingInvitationsForFarm(
  *
  * @param fdm - The FDM instance providing the connection to the database.
  * @param user_id - The ID of the user to retrieve invitations for.
+ * @param include_readonly - Whether to include the invitations that the user's organization has
+ * received but the user themselves can't accept.
  *
  * @returns A Promise that resolves to an array of pending invitation records enriched with farm_name and org_name.
  */
 export async function listPendingInvitationsForUser(
     fdm: FdmType,
     user_id: string,
+    include_readonly?: boolean,
 ): Promise<
-    (authZSchema.invitationTypeSelect & {
+    (Awaited<ReturnType<typeof listPendingInvitationsForPrincipal>>[number] & {
         farm_name: string | null
         org_name: string | null
     })[]
@@ -807,6 +810,7 @@ export async function listPendingInvitationsForUser(
             const pending = await listPendingInvitationsForPrincipal(
                 tx,
                 user_id,
+                include_readonly,
             )
 
             if (pending.length === 0) {

--- a/fdm-core/src/invitation.test.ts
+++ b/fdm-core/src/invitation.test.ts
@@ -888,6 +888,114 @@ describe("listPendingInvitationsForPrincipal", () => {
         expect(orgInv).toBeDefined()
         expect(orgInv?.status).toBe("pending")
     })
+
+    it("should not include org-targeted invitations for a user who is a regular org member", async () => {
+        const orgMember = await fdmAuth.api.signUpEmail({
+            headers: undefined,
+            body: {
+                email: "list_inv_orgmemberrofalse@example.com",
+                name: "list_inv_orgmemberrofalse",
+                username: "list_inv_orgmemberrofalse",
+                password: "password",
+            } as any,
+        })
+
+        // No fdm-core API for org creation — use raw insert (same pattern as authorization.test.ts)
+        const orgId = createId()
+        const orgSlug = `list-inv-org-${orgId.toLowerCase()}`
+        await fdm.insert(authNSchema.organization).values({
+            id: orgId,
+            name: "List Inv Org",
+            slug: orgSlug,
+            createdAt: new Date(),
+        })
+        await fdm.insert(authNSchema.member).values({
+            id: createId(),
+            organizationId: orgId,
+            userId: orgMember.user.id,
+            role: "member",
+            createdAt: new Date(),
+        })
+
+        const orgFarmId = await addFarm(
+            fdm,
+            ownerPrincipalId,
+            "List Inv Org Farm",
+            "LSIORG",
+            "List Inv Org Lane",
+            "10006",
+        )
+        await grantRoleToFarm(
+            fdm,
+            ownerPrincipalId,
+            orgSlug,
+            orgFarmId,
+            "advisor",
+        )
+
+        const invitations = await listPendingInvitationsForPrincipal(
+            fdm,
+            orgMember.user.id,
+        )
+        expect(invitations.some((i) => i.target_principal_id === orgId)).toBe(
+            false,
+        )
+    })
+
+    it("should include org-targeted invitations for a user who is a regular org member when include_readonly is true", async () => {
+        const orgMember = await fdmAuth.api.signUpEmail({
+            headers: undefined,
+            body: {
+                email: "list_inv_orgmember@example.com",
+                name: "list_inv_orgmember",
+                username: "list_inv_orgmember",
+                password: "password",
+            } as any,
+        })
+
+        // No fdm-core API for org creation — use raw insert (same pattern as authorization.test.ts)
+        const orgId = createId()
+        const orgSlug = `list-inv-org-${orgId.toLowerCase()}`
+        await fdm.insert(authNSchema.organization).values({
+            id: orgId,
+            name: "List Inv Org",
+            slug: orgSlug,
+            createdAt: new Date(),
+        })
+        await fdm.insert(authNSchema.member).values({
+            id: createId(),
+            organizationId: orgId,
+            userId: orgMember.user.id,
+            role: "member",
+            createdAt: new Date(),
+        })
+
+        const orgFarmId = await addFarm(
+            fdm,
+            ownerPrincipalId,
+            "List Inv Org Farm",
+            "LSIORG",
+            "List Inv Org Lane",
+            "10006",
+        )
+        await grantRoleToFarm(
+            fdm,
+            ownerPrincipalId,
+            orgSlug,
+            orgFarmId,
+            "advisor",
+        )
+
+        const invitations = await listPendingInvitationsForPrincipal(
+            fdm,
+            orgMember.user.id,
+            true,
+        )
+        const orgInv = invitations.find((i) => i.target_principal_id === orgId)
+        expect(orgInv).toBeDefined()
+        expect(orgInv?.status).toBe("pending")
+        expect(orgInv?.can_accept).toBe(false)
+    })
 })
 
 describe("createInvitation spam prevention", () => {

--- a/fdm-core/src/invitation.test.ts
+++ b/fdm-core/src/invitation.test.ts
@@ -834,6 +834,7 @@ describe("listPendingInvitationsForPrincipal", () => {
         const emailInv = invitations.find((i) => i.resource_id === emailFarmId)
         expect(emailInv).toBeDefined()
         expect(emailInv?.status).toBe("pending")
+        expect(emailInv?.can_accept).toBe(true)
     })
 
     it("should include org-targeted invitations for a user who is an org admin", async () => {
@@ -887,6 +888,7 @@ describe("listPendingInvitationsForPrincipal", () => {
         const orgInv = invitations.find((i) => i.target_principal_id === orgId)
         expect(orgInv).toBeDefined()
         expect(orgInv?.status).toBe("pending")
+        expect(orgInv?.can_accept).toBe(true)
     })
 
     it("should not include org-targeted invitations for a user who is a regular org member", async () => {

--- a/fdm-core/src/invitation.ts
+++ b/fdm-core/src/invitation.ts
@@ -597,6 +597,7 @@ export async function listPendingInvitationsForPrincipal(
                 ...invitation,
                 can_accept:
                     invitation.target_principal_id === user_id ||
+                    invitation.target_email === userEmail ||
                     !!(
                         invitation.target_principal_id &&
                         orgMap.get(invitation.target_principal_id)?.can_invite

--- a/fdm-core/src/invitation.ts
+++ b/fdm-core/src/invitation.ts
@@ -509,17 +509,22 @@ export async function declineInvitation(
  * Lists all pending (non-expired) invitations for a given user across all resources.
  *
  * Returns invitations where the target matches the user's principal ID, email address,
- * or an organization for which the user is an admin or owner.
+ * or an organization for which the user is an admin or owner. The `include_readonly`
+ * parameter can be set to true to include the invitations for an organization for
+ * which the user is just a member.
  *
  * @param fdm - The FDM instance providing the connection to the database.
  * @param user_id - The ID of the user to retrieve invitations for.
+ * @param include_readonly - Whether to include the invitations that the user's
+ * organization has received but the user themselves can't accept.
  *
  * @returns A Promise that resolves to an array of pending invitation records.
  */
 export async function listPendingInvitationsForPrincipal(
     fdm: FdmType,
     user_id: string,
-): Promise<authZSchema.invitationTypeSelect[]> {
+    include_readonly = false,
+): Promise<(authZSchema.invitationTypeSelect & { can_accept: boolean })[]> {
     try {
         return await fdm.transaction(async (tx) => {
             const userRecord = await tx
@@ -534,16 +539,25 @@ export async function listPendingInvitationsForPrincipal(
             const userEmail = userRecord[0].email.toLowerCase().trim()
 
             const orgMemberships = await tx
-                .select({ organizationId: authNSchema.member.organizationId })
+                .select({
+                    organizationId: authNSchema.member.organizationId,
+                    can_invite: inArray(authNSchema.member.role, [
+                        "admin",
+                        "owner",
+                    ]),
+                })
                 .from(authNSchema.member)
-                .where(
+                .where((t) =>
                     and(
                         eq(authNSchema.member.userId, user_id),
-                        inArray(authNSchema.member.role, ["admin", "owner"]),
+                        !include_readonly ? t.can_invite : undefined,
                     ),
                 )
             const orgIds = orgMemberships.map(
                 (m: { organizationId: string }) => m.organizationId,
+            )
+            const orgMap = new Map(
+                orgMemberships.map((org) => [org.organizationId, org]),
             )
 
             const now = new Date()
@@ -574,10 +588,20 @@ export async function listPendingInvitationsForPrincipal(
                 )
             }
 
-            return await tx
+            const invitations = await tx
                 .select()
                 .from(authZSchema.invitation)
                 .where(or(...conditions))
+
+            return invitations.map((invitation) => ({
+                ...invitation,
+                can_accept:
+                    invitation.target_principal_id === user_id ||
+                    !!(
+                        invitation.target_principal_id &&
+                        orgMap.get(invitation.target_principal_id)?.can_invite
+                    ),
+            }))
         })
     } catch (err) {
         throw handleError(

--- a/fdm-rvo/CHANGELOG.md
+++ b/fdm-rvo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @nmi-agro/fdm-rvo
 
+## 0.3.1
+
+### Patch Changes
+
+- Updated dependencies [[`845197e`](https://github.com/nmi-agro/fdm/commit/845197e28776b331f6d44e0eb64dc144e786f8f3)]:
+  - @nmi-agro/fdm-core@0.35.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/fdm-rvo/package.json
+++ b/fdm-rvo/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@nmi-agro/fdm-rvo",
     "private": false,
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "RVO Synchronization Logic for FDM",
     "homepage": "https://svenvw.github.io/fdm/",
     "repository": {


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Organization members can now view pending farm invitations, even when they lack permission to accept or decline them.
  - Invitations clearly indicate whether the current viewer can take action.
  - Authorized recipients can accept or decline invitations directly from the invitation card.

- **Improvements**
  - Read-only viewers now see guidance that an organization administrator must handle the invitation.

- **Documentation**
  - Updated release notes and package versions across affected components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->