### PR TITLE
Update Gemini defaults and sanitize PostHog payloads

### DIFF
--- a/.changeset/frank-games-argue.md
+++ b/.changeset/frank-games-argue.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-agents": patch
+"@nmi-agro/fdm-app": patch
+---
+
+Replace Gemini 3.5 Flash with Gemini 3.6 Flash

--- a/.changeset/plain-weeks-look.md
+++ b/.changeset/plain-weeks-look.md
@@ -1,0 +1,6 @@
+---
+"@nmi-agro/fdm-agents": patch
+"@nmi-agro/fdm-app": patch
+---
+
+Replace Gemini 3.1 Flash Lite with Gemini 3.5 Flash Lite

--- a/.changeset/red-rooms-lead.md
+++ b/.changeset/red-rooms-lead.md
@@ -1,0 +1,5 @@
+---
+"@nmi-agro/fdm-app": patch
+---
+
+Add PostHog event payload truncation to prevent HTTP 413 drops on large LLM generation events while preserving token usage and cost metric

--- a/fdm-agents/src/agents/ticket-triage/agent.test.ts
+++ b/fdm-agents/src/agents/ticket-triage/agent.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../runners/one-shot", () => ({
 
 describe("Ticket Triage Agent — constants", () => {
   it("DEFAULT_MODEL_CODE should be the expected lite model", () => {
-    expect(DEFAULT_MODEL_CODE).toBe("gemini-3.1-flash-lite")
+    expect(DEFAULT_MODEL_CODE).toBe("gemini-3.5-flash-lite")
   })
 
   it("SUBJECT_AND_PRIORITY_PROMPT should contain the four priority labels", () => {

--- a/fdm-agents/src/agents/ticket-triage/agent.ts
+++ b/fdm-agents/src/agents/ticket-triage/agent.ts
@@ -5,7 +5,7 @@ import { createDefaultModel } from "../../models/default"
 import { runOneShotAgent } from "../../runners/one-shot"
 
 /** Default Gemini model used by the ticket-triage agent. Optimised for low-latency triage tasks. */
-export const DEFAULT_MODEL_CODE = "gemini-3.1-flash-lite"
+export const DEFAULT_MODEL_CODE = "gemini-3.5-flash-lite"
 
 export interface TriageAgentConfig {
   apiKey: string

--- a/fdm-agents/src/agents/ticket-triage/agent.ts
+++ b/fdm-agents/src/agents/ticket-triage/agent.ts
@@ -87,7 +87,7 @@ export function createTicketTriageAgent(apiKey?: string, modelName?: string) {
   const result: unknown = createAgent({
     name: AGENT_NAME,
     description: AGENT_DESCRIPTION,
-    model: createDefaultModel(resolvedKey, modelName),
+    model: createDefaultModel(resolvedKey, modelName ?? DEFAULT_MODEL_CODE),
     responseFormat: SubjectAndPrioritySchema,
   })
 

--- a/fdm-agents/src/models/default.test.ts
+++ b/fdm-agents/src/models/default.test.ts
@@ -23,7 +23,7 @@ describe("Default Model", () => {
     expect(mockChatGoogleGenerativeAI).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: "fake-api-key",
-        model: "gemini-3.5-flash",
+        model: "gemini-3.6-flash",
         maxOutputTokens: 65536,
         thinkingConfig: { includeThoughts: true },
       }),

--- a/fdm-agents/src/models/default.ts
+++ b/fdm-agents/src/models/default.ts
@@ -3,12 +3,12 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai"
 /**
  * Creates a ChatGoogleGenerativeAI model configuration for the fdm-agents workspace.
  * @param apiKey Optional API key. If not provided, it looks for standard environment variables.
- * @param model Optional model name. Defaults to gemini-3.1-pro-preview.
+ * @param model Optional model name. Defaults to gemini-3.6-flash.
  * @returns A ChatGoogleGenerativeAI model instance.
  */
 export function createDefaultModel(apiKey?: string, model?: string) {
   return new ChatGoogleGenerativeAI({
-    model: model ?? "gemini-3.5-flash",
+    model: model ?? "gemini-3.6-flash",
     apiKey: apiKey,
     maxOutputTokens: 65536,
     // Surface the model's reasoning ("thoughts") so the streaming UI can

--- a/fdm-app/app/components/blocks/gerrit/schema.ts
+++ b/fdm-app/app/components/blocks/gerrit/schema.ts
@@ -53,7 +53,7 @@ export const GEMINI_MODELS = [
   // { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   // { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   {
-    value: "gemini-3.1-flash-lite",
-    label: "Gemini 3.1 Flash Lite",
+    value: "gemini-3.5-flash-lite",
+    label: "Gemini 3.5 Flash Lite",
   },
 ]

--- a/fdm-app/app/components/blocks/gerrit/schema.ts
+++ b/fdm-app/app/components/blocks/gerrit/schema.ts
@@ -22,7 +22,7 @@ export const GerritFormSchema = z
       .max(1000, "Maximaal 1000 karakters toegestaan.")
       .optional()
       .default(""),
-    geminiModel: z.string().optional().default("gemini-3.5-flash"),
+    geminiModel: z.string().optional().default("gemini-3.6-flash"),
   })
   .superRefine((data, ctx) => {
     if (Array.isArray(data.selectedFertilizerIds) && data.selectedFertilizerIds.length === 0) {
@@ -47,7 +47,7 @@ export const STRATEGY_LABELS: Record<string, string> = {
 }
 
 export const GEMINI_MODELS = [
-  { value: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
+  { value: "gemini-3.6-flash", label: "Gemini 3.6 Flash" },
   { value: "gemini-3-flash-preview", label: "Gemini 3 Flash" },
   { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro" },
   // { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },

--- a/fdm-app/app/posthog.server.ts
+++ b/fdm-app/app/posthog.server.ts
@@ -1,6 +1,105 @@
-import { PostHog } from "posthog-node"
+import { type EventMessage, PostHog } from "posthog-node"
 
 let posthogClient: PostHog | null = null
+
+/**
+ * Recursively truncates string values inside an object or array if they exceed a maximum character length.
+ */
+function truncateLargeValues<T>(value: T, maxStringLength: number): T {
+  if (typeof value === "string") {
+    if (value.length > maxStringLength) {
+      return (value.slice(0, maxStringLength) +
+        `\n... [truncated for PostHog event payload limit (original length: ${value.length} chars)]`) as unknown as T
+    }
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => truncateLargeValues(item, maxStringLength)) as unknown as T
+  }
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = truncateLargeValues(val, maxStringLength)
+    }
+    return result as T
+  }
+  return value
+}
+
+/**
+ * Sanitizes event messages before sending them to PostHog.
+ * Prevents HTTP 413 / Kafka "maximum event size exceeded" errors caused by large
+ * LLM prompts, reasoning traces, or farm context payloads, while preserving all
+ * token usage, model identifiers, and cost calculation metrics.
+ */
+export function sanitizePostHogEvent(event: EventMessage | null): EventMessage | null {
+  if (!event) return null
+
+  const MAX_EVENT_BYTES = 150_000 // Target 150 KB max JSON payload size
+
+  let serialized = ""
+  try {
+    serialized = JSON.stringify(event)
+  } catch {
+    return event
+  }
+
+  // If the event payload fits easily within limits, return untouched
+  if (serialized.length <= MAX_EVENT_BYTES) {
+    return event
+  }
+
+  // Pass 1: Truncate oversized string properties to 20,000 chars
+  if (event.properties) {
+    event.properties = truncateLargeValues(event.properties, 20_000)
+  }
+
+  try {
+    serialized = JSON.stringify(event)
+  } catch {
+    return event
+  }
+
+  if (serialized.length <= MAX_EVENT_BYTES) {
+    return event
+  }
+
+  // Pass 2: More aggressive truncation to 2,000 chars if still over limit
+  if (event.properties) {
+    event.properties = truncateLargeValues(event.properties, 2_000)
+  }
+
+  try {
+    serialized = JSON.stringify(event)
+  } catch {
+    return event
+  }
+
+  if (serialized.length <= MAX_EVENT_BYTES) {
+    return event
+  }
+
+  // Pass 3: Hard fallback for AI trace text fields while preserving token usage & cost metrics
+  if (event.properties) {
+    const textFieldsToClear = [
+      "$ai_input",
+      "$ai_input_state",
+      "$ai_output_choices",
+      "$ai_output_state",
+      "prompt",
+      "input",
+      "output",
+      "messages",
+    ]
+    for (const field of textFieldsToClear) {
+      if (field in event.properties) {
+        event.properties[field] = "[Payload text truncated to preserve token & cost metrics in PostHog]"
+      }
+    }
+  }
+
+  return event
+}
 
 export default function PostHogClient(): PostHog | null {
   if (!posthogClient) {
@@ -9,11 +108,13 @@ export default function PostHogClient(): PostHog | null {
     if (posthogHost && posthogKey?.startsWith("phc")) {
       posthogClient = new PostHog(posthogKey, {
         host: posthogHost,
-        // Send events one at a time to avoid 413s from large LLM
-        // payloads (reasoning traces + tool results can be sizeable).
+        // Send events one at a time to avoid batch payload spikes
         maxBatchSize: 1,
+        // Intercept events before sending to prevent 413s from large LLM payloads
+        before_send: sanitizePostHogEvent,
       })
     }
   }
   return posthogClient
 }
+

--- a/fdm-app/app/posthog.server.ts
+++ b/fdm-app/app/posthog.server.ts
@@ -35,17 +35,19 @@ function truncateLargeValues<T>(value: T, maxStringLength: number): T {
 export function sanitizePostHogEvent(event: EventMessage | null): EventMessage | null {
   if (!event) return null
 
-  const MAX_EVENT_BYTES = 150_000 // Target 150 KB max JSON payload size
+  const MAX_EVENT_BYTES = 150_000 // Target 150 KB max JSON payload size in UTF-8 bytes
+
+  const getByteLength = (str: string) => Buffer.byteLength(str, "utf8")
 
   let serialized = ""
   try {
     serialized = JSON.stringify(event)
   } catch {
-    return event
+    return null
   }
 
   // If the event payload fits easily within limits, return untouched
-  if (serialized.length <= MAX_EVENT_BYTES) {
+  if (getByteLength(serialized) <= MAX_EVENT_BYTES) {
     return event
   }
 
@@ -57,10 +59,10 @@ export function sanitizePostHogEvent(event: EventMessage | null): EventMessage |
   try {
     serialized = JSON.stringify(event)
   } catch {
-    return event
+    return null
   }
 
-  if (serialized.length <= MAX_EVENT_BYTES) {
+  if (getByteLength(serialized) <= MAX_EVENT_BYTES) {
     return event
   }
 
@@ -72,10 +74,10 @@ export function sanitizePostHogEvent(event: EventMessage | null): EventMessage |
   try {
     serialized = JSON.stringify(event)
   } catch {
-    return event
+    return null
   }
 
-  if (serialized.length <= MAX_EVENT_BYTES) {
+  if (getByteLength(serialized) <= MAX_EVENT_BYTES) {
     return event
   }
 
@@ -98,7 +100,58 @@ export function sanitizePostHogEvent(event: EventMessage | null): EventMessage |
     }
   }
 
-  return event
+  try {
+    serialized = JSON.stringify(event)
+  } catch {
+    return null
+  }
+
+  if (getByteLength(serialized) <= MAX_EVENT_BYTES) {
+    return event
+  }
+
+  // Pass 4: Final fallback for extreme edge cases — strip all non-essential properties while keeping token & cost metrics
+  if (event.properties) {
+    const essentialKeys = new Set([
+      "$ai_lib",
+      "$ai_lib_version",
+      "$ai_trace_id",
+      "$ai_span_id",
+      "$ai_span_name",
+      "$ai_parent_id",
+      "$ai_provider",
+      "$ai_model",
+      "$ai_input_tokens",
+      "$ai_output_tokens",
+      "$ai_reasoning_tokens",
+      "$ai_cache_read_input_tokens",
+      "$ai_cache_creation_input_tokens",
+      "$ai_latency",
+      "$ai_http_status",
+      "$ai_framework",
+      "$groups",
+      "b_id_farm",
+      "org_slug",
+    ])
+    const sanitizedProperties: Record<string, unknown> = {}
+    for (const [key, val] of Object.entries(event.properties)) {
+      if (essentialKeys.has(key)) {
+        sanitizedProperties[key] = val
+      }
+    }
+    event.properties = sanitizedProperties
+  }
+
+  try {
+    serialized = JSON.stringify(event)
+    if (getByteLength(serialized) <= MAX_EVENT_BYTES) {
+      return event
+    }
+  } catch {
+    return null
+  }
+
+  return null
 }
 
 export default function PostHogClient(): PostHog | null {

--- a/fdm-app/app/routes/api.gerrit.clarify.ts
+++ b/fdm-app/app/routes/api.gerrit.clarify.ts
@@ -32,7 +32,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     })
   }
 
-  const modelName = url.searchParams.get("geminiModel") || "gemini-3.5-flash"
+  const modelName = url.searchParams.get("geminiModel") || "gemini-3.6-flash"
 
   // Parse selectedFertilizerIds (allow only safe catalogue ID chars)
   const SAFE_ID = /^[A-Za-z0-9_-]+$/

--- a/fdm-app/app/routes/api.gerrit.stream.ts
+++ b/fdm-app/app/routes/api.gerrit.stream.ts
@@ -65,7 +65,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     includeRenure: url.searchParams.get("includeRenure") === "true",
   }
   const additionalContext = url.searchParams.get("additionalContext") || ""
-  const modelName = url.searchParams.get("geminiModel") || "gemini-3.5-flash"
+  const modelName = url.searchParams.get("geminiModel") || "gemini-3.6-flash"
 
   // Parse selectedFertilizerIds (allow only safe catalogue ID chars: alphanumeric, _, -)
   const SAFE_ID = /^[A-Za-z0-9_-]+$/

--- a/fdm-app/app/routes/farm.$b_id_farm.$calendar.gerrit.tsx
+++ b/fdm-app/app/routes/farm.$b_id_farm.$calendar.gerrit.tsx
@@ -541,7 +541,7 @@ export default function GerritApp() {
           ? (fertilizerOptions.map((f) => f.p_id_catalogue) as any)
           : undefined,
       additionalContext: "",
-      geminiModel: "gemini-3.5-flash",
+      geminiModel: "gemini-3.6-flash",
     },
     submitHandlers: {
       onValid: handleSubmit,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Set Gemini 3.6 Flash as the default model across Gerrit workflows and related API routes.
  - Updated available model options, including updated “lite” model mappings.
  - Ticket triage now defaults to Gemini 3.5 Flash Lite.

- **Bug Fixes**
  - Added PostHog event sanitization to truncate oversized payloads, preventing delivery failures while preserving token usage and cost metrics.

- **Documentation**
  - Updated changelog entries to reflect the Gemini model version changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #713 